### PR TITLE
Setup Travis and AppVeyor CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: cpp
+
+compiler:
+  - gcc
+  - clang
+
+os:
+  - linux
+  - osx
+
+script:
+  - mkdir -p build
+  - cd build
+  - cmake -DENABLE_CLIPROF=1 ..
+  - make -j 4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Intercept Layer for OpenCL<sup>TM</sup> Applications
+Linux and OSX: [![Linux OSX Build Status](https://travis-ci.org/msriram/opencl-intercept-layer.svg?branch=travis)](https://travis-ci.org/msriram/opencl-intercept-layer) | Windows: [![Windows Build status](https://ci.appveyor.com/api/projects/status/k9bnhdcwl60hf8t5/branch/travis?svg=true)](https://ci.appveyor.com/project/msriram/opencl-intercept-layer/branch/travis)
 
 The Intercept Layer for OpenCL Applications is a tool that can intercept
 and modify OpenCL calls for debugging and performance analysis.  Using the

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+os:
+  - Visual Studio 2017
+  - Visual Studio 2015
+
+platform:
+  - Win32
+  - x64
+
+configuration:
+  - Debug
+  - Release
+
+before_build:
+  - cmake -H. -Bbuild -A%PLATFORM%
+
+build:
+  project: build\CLIntercept.sln
+  parallel: true
+  verbosity: normal


### PR DESCRIPTION
added yaml files for hooking into travis and appveyor CI for Linux, OSX and Windows respectively

Fixes #

## Description of Changes
two yml files one for linux and osx via travis CI, and one for windows via appveyor
also added badges in the readme. this can be fixed for providing the right travil and appveyor path
## Testing Done

(Please describe how you tested your changes.)
