### PR TITLE
Shorten long kernel names and refer to them by a kernel id

### DIFF
--- a/Src/controls.h
+++ b/Src/controls.h
@@ -50,8 +50,10 @@ CLI_CONTROL( cl_uint,       ContextHintLevel,                       0,     "If s
 CLI_CONTROL( bool,          EventCallbackLogging,                   false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will install its own callback for every event callback and log the call to the event callback.  The application's event callback will be invoked after the Intercept Layer for OpenCL Applications' event callback." )
 CLI_CONTROL( bool,          EventChecking,                          false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will check and log any events in an event wait list that are invalid or in an error state.  This can help to debug complex event dependency issues." )
 CLI_CONTROL( bool,          LeakChecking,                           false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will check for leaks of various OpenCL objects, such as memory objects and events." )
+CLI_CONTROL( bool,          IndexLongKernelNames,                   false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will create a mapping to each kernel name longer than 32 characters to a shortName that will replace the kernel name in the logging. In addition, the mapping will be displayed on the clintercept_report.txt for easy reference." )
 CLI_CONTROL( bool,          CLInfoLogging,                          false, "If set to a nonzero value, logs information about the platforms and devices in the system on the first call to clGetPlatformIDs()." )
 CLI_CONTROL( std::string,   LogDir,                                 "",    "If set, the Intercept Layer for OpenCL Applications will emit logs to this directory instead of the default log directory." )
+
 
 CLI_CONTROL_SEPARATOR( Reporting Controls: )
 CLI_CONTROL( bool,          ReportToStderr,                         false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will emit reports to stderr." )

--- a/Src/intercept.h
+++ b/Src/intercept.h
@@ -689,6 +689,9 @@ private:
 #error Unknown OS!
 #endif
 
+    std::string getKernelName(
+                  const cl_kernel kernel );
+
     void    getCallLoggingPrefix(
                 std::string& str );
 
@@ -737,6 +740,7 @@ private:
 
     struct SDeviceTimingStats
     {
+        std::string KernelId;
         uint64_t    NumberOfCalls;
         cl_ulong    MinNS;
         cl_ulong    MaxNS;
@@ -746,13 +750,21 @@ private:
     typedef std::map< std::string, SDeviceTimingStats* >   CDeviceTimingStatsMap;
     CDeviceTimingStatsMap   m_DeviceTimingStatsMap;
 
-    typedef std::map< const cl_kernel, std::string >    CKernelNameMap;
+    struct kernelNameInfo
+    {
+      std::string kernelId;
+      std::string kernelName;
+    };
+    typedef std::map< const cl_kernel, kernelNameInfo >    CKernelNameMap;
     CKernelNameMap  m_KernelNameMap;
+    int m_kernelId;
+    uint m_maxKernelLength;
 
     struct SEventListNode
     {
         std::string FunctionName;
         std::string KernelName;
+        std::string KernelId;
         uint64_t    QueuedTime;
         cl_kernel   Kernel;
         cl_event    Event;
@@ -1168,13 +1180,13 @@ inline bool CLIntercept::nullEnqueue() const
 inline bool CLIntercept::dumpBufferForKernel( const cl_kernel kernel )
 {
     return m_Config.DumpBuffersForKernel.empty() ||
-        m_KernelNameMap[ kernel ] == m_Config.DumpBuffersForKernel;
+        m_KernelNameMap[ kernel ].kernelName == m_Config.DumpBuffersForKernel;
 }
 
 inline bool CLIntercept::dumpImagesForKernel( const cl_kernel kernel )
 {
     return m_Config.DumpImagesForKernel.empty() ||
-        m_KernelNameMap[ kernel ] == m_Config.DumpImagesForKernel;
+        m_KernelNameMap[ kernel ].kernelName == m_Config.DumpImagesForKernel;
 }
 
 inline bool CLIntercept::checkDumpBufferEnqueueLimits() const

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -166,6 +166,10 @@ If set to a nonzero value, the Intercept Layer for OpenCL Applications will chec
 
 If set to a nonzero value, the Intercept Layer for OpenCL Applications will check for leaks of various OpenCL objects, such as memory objects and events.
 
+##### `IndexLongKernelNames` (bool)
+
+If set to a nonzero value, the Intercept Layer for OpenCL Applications will create a mapping to each kernel name longer than 32 characters to a shortName that will replace the kernel name in the logging. In addition, the mapping will be displayed on the clintercept_report.txt for easy reference.
+
 ##### `CLInfoLogging` (bool)
 
 If set to a nonzero value, logs information about the platforms and devices in the system on the first call to clGetPlatformIDs().


### PR DESCRIPTION
- enable using control: IndexLongKernelName

(In general, it is desirable to create an issue for discussion before creating a pull request, though this is not required for simple changes.)

Fixes #
Creates a kernelNameTag called KernelId, and uses that instead of the actual kernel name in case of really long kernel names (names with length > 32 characters)

## Description of Changes
Created a separate branch to minimize the changes for this pull request

## Testing Done

(Please describe how you tested your changes.)
