### PR TITLE
add check for no platforms to CLIConfig

### DIFF
--- a/cliconfig/CLIConfig.cpp
+++ b/cliconfig/CLIConfig.cpp
@@ -840,7 +840,8 @@ void CAboutPage::OnPlatformListChange()
 
         if( errorCode == CL_SUCCESS &&
             dclGetDeviceIDs &&
-            dclGetDeviceInfo )
+            dclGetDeviceInfo &&
+            platformIndex < m_Platforms.size() )
         {
             errorCode = dclGetDeviceIDs(
                 m_Platforms[platformIndex],


### PR DESCRIPTION
Fixes #10

## Description of Changes

Added a missing check for when no OpenCL platforms are available.

## Testing Done

Disabled all OpenCL platforms and verified that the CLIConfig info tab behaved correctly (using a debug build).
