### PR TITLE
Minor fixes

### DIFF
--- a/OS/OS_windows_common.h
+++ b/OS/OS_windows_common.h
@@ -183,12 +183,14 @@ inline bool Services_Common::ReadRegistry(
             {
                 unsigned int *puVal = (unsigned int *)pValue;
                 *puVal = atoi(envVal);
+                free( envVal );
                 return true;
             }
             else if( ( envVal != NULL ) && ( strlen(envVal) < size ) )
             {
                 char* pStr = (char*)pValue;
                 strcpy_s( pStr, size, envVal );
+                free( envVal );
                 return true;
             }
             free( envVal );

--- a/cliprof/cliprof.cpp
+++ b/cliprof/cliprof.cpp
@@ -456,11 +456,11 @@ int main(int argc, char *argv[])
 
     // Add intercept library to LD_PRELOAD:
     std::string ld_preload = path + "/libOpenCL." + LIB_EXTENSION;
-    const char *odl_ld_preload = getenv(LD_PRELOAD_ENV);
-    if( odl_ld_preload )
+    const char *old_ld_preload = getenv(LD_PRELOAD_ENV);
+    if( old_ld_preload )
     {
         ld_preload += ":";
-        ld_preload += odl_ld_preload;
+        ld_preload += old_ld_preload;
     }
 
     DEBUG("New %s is %s\n", LD_LIBRARY_PATH_ENV, ld_library_path.c_str());


### PR DESCRIPTION
## Description of Changes

Fixes a memory leak when handling controls read from environment variables on Windows, and a minor misspelling of a variable in cliprof for Linux.

## Testing Done

Verified that controls are still read properly on Windows and that cliprof still executes correctly on Linux.