### PR TITLE
MDAPI support for Intel GPU OpenCL devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,10 +69,10 @@ link_directories(
 
 set( CLINTERCEPT_OS_FILES
     OS/OS.h
+    OS/OS_timer.h
 )
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     list( APPEND CLINTERCEPT_OS_FILES
-        OS/OS_timer.h
         OS/OS_windows.cpp
         OS/OS_windows.h
         OS/OS_windows_common.cpp
@@ -170,23 +170,23 @@ set( CLINTERCEPT_CL_HEADERS
     CL/cl.h
     CL/cl_gl.h
     CL/cl_platform.h
+    CL/cl_version.h
 )
 source_group( CL FILES
     ${CLINTERCEPT_CL_HEADERS}
 )
 
 # MDAPI Support (optional)
-set( ENABLE_MDAPI CACHE BOOL "Enable MDAPI Support" )
+set( ENABLE_MDAPI TRUE CACHE BOOL "Enable MDAPI Support" )
 if( ENABLE_MDAPI )
     add_definitions("-DUSE_MDAPI")
-    include_directories( embargo/mdapi )
+    include_directories( mdapi )
     set( CLINTERCEPT_MDAPI_FILES
-        embargo/mdapi/DriverStorePath.h
-        embargo/mdapi/intercept_mdapi.cpp
-        embargo/mdapi/MetricsDiscoveryHelper.cpp
-        embargo/mdapi/MetricsDiscoveryHelper.h
-        embargo/mdapi/metrics_discovery_api.h
-        embargo/mdapi/windef4linux.h
+        mdapi/DriverStorePath.h
+        mdapi/intercept_mdapi.cpp
+        mdapi/MetricsDiscoveryHelper.cpp
+        mdapi/MetricsDiscoveryHelper.h
+        mdapi/metrics_discovery_api.h
     )
     source_group( MDAPI FILES
         ${CLINTERCEPT_MDAPI_FILES}

--- a/OS/OS_timer.h
+++ b/OS/OS_timer.h
@@ -22,15 +22,11 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #if defined(_WIN32)
 #include <Windows.h>
-// Visual Studio 2008 doesn't support stdint.h, but
-// Visual Studio 2010 does.  When CLIntercept stops
-// supporting Visual Studio 2008 we can remove this
-// typedef and include stdint.h instead.
-typedef unsigned __int64 uint64_t;
 #elif defined(__linux__)
-#include <stdint.h>
 #include <time.h>
 #include <sys/time.h>
 #endif

--- a/Src/intercept.cpp
+++ b/Src/intercept.cpp
@@ -130,6 +130,10 @@ CLIntercept::CLIntercept( void* pGlobalData )
 
     m_ProgramNumber = 0;
 
+#if defined(USE_MDAPI)
+    m_pMDHelper = NULL;
+#endif
+
     m_MemAllocNumber = 0;
 
     m_AubCaptureStarted = false;
@@ -176,6 +180,7 @@ CLIntercept::~CLIntercept()
     if( m_OpenCLLibraryHandle != NULL )
     {
         OS().UnloadLibrary( m_OpenCLLibraryHandle );
+        m_OpenCLLibraryHandle = NULL;
     }
 
     {
@@ -9783,6 +9788,7 @@ bool CLIntercept::initDispatch( const std::string& dllName )
         if( m_OpenCLLibraryHandle != NULL )
         {
             OS().UnloadLibrary( m_OpenCLLibraryHandle );
+            m_OpenCLLibraryHandle = NULL;
         }
     }
 

--- a/Src/intercept.h
+++ b/Src/intercept.h
@@ -581,8 +581,8 @@ public:
                 const std::string& func_name ) const;
 
 #if defined(USE_MDAPI)
-    GTDI_CONFIGURATION_SET initCustomPerfCounters(
-                const std::string& setName );
+    cl_uint initCustomPerfCounters();
+
     cl_command_queue    createMDAPICommandQueue(
                 cl_context context,
                 cl_device_id device,
@@ -762,11 +762,10 @@ private:
     CEventList  m_EventList;
 
 #if defined(USE_MDAPI)
-    TimingProfile m_DeviceTimingProfile;
+    MetricsDiscovery::MDHelper* m_pMDHelper;
+    MetricsDiscovery::CMetricAggregations m_MetricAggregations;
 
-    typedef std::pair< std::string, char* > CMDDataEntry;
-    typedef std::queue< CMDDataEntry* > CMDDataList;
-    CMDDataList m_MDDataList;
+    std::ofstream   m_MetricDump;
 
     void    saveMDAPICounters(
                 const std::string& name,

--- a/mdapi/DriverStorePath.h
+++ b/mdapi/DriverStorePath.h
@@ -1,0 +1,333 @@
+/*
+// Copyright (c) 2018 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+*/
+#pragma once
+
+#include <initguid.h>
+#include <ntddvdeo.h>
+#include <Devpkey.h>
+#include <SetupAPI.h>
+#include <Shlwapi.h>
+
+#define DEBUG 0
+
+#if DEBUG
+#define DBG(std, fmt, ...) fprintf_s(stderr, fmt, __VA_ARGS__)
+#else
+#define DBG(std, fmt, ...)
+#endif
+
+/********************************************************************************************/
+/* GetPropertyFromDevice                                                                    */
+/*                                                                                          */
+/* This function can be used to request a value of any device property.                     */
+/* There are many types of properties values. Refer to devpkey.h for more details.          */
+/* Function SetupDiGetDeviceProperty() inside GetPropertyFromDevice() fills a property value*/
+/* in a correct format, but always returns the value as a pointer to a string of bytes.     */
+/* The string of bytes must be casted outside of the function GetPropertyFromDevice()       */
+/* to get a value in a format suitable for the given type of property.                      */
+/*                                                                                          */
+/********************************************************************************************/
+static bool GetPropertyFromDevice(
+    void* pDevInfo,
+    PSP_DEVINFO_DATA pDevInfoData,
+    const DEVPROPKEY* pPropertyKey,
+    unsigned char** ppStringOut,
+    unsigned long* pStringOutSize)
+{
+    unsigned long propertyType = 0;
+    unsigned long propertySize = 0;
+
+    // request a size, in bytes, required for a buffer in which property value will be stored
+    // SetupDiGetDeviceProperty() returns false and ERROR_INSUFFICIENT_BUFFER for the call
+    if (SetupDiGetDevicePropertyW(pDevInfo, pDevInfoData, pPropertyKey, &propertyType, NULL, 0, &propertySize, 0))
+    {
+        DBG(stderr, "%s [%d] ---> SetupDiGetDeviceProperty() failed with the error code 0x%02x\n", __FUNCTION__, __LINE__, GetLastError());
+        return false;
+    }
+
+    if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+    {
+        DBG(stderr, "%s [%d] ---> SetupDiGetDeviceProperty() failed with the error code 0x%02x\n", __FUNCTION__, __LINE__, GetLastError());
+        return false;
+    }
+
+    if (ppStringOut == NULL)
+    {
+        SetLastError(ERROR_INVALID_HANDLE);
+        DBG(stderr, "%s [%d] ---> Error: input parameter ppStringOut = NULL\n", __FUNCTION__, __LINE__);
+        return false;
+    }
+
+    // allocate memory for the buffer
+    *ppStringOut = new (std::nothrow) unsigned char[propertySize];
+    if (*ppStringOut == NULL)
+    {
+        SetLastError(ERROR_INVALID_HANDLE);
+        DBG(stderr, "%s [%d] ---> Error: *ppStringOut = NULL\n", __FUNCTION__, __LINE__);
+        return false;
+    }
+
+    // fill in the buffer with property value
+    if (!SetupDiGetDevicePropertyW(pDevInfo, pDevInfoData, pPropertyKey, &propertyType, *ppStringOut, propertySize, NULL, 0))
+    {
+        DBG(stderr, "%s [%d] ---> SetupDiGetDeviceProperty() failed with the error code 0x%02x\n", __FUNCTION__, __LINE__, GetLastError());
+        delete[] *ppStringOut;
+        *ppStringOut = NULL;
+        return false;
+    }
+
+    if (pStringOutSize)
+    {
+        *pStringOutSize = propertySize;
+    }
+
+    return true;
+}
+
+/************************************************************************/
+/* GetIntelDriverStoreFullPath                                          */
+/************************************************************************/
+static bool GetIntelDriverStoreFullPath(
+    wchar_t* pDriverStorePath,
+    unsigned long driverStorePathSizeInCharacters,
+    unsigned long* pDriverStorePathLengthInCharacters)
+{
+    bool result = false;
+    // allocated memory must be freed with delete operation
+    unsigned char* pPropertyInfName = NULL;
+    // allocated memory must be freed with delete operation
+    unsigned char* pPropertyDevServiceName = NULL;
+
+    // guid defined for display adapters
+    const GUID guid = GUID_DISPLAY_DEVICE_ARRIVAL;
+
+    // create device information set containing display adapters which support interfaces and are currently present in the system
+    void* pDevInfo = SetupDiGetClassDevs(&guid, NULL, NULL, DIGCF_DEVICEINTERFACE | DIGCF_PRESENT);
+    if (pDevInfo == INVALID_HANDLE_VALUE)
+    {
+        DBG(stderr, "%s [%d] ---> SetupDiGetClassDevs() failed with the error code 0x%02x, pDevInfo = INVALID_HANDLE_VALUE\n", __FUNCTION__, __LINE__, GetLastError());
+        goto END;
+    }
+
+    unsigned long deviceIndex = 0;
+    SP_DEVINFO_DATA devInfoData;
+    ZeroMemory(&devInfoData, sizeof(SP_DEVINFO_DATA));
+    unsigned long interfaceIndex = 0;
+    SP_DEVICE_INTERFACE_DATA deviceInterfaceData;
+    ZeroMemory(&deviceInterfaceData, sizeof(SP_DEVICE_INTERFACE_DATA));
+    DEVPROPKEY devPropKey;
+    ZeroMemory(&devPropKey, sizeof(DEVPROPKEY));
+    unsigned long driverStorePathLengthInCharacters = 0;
+
+    // enumerate display adapters
+    while (true)
+    {
+        ZeroMemory(&devInfoData, sizeof(SP_DEVINFO_DATA));
+        devInfoData.cbSize = sizeof(SP_DEVINFO_DATA);
+
+        if (!SetupDiEnumDeviceInfo(pDevInfo, deviceIndex, &devInfoData))
+        {
+            if (GetLastError() != ERROR_NO_MORE_ITEMS)
+            {
+                DBG(stderr, "%s [%d] ---> SetupDiEnumDeviceInfo() failed with the error code 0x%02x\n", __FUNCTION__, __LINE__, GetLastError());
+            }
+
+            deviceIndex = 0;
+            goto END;
+        }
+
+        // enumerate interfaces of display adapters
+        while (true)
+        {
+            ZeroMemory(&deviceInterfaceData, sizeof(SP_DEVICE_INTERFACE_DATA));
+            deviceInterfaceData.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
+
+            if (!SetupDiEnumDeviceInterfaces(pDevInfo, &devInfoData, &guid, interfaceIndex, &deviceInterfaceData))
+            {
+                if (GetLastError() == ERROR_NO_MORE_ITEMS)
+                {
+                    interfaceIndex = 0;
+                    break;
+                }
+                else
+                {
+                    DBG(stderr, "%s [%d] ---> SetupDiEnumDeviceInterfaces() failed with the error code 0x%02x\n", __FUNCTION__, __LINE__, GetLastError());
+                    interfaceIndex = 0;
+                    goto END;
+                }
+            }
+
+            // get an inf file name for a display adapter
+            if (GetPropertyFromDevice(pDevInfo, &devInfoData, &DEVPKEY_Device_DriverInfPath, &pPropertyInfName, NULL) == false)
+            {
+                DBG(stderr, "%s [%d] ---> GetPropertyFromDevice() failed with the error code 0x%02x\n", __FUNCTION__, __LINE__, GetLastError());
+                goto END;
+            }
+
+            // to read DEVPKEY_Device_DriverInfPath property value correctly just cast unsigned char* (means PBYTE) to const wchar_t*
+            const wchar_t* pInfName = reinterpret_cast<const wchar_t*>(pPropertyInfName);
+            DBG(stdout, "\n");
+            DBG(stdout, "pPropertyInfName = %ws\n", pInfName);
+            wchar_t driverStorePath[MAX_PATH];
+            ZeroMemory(driverStorePath, sizeof(driverStorePath));
+
+            // get a fully qualified name of an inf file (directory path and file name)
+            if (!SetupGetInfDriverStoreLocationW(pInfName, NULL, NULL, driverStorePath, ARRAYSIZE(driverStorePath), NULL))
+            {
+                DBG(stderr, "%s [%d] ---> SetupGetInfDriverStoreLocation() failed with the error code 0x%02x\n", __FUNCTION__, __LINE__, GetLastError());
+                goto END;
+            }
+
+            // remove backslash and file name from the fully qualified name
+            PathRemoveFileSpecW(driverStorePath);
+            DBG(stdout, "driverStorePath = %ws\n", driverStorePath);
+            driverStorePathLengthInCharacters = (unsigned long)wcsnlen_s(driverStorePath, ARRAYSIZE(driverStorePath));
+            DBG(stdout, "driverStorePathLengthInCharacters = %d\n", driverStorePathLengthInCharacters);
+
+            // get service name for a display adapter
+            if (GetPropertyFromDevice(pDevInfo, &devInfoData, &DEVPKEY_Device_Service, &pPropertyDevServiceName, NULL) == false)
+            {
+                DBG(stderr, "%s [%d] ---> GetPropertyFromDevice() failed with the error code 0x%02x\n", __FUNCTION__, __LINE__, GetLastError());
+                goto END;
+            }
+
+            // to read DEVPKEY_Device_Service property value correctly just cast unsigned char* (means PBYTE) to const wchar_t*
+            const wchar_t* pDevServiceName = reinterpret_cast<const wchar_t*>(pPropertyDevServiceName);
+            DBG(stdout, "pDevServiceName = %ws\n", pDevServiceName);
+
+            // check if a given display adapter is from Intel based on driver device service name "igfx"
+            // check if pDevServiceName contains "igfx" name
+            if (wcsstr(pDevServiceName, L"igfx"))
+            {
+                // display adapter is from Intel
+                DBG(stdout, "this display adapter is from Intel\n");
+
+                if (pDriverStorePath == NULL)
+                {
+                    DBG(stderr, "%s [%d] ---> Error: input parameter pDriverStorePath = NULL\n", __FUNCTION__, __LINE__);
+                    goto END;
+                }
+
+                if (driverStorePathSizeInCharacters < driverStorePathLengthInCharacters + 1)
+                {
+                    DBG(stderr, "%s [%d] ---> Error: input parameter driverStorePathSizeInCharacters = %d is too small, the required size is %d\n", __FUNCTION__, __LINE__, driverStorePathSizeInCharacters, driverStorePathLengthInCharacters + 1);
+                    goto END;
+                }
+
+                wcscpy_s(pDriverStorePath, driverStorePathSizeInCharacters, driverStorePath);
+
+                if (pDriverStorePathLengthInCharacters)
+                {
+                    *pDriverStorePathLengthInCharacters = driverStorePathLengthInCharacters;
+                }
+
+                result = (driverStorePathLengthInCharacters > 0) ? true : false;
+                if (result == false)
+                {
+                    SetLastError(ERROR_BAD_LENGTH);
+                    DBG(stderr, "%s [%d] ---> Error: driverStorePathLengthInCharacters = 0, result = false\n", __FUNCTION__, __LINE__);
+                }
+                goto END;
+            }
+            else
+            {
+                // display adapter is from other vendor
+                DBG(stdout, "this display adapter is NOT from Intel\n");
+
+                if (pPropertyDevServiceName)
+                {
+                    delete[] pPropertyDevServiceName;
+                    pPropertyDevServiceName = NULL;
+                }
+
+                if (pPropertyInfName)
+                {
+                    delete[] pPropertyInfName;
+                    pPropertyInfName = NULL;
+                }
+            }
+
+            ++interfaceIndex;
+        }
+
+        ++deviceIndex;
+    }
+
+END:
+    DBG(stdout, "\n");
+
+    if (pPropertyDevServiceName)
+    {
+        delete[] pPropertyDevServiceName;
+        pPropertyDevServiceName = NULL;
+    }
+
+    if (pPropertyInfName)
+    {
+        delete[] pPropertyInfName;
+        pPropertyInfName = NULL;
+    }
+
+    if (pDevInfo)
+    {
+        SetupDiDestroyDeviceInfoList(pDevInfo);
+        pDevInfo = NULL;
+    }
+
+    return result;
+}
+
+/************************************************************************/
+/* LoadDynamicLibrary                                                   */
+/************************************************************************/
+static HMODULE LoadDynamicLibrary(const wchar_t* pFileName, HANDLE hFile = NULL, unsigned long flags = 0)
+{
+    HMODULE hModule = NULL;
+    unsigned long driverStorePathLengthInCharacters = 0;
+    // contains fully qualified name of DriverStore (directory path only without backslash at the end) for Intel display driver
+    // for example: C:\Windows\System32\DriverStore\FileRepository\igdlh64.inf_amd64_1d1d318ad2d391db
+    wchar_t driverStorePath[MAX_PATH] = { 0 };
+
+    // find fully qualified name of DriverStore for Intel graphics driver
+    if (GetIntelDriverStoreFullPath(driverStorePath, ARRAYSIZE(driverStorePath), &driverStorePathLengthInCharacters) == true)
+    {
+        std::wstring driverStoreFullPath(driverStorePath);
+
+        if (driverStorePathLengthInCharacters)
+        {
+            driverStoreFullPath += L"\\";
+            driverStoreFullPath += pFileName;
+        }
+
+        DBG(stdout, "full path: %ws\n\n", driverStoreFullPath.c_str());
+
+        // load dll from DriverStore full path
+        hModule = LoadLibraryExW(driverStoreFullPath.c_str(), NULL, 0);
+    }
+    else
+    {
+        DBG(stderr, "%s [%d] ---> GetIntelDriverStoreFullPath() failed\n", __FUNCTION__, __LINE__);
+        hModule = NULL;
+    }
+
+    return hModule;
+}

--- a/mdapi/MetricsDiscoveryHelper.cpp
+++ b/mdapi/MetricsDiscoveryHelper.cpp
@@ -1,0 +1,1142 @@
+/*
+// Copyright (c) 2018 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+*/
+
+#include "MetricsDiscoveryHelper.h"
+
+#include "common.h"
+
+#include <algorithm>
+#include <stack>
+#include <string>
+
+#include <stdio.h>
+
+// Enables logs
+#define MD_DEBUG 1
+
+#if defined(_WIN32)
+static const wchar_t* cMDLibFileName =
+    sizeof(void*) == 8 ?
+    L"igdmd64.dll" :
+    L"igdmd32.dll";
+
+#include "DriverStorePath.h"
+
+#define OpenLibrary(_filename)              (void*)LoadDynamicLibrary( _filename )
+#define GetFunctionAddress(_handle, _name)  GetProcAddress((HMODULE)_handle, _name)
+
+#elif defined(__linux__) || defined(__APPLE__)
+static const char* cMDLibFileName = "libmd.so";
+
+#include <dlfcn.h>
+#include <stdarg.h>
+#include <string.h>
+
+#define OpenLibrary(_filename)              dlopen( _filename, RTLD_LAZY | RTLD_LOCAL )
+#define GetFunctionAddress(_handle, _name)  dlsym(_handle, _name)
+#define GetLastError()                      dlerror()
+#define OutputDebugString(_buf)             fprintf(stderr, "%s\n", _buf);
+
+#endif
+
+namespace MetricsDiscovery
+{
+
+#ifdef MD_DEBUG
+/************************************************************************/
+/* DebugPrint                                                           */
+/************************************************************************/
+static void DebugPrint(const char* formatString, ...)
+{
+    const int BUFF_SIZE = 1024;
+    const int FORMAT_SIZE = 512;
+
+    va_list ap;
+    char buf[BUFF_SIZE];
+    char format[FORMAT_SIZE];
+
+    CLI_SPRINTF(format, FORMAT_SIZE, "MDAPI Helper: %s", formatString);
+    va_start(ap, formatString);
+    CLI_VSPRINTF(buf, BUFF_SIZE, format, ap);
+    OutputDebugString(buf);
+    va_end(ap);
+}
+#else
+#define DebugPrint(...)
+#endif // MD_DEBUG
+
+/************************************************************************/
+/* MDHelper constructor                                                 */
+/************************************************************************/
+MDHelper::MDHelper() :
+    m_Initialized(false),
+    m_APIMask( API_TYPE_OCL | API_TYPE_OGL | API_TYPE_DX12 ),
+    m_CategoryMask( GPU_RENDER | GPU_COMPUTE | GPU_MEDIA | GPU_GENERIC ),
+    m_MetricsDevice( NULL ),
+    m_MetricSet( NULL )
+{
+}
+
+/************************************************************************/
+/* ~MDHelper                                                            */
+/************************************************************************/
+MDHelper::~MDHelper()
+{
+    DebugPrint("MDHelper Destructor");
+
+    if(CloseMetricsDevice != NULL && m_MetricsDevice)
+    {
+        CloseMetricsDevice( m_MetricsDevice );
+        m_MetricsDevice = NULL;
+    }
+
+    m_Initialized = false;
+}
+
+/************************************************************************/
+/* InitMetricsDiscovery                                                 */
+/************************************************************************/
+bool MDHelper::InitMetricsDiscovery(
+    const std::string& metricSetSymbolName,
+    const std::string& metricsFileName )
+{
+    m_Initialized = false;
+
+    CloseMetricsDevice = NULL;
+    OpenMetricsDevice = NULL;
+    OpenMetricsDeviceFromFile = NULL;
+
+    TCompletionCode res = CC_OK;
+
+    if (m_APIMask & API_TYPE_IOSTREAM )
+    {
+        DebugPrint("API type must not be IOSTREAM.");
+        return false;
+    }
+
+    void* pLibrary = OpenLibrary(cMDLibFileName);
+    if (pLibrary == NULL)
+    {
+        DebugPrint("Couldn't load metrics discovery library!");
+        return false;
+    }
+
+    CloseMetricsDevice = (CloseMetricsDevice_fn)GetFunctionAddress(pLibrary, "CloseMetricsDevice");
+    if (CloseMetricsDevice == NULL)
+    {
+        DebugPrint("CloseMetricsDevice NULL, error: %d", GetLastError());
+        return false;
+    }
+
+    OpenMetricsDevice = (OpenMetricsDevice_fn)GetFunctionAddress(pLibrary, "OpenMetricsDevice");
+    if (OpenMetricsDevice == NULL)
+    {
+        DebugPrint("OpenMetricsDevice NULL, error: %d", GetLastError());
+        return false;
+    }
+
+    OpenMetricsDeviceFromFile = (OpenMetricsDeviceFromFile_fn)GetFunctionAddress(pLibrary, "OpenMetricsDeviceFromFile");
+    if (OpenMetricsDeviceFromFile == NULL)
+    {
+        DebugPrint("OpenMetricsDeviceFromFile NULL, error: %d", GetLastError());
+        return false;
+    }
+
+    if (!metricsFileName.empty())
+    {
+        res = OpenMetricsDeviceFromFile(metricsFileName.c_str(), (void*)"", &m_MetricsDevice);
+        if (res != CC_OK)
+        {
+            DebugPrint("OpenMetricsDeviceFromFile failed, res: %d", res);
+            return false;
+        }
+    }
+    else
+    {
+        res = OpenMetricsDevice(&m_MetricsDevice);
+        if (res != CC_OK)
+        {
+            DebugPrint("OpenMetricsDevice failed, res: %d", res);
+            return false;
+        }
+    }
+
+    TMetricsDeviceParams_1_0* deviceParams = m_MetricsDevice->GetParams();
+    if (NULL == deviceParams)
+    {
+        DebugPrint("DeviceParams null");
+        return false;
+    }
+
+    DebugPrint("MDAPI Headers: v%d.%d.%d, MDAPI Lib: v%d.%d.%d\n",
+        MD_API_MAJOR_NUMBER_CURRENT,
+        MD_API_MINOR_NUMBER_CURRENT,
+        MD_API_BUILD_NUMBER_CURRENT,
+        deviceParams->Version.MajorNumber,
+        deviceParams->Version.MinorNumber,
+        deviceParams->Version.BuildNumber);
+
+    {
+        TTypedValue_1_0* euCores = GetGlobalSymbolValue("EuCoresTotalCount");
+        if (euCores == NULL)
+        {
+            DebugPrint("EuCoresTotalCount null, maybe support_enable");
+            return false;
+        }
+        m_EUCoresCount = euCores->ValueUInt32;
+    }
+
+    bool found = false;
+    for( uint32_t cg = 0; !found && cg < deviceParams->ConcurrentGroupsCount; cg++ )
+    {
+        IConcurrentGroup_1_1 *group = m_MetricsDevice->GetConcurrentGroup(cg);
+        TConcurrentGroupParams_1_0* groupParams = group->GetParams();
+        if( groupParams )
+        {
+            for( uint32_t ms = 0; !found && ms < groupParams->MetricSetsCount; ms++)
+            {
+                IMetricSet_1_1* metricSet = group->GetMetricSet(ms);
+                TMetricSetParams_1_0* setParams = metricSet->GetParams();
+
+                if( setParams &&
+                    ( setParams->ApiMask & m_APIMask ) &&
+                    ( setParams->CategoryMask & m_CategoryMask ) &&
+                    ( metricSetSymbolName == setParams->SymbolName ) )
+                {
+                    DebugPrint("Matched Group: %s MetricSet: %s MetricCount: %d API: %X, Category: %X\n",
+                        groupParams->SymbolName,
+                        setParams->SymbolName,
+                        setParams->MetricsCount,
+                        setParams->ApiMask,
+                        setParams->CategoryMask );
+
+                    found = true;
+                    m_MetricSet = metricSet;
+                }
+                else if( setParams )
+                {
+                    DebugPrint("Skipped Group: %s MetricSet: %s MetricCount: %d API: %X, Category: %X\n",
+                        groupParams->SymbolName,
+                        setParams->SymbolName,
+                        setParams->MetricsCount,
+                        setParams->ApiMask,
+                        setParams->CategoryMask );
+                }
+            }
+        }
+    }
+
+    if (m_MetricSet == NULL)
+    {
+        DebugPrint("MetricSet is null\n");
+        return false;
+    }
+
+    m_Initialized = true;
+
+    DebugPrint("MetricsDiscoveryInit End\n");
+    return m_Initialized;
+}
+
+/************************************************************************/
+/* ActivateMetricSet                                                    */
+/************************************************************************/
+void MDHelper::ActivateMetricSet()
+{
+    if( !m_Initialized || !m_MetricSet ) return;
+
+    TCompletionCode res = m_MetricSet->Activate();
+    if( res != CC_OK ) DebugPrint("ActivateMetricSet failed!\n");
+}
+
+/************************************************************************/
+/* DeactivateMetricSet                                                  */
+/************************************************************************/
+void MDHelper::DeactivateMetricSet()
+{
+    if( !m_Initialized || !m_MetricSet ) return;
+
+    TCompletionCode res = m_MetricSet->Deactivate();
+    if( res != CC_OK ) DebugPrint("DeactivateMetricSet failed!\n");
+}
+
+/************************************************************************/
+/* SetMetricSetFiltering                                                */
+/************************************************************************/
+void MDHelper::SetMetricSetFiltering( TMetricApiType apiMask )
+{
+    if( !m_Initialized || !m_MetricSet ) return;
+
+    TCompletionCode res = m_MetricSet->SetApiFiltering( apiMask );
+    if( res != CC_OK ) DebugPrint("SetMetricSetFiltering failed!\n");
+}
+
+/************************************************************************/
+/* GetMetricsFromReport                                                 */
+/************************************************************************/
+void MDHelper::GetMetricsFromReport(
+    const char* pReportData,
+    std::vector<TTypedValue_1_0>& results,
+    std::vector<TTypedValue_1_0>& information )
+{
+    if( !m_Initialized || !m_MetricSet ) return;
+
+    const uint32_t metricsCount     = m_MetricSet->GetParams()->MetricsCount;
+    const uint32_t informationCount = m_MetricSet->GetParams()->InformationCount;
+
+    std::vector<TTypedValue_1_0>    deltaValues;
+
+    deltaValues.resize( metricsCount );
+    results.resize( metricsCount );
+    information.resize( informationCount );
+
+    // Read metrics from the report data and normalize:
+    ReadMetrics( pReportData, deltaValues );
+    NormalizeMetrics( deltaValues, results );
+
+    // Read informational from the report data:
+    ReadInformation( pReportData, information );
+}
+
+/************************************************************************/
+/* PrintMetricNames                                                     */
+/************************************************************************/
+void MDHelper::PrintMetricNames( std::ostream& os )
+{
+    if( !m_Initialized || !m_MetricSet || !os.good() ) return;
+
+    os << "kernel,";
+
+    for( uint32_t i = 0; i < m_MetricSet->GetParams( )->MetricsCount; i++ )
+    {
+        // Skip if not supported
+        if ( 0 == ( m_MetricSet->GetMetric( i )->GetParams()->ApiMask & m_APIMask )) continue;
+        os << m_MetricSet->GetMetric( i )->GetParams()->SymbolName << ",";
+    }
+
+    os << ",";
+
+    for(uint32_t i = 0; i < m_MetricSet->GetParams()->InformationCount; i++)
+    {
+        // Skip if not supported
+        if ( 0 == ( m_MetricSet->GetInformation( i )->GetParams()->ApiMask & m_APIMask )) continue;
+        os << m_MetricSet->GetInformation( i )->GetParams()->SymbolName << ",";
+    }
+
+    os << std::endl;
+}
+
+/************************************************************************/
+/* PrintMetricValues                                                    */
+/************************************************************************/
+void MDHelper::PrintMetricValues(
+    std::ostream& os,
+    const std::string& name,
+    const std::vector<TTypedValue_1_0>& results,
+    const std::vector<TTypedValue_1_0>& information )
+{
+    if( !m_Initialized || !m_MetricSet || !os.good() ) return;
+
+    os << name << ",";
+
+    uint32_t metricsCount = m_MetricSet->GetParams()->MetricsCount;
+    for( uint32_t i = 0; i < metricsCount; i++ )
+    {
+        // Skip if not supported
+        if ( 0 == ( m_MetricSet->GetMetric( i )->GetParams()->ApiMask & m_APIMask )) continue;
+
+        PrintValue( os, results[ i ] );
+
+    }
+
+    os << ",";
+
+    for( uint32_t i = 0; i < m_MetricSet->GetParams()->InformationCount; i++ )
+    {
+        // Skip if not supported
+        if ( 0 == ( m_MetricSet->GetInformation( i )->GetParams()->ApiMask & m_APIMask )) continue;
+
+        PrintValue( os, information[ i ] );
+    }
+
+    os << std::endl;
+}
+
+/************************************************************************/
+/* AggregateMetrics                                                     */
+/************************************************************************/
+void MDHelper::AggregateMetrics(
+    CMetricAggregations& aggregations,
+    const std::string& name,
+    const std::vector<TTypedValue_1_0>& results )
+{
+    if( !m_Initialized || !m_MetricSet ) return;
+
+    CMetricAggregationsForKernel& kernelMetrics = aggregations[ name ];
+
+    uint32_t metricsCount = m_MetricSet->GetParams()->MetricsCount;
+    for( uint32_t i = 0; i < metricsCount; i++ )
+    {
+        TMetricParams_1_0* metricParams = m_MetricSet->GetMetric( i )->GetParams();
+
+        // Skip if not supported
+        if( 0 == ( metricParams->ApiMask & m_APIMask ) ) continue;
+
+        // Find profile data for metric
+        const char* metricName = metricParams->SymbolName;
+        SMetricAggregationData& aggregationData =
+            kernelMetrics[ metricName ];
+
+        // Add data to metricData
+        uint64_t value = CastToUInt64( results[ i ] );
+
+        aggregationData.Count++;
+        aggregationData.Sum += value;
+        aggregationData.Min = std::min<uint64_t>( aggregationData.Min, value );
+        aggregationData.Max = std::max<uint64_t>( aggregationData.Max, value );
+    }
+}
+
+/************************************************************************/
+/* ReadMetrics                                                          */
+/************************************************************************/
+void MDHelper::ReadMetrics(
+    const char* pReportData,
+    std::vector<TTypedValue_1_0>& deltaValues )
+{
+    if( !pReportData ) return;
+
+    uint32_t metricsCount = m_MetricSet->GetParams()->MetricsCount;
+    m_GPUCoreClocks             = 0;
+
+    for( uint32_t i = 0; i < metricsCount; i++ )
+    {
+        TMetricParams_1_0* metricParams = m_MetricSet->GetMetric( i )->GetParams();
+        if ( 0 == ( metricParams->ApiMask & m_APIMask )) continue;
+
+        IEquation_1_0* equation = metricParams->QueryReadEquation;
+
+        if( equation )
+        {
+            deltaValues[ i ] = CalculateReadEquation( equation, pReportData );
+        }
+        else
+        {
+            deltaValues[ i ].ValueType = VALUE_TYPE_UINT64;
+            deltaValues[ i ].ValueUInt64 = 0ULL;
+        }
+
+        if( strcmp( metricParams->SymbolName, "GpuCoreClocks" ) == 0 )
+        {
+            m_GPUCoreClocks = deltaValues[ i ].ValueUInt64;
+        }
+    }
+}
+
+/************************************************************************/
+/* NormalizeMetrics                                                     */
+/************************************************************************/
+void MDHelper::NormalizeMetrics(
+    std::vector<TTypedValue_1_0>& deltaValues,
+    std::vector<TTypedValue_1_0>& results )
+{
+    uint32_t metricsCount = m_MetricSet->GetParams()->MetricsCount;
+
+    for( uint32_t i = 0; i < metricsCount; i++ )
+    {
+        TMetricParams_1_0* metricParams = m_MetricSet->GetMetric( i )->GetParams();
+        if ( 0 == ( metricParams->ApiMask & m_APIMask )) continue;
+
+        IEquation_1_0* normEquation = metricParams->NormEquation;
+
+        if ( normEquation )
+        {
+            // do final calculation, may refer to global symbols, local delta results and local normalization results
+            results[ i ] = CalculateLocalNormalizationEquation(
+                normEquation,
+                deltaValues.data(),
+                results.data(),
+                i );
+        }
+        else
+        {
+            results[ i ] = deltaValues[ i ];
+        }
+    }
+}
+
+/************************************************************************/
+/* ReadInformation                                                      */
+/************************************************************************/
+void MDHelper::ReadInformation(
+    const char* pReportData,
+    std::vector<TTypedValue_1_0>& results )
+{
+    if( !pReportData ) return;
+
+    uint32_t informationCount = m_MetricSet->GetParams()->InformationCount;
+
+    for( uint32_t i = 0; i < informationCount; i++ )
+    {
+        IInformation_1_0* information = m_MetricSet->GetInformation( i );
+        ReadSingleInformation( pReportData, information, &results[ i ] );
+    }
+}
+
+/************************************************************************/
+/* ReadSingleInformation                                                */
+/************************************************************************/
+void MDHelper::ReadSingleInformation(
+    const char* pReportData,
+    IInformation_1_0* information,
+    TTypedValue_1_0* result )
+{
+    if( !pReportData || !information || !result ) return;
+
+    TInformationParams_1_0* informationParams = information->GetParams();
+    if ( 0 == ( informationParams->ApiMask & m_APIMask )) return;
+
+    IEquation_1_0* equation = informationParams->QueryReadEquation;
+
+    if( equation )
+    {
+        *result = CalculateReadEquation( equation, pReportData );
+    }
+    else
+    {
+        result->ValueUInt64 = 0ULL;
+    }
+
+    if( informationParams->InfoType == INFORMATION_TYPE_FLAG )
+    {
+        result->ValueType = VALUE_TYPE_BOOL;
+    }
+    else
+    {
+        result->ValueType = VALUE_TYPE_UINT64;
+    }
+}
+
+/************************************************************************/
+/* PrintValue                                                           */
+/************************************************************************/
+void MDHelper::PrintValue( std::ostream& os, const TTypedValue_1_0& value )
+{
+    switch( value.ValueType )
+    {
+    case VALUE_TYPE_UINT64:
+        os << value.ValueUInt64 << ",";
+        break;
+
+    case VALUE_TYPE_FLOAT:
+        os << value.ValueFloat << ",";
+        break;
+
+    case VALUE_TYPE_BOOL:
+        os << (value.ValueBool ? "TRUE" : "FALSE") << ",";
+        break;
+
+    case VALUE_TYPE_UINT32:
+        os << value.ValueUInt32 << ",";
+        break;
+
+    default:
+        CLI_ASSERT(false);
+    }
+}
+
+/************************************************************************/
+/* GetGlobalSymbolValue                                                 */
+/************************************************************************/
+TTypedValue_1_0* MDHelper::GetGlobalSymbolValue(
+    const char* SymbolName )
+{
+    for( uint32_t i = 0; i < m_MetricsDevice->GetParams( )->GlobalSymbolsCount; i++ )
+    {
+        TGlobalSymbol_1_0* symbol = m_MetricsDevice->GetGlobalSymbol( i );
+        if( strcmp( symbol->SymbolName, SymbolName ) == 0 )
+        {
+            return &( symbol->SymbolTypedValue );
+        }
+    }
+    return NULL;
+}
+
+/*******************************************************************************/
+/* CalculateReadEquation                                                       */
+/*******************************************************************************/
+TTypedValue_1_0 MDHelper::CalculateReadEquation(
+    IEquation_1_0* equation,
+    const char* pReportData )
+{
+    std::stack<TTypedValue_1_0> equationStack;
+    TTypedValue_1_0 typedValue;
+
+    for( uint32_t i = 0; i < equation->GetEquationElementsCount(); i++ )
+    {
+        TEquationElement_1_0* element = equation->GetEquationElement( i );
+        switch( element->Type )
+        {
+        case EQUATION_ELEM_RD_BITFIELD:
+
+            typedValue.ValueUInt64 = ReadBitfield( (const char *)(pReportData + element->ReadParams.ByteOffset),
+                element->ReadParams.BitOffset, element->ReadParams.BitsCount );
+            typedValue.ValueType   = VALUE_TYPE_UINT64;
+
+            equationStack.push( typedValue );
+            break;
+
+        case EQUATION_ELEM_RD_UINT8:
+            {
+                uint8_t byteValue = *((const uint8_t *)(pReportData + element->ReadParams.ByteOffset));
+                typedValue.ValueUInt64    = (uint64_t) byteValue;
+                typedValue.ValueType      = VALUE_TYPE_UINT64;
+            }
+            equationStack.push( typedValue );
+            break;
+
+        case EQUATION_ELEM_RD_UINT16:
+            {
+                uint16_t shortValue = *((const uint16_t *)(pReportData + element->ReadParams.ByteOffset));
+                typedValue.ValueUInt64      = (uint64_t) shortValue;
+                typedValue.ValueType        = VALUE_TYPE_UINT64;
+            }
+            equationStack.push( typedValue );
+            break;
+
+        case EQUATION_ELEM_RD_UINT32:
+            {
+                uint32_t dwordValue = *((const uint32_t *)(pReportData + element->ReadParams.ByteOffset));
+                typedValue.ValueUInt64  = (uint64_t) dwordValue;
+                typedValue.ValueType    = VALUE_TYPE_UINT64;
+            }
+            equationStack.push( typedValue );
+            break;
+
+        case EQUATION_ELEM_RD_UINT64:
+            typedValue.ValueUInt64 = *((const uint64_t *)(pReportData + element->ReadParams.ByteOffset));
+            typedValue.ValueType   = VALUE_TYPE_UINT64;
+            equationStack.push( typedValue );
+            break;
+
+        case EQUATION_ELEM_RD_FLOAT:
+            typedValue.ValueFloat = *((const float *)(pReportData + element->ReadParams.ByteOffset));
+            typedValue.ValueType  = VALUE_TYPE_FLOAT;
+            equationStack.push( typedValue );
+            break;
+
+        case EQUATION_ELEM_RD_40BIT_CNTR:
+            {
+                typedValue.ValueUInt64Fields.Low = *((const uint32_t *)(pReportData + element->ReadParams.ByteOffset));
+                typedValue.ValueUInt64Fields.High = (uint32_t)*((const unsigned char *)(pReportData + element->ReadParams.ByteOffsetExt));
+                typedValue.ValueType = VALUE_TYPE_UINT64;
+                equationStack.push( typedValue );
+            }
+            break;
+
+        case EQUATION_ELEM_IMM_UINT64:
+            typedValue.ValueUInt64 = element->ImmediateUInt64;
+            typedValue.ValueType   = VALUE_TYPE_UINT64;
+            equationStack.push( typedValue );
+            break;
+
+        case EQUATION_ELEM_IMM_FLOAT:
+            typedValue.ValueFloat = element->ImmediateFloat;
+            typedValue.ValueType   = VALUE_TYPE_FLOAT;
+            equationStack.push( typedValue );
+            break;
+
+        case EQUATION_ELEM_GLOBAL_SYMBOL:
+            {
+                TTypedValue_1_0* pValue = GetGlobalSymbolValue( element->SymbolName );
+                if( pValue )
+                {
+                    typedValue = *pValue;
+                }
+                else
+                {
+                    typedValue.ValueUInt64 = 0;
+                    typedValue.ValueType   = VALUE_TYPE_UINT64;
+                }
+                equationStack.push( typedValue );
+            }
+            break;
+
+        case EQUATION_ELEM_OPERATION:
+            {
+                //pop two values from stack
+                TTypedValue_1_0 valueLast = equationStack.top();
+                equationStack.pop();
+                TTypedValue_1_0 valuePrev = equationStack.top();
+                equationStack.pop();
+
+                typedValue = CalculateEquationElemOperation( element->Operation, valuePrev, valueLast );
+                equationStack.push( typedValue );
+            }
+            break;
+
+        default:
+            CLI_ASSERT( false );
+            break;
+        }
+    }
+
+    typedValue = equationStack.top();
+    equationStack.pop();
+
+    CLI_ASSERT( equationStack.empty() );
+
+    return typedValue;
+}
+
+/************************************************************************/
+/* CalculateLocalNormalizationEquation                                  */
+/************************************************************************/
+TTypedValue_1_0 MDHelper::CalculateLocalNormalizationEquation(
+    IEquation_1_0* equation,        // can't be const but should
+    TTypedValue_1_0* deltaValues,   // could be const
+    TTypedValue_1_0* results,
+    uint32_t metricIndex )
+{
+    TTypedValue_1_0 typedValue;
+
+    std::stack<TTypedValue_1_0> equationStack;
+
+    for( uint32_t i = 0; i < equation->GetEquationElementsCount(); i++ )
+    {
+        const TEquationElement_1_0* element = equation->GetEquationElement( i );
+        switch( element->Type )
+        {
+        case EQUATION_ELEM_RD_BITFIELD:
+        case EQUATION_ELEM_RD_UINT8:
+        case EQUATION_ELEM_RD_UINT16:
+        case EQUATION_ELEM_RD_UINT32:
+        case EQUATION_ELEM_RD_UINT64:
+        case EQUATION_ELEM_RD_FLOAT:
+        case EQUATION_ELEM_RD_40BIT_CNTR:
+            //not allowed in norm equation
+            CLI_ASSERT( false );
+            break;
+
+        case EQUATION_ELEM_IMM_FLOAT:
+            typedValue.ValueFloat = element->ImmediateFloat;
+            typedValue.ValueType = VALUE_TYPE_FLOAT;
+            equationStack.push( typedValue );
+
+            break;
+
+        case EQUATION_ELEM_IMM_UINT64:
+            typedValue.ValueUInt64 = element->ImmediateUInt64;
+            typedValue.ValueType = VALUE_TYPE_UINT64;
+            equationStack.push( typedValue );
+            break;
+
+        case EQUATION_ELEM_SELF_COUNTER_VALUE:
+            //get result of delta equation
+            typedValue = deltaValues[ metricIndex ];
+            equationStack.push( typedValue );
+            break;
+
+        case EQUATION_ELEM_LOCAL_COUNTER_SYMBOL:
+            {
+                bool found = false;
+                for( uint32_t j = 0; j < m_MetricSet->GetParams()->MetricsCount; j++ )
+                {
+                    //find symbol by name in the set
+                    IMetric_1_0* metric = m_MetricSet->GetMetric( j );
+                    if( strcmp( element->SymbolName, metric->GetParams()->SymbolName ) == 0 )
+                    {
+                        found = true;
+                        typedValue = deltaValues[ metric->GetParams()->IdInSet ];
+                    }
+                }
+                if( !found )
+                {
+                    typedValue.ValueUInt64 = 0;
+                    typedValue.ValueType   = VALUE_TYPE_UINT64;
+                }
+                equationStack.push( typedValue );
+            }
+            break;
+
+        case EQUATION_ELEM_LOCAL_METRIC_SYMBOL:
+            {
+                bool found = false;
+                for( uint32_t j = 0; j < metricIndex; j++ )
+                {
+                    //find symbol by name in the set
+                    IMetric_1_0* metric = m_MetricSet->GetMetric( j );
+                    if( strcmp( element->SymbolName, metric->GetParams()->SymbolName ) == 0 )
+                    {
+                        found = true;
+                        typedValue = results[ metric->GetParams()->IdInSet ];
+                    }
+                }
+                if( !found )
+                {
+                    typedValue.ValueUInt64 = 0;
+                    typedValue.ValueType   = VALUE_TYPE_UINT64;
+                }
+                equationStack.push( typedValue );
+            }
+            break;
+
+        case EQUATION_ELEM_GLOBAL_SYMBOL:
+            {
+                TTypedValue_1_0* pValue = GetGlobalSymbolValue( element->SymbolName );
+                if( pValue )
+                {
+                    typedValue = *pValue;
+                }
+                else
+                {
+                    typedValue.ValueUInt64 = 0;
+                    typedValue.ValueType   = VALUE_TYPE_UINT64;
+                }
+                equationStack.push( typedValue );
+            }
+            break;
+
+        case EQUATION_ELEM_OPERATION:
+            {
+                TTypedValue_1_0 valueLast = equationStack.top();
+                equationStack.pop();
+                TTypedValue_1_0 valuePrev = equationStack.top();
+                equationStack.pop();
+
+                typedValue = CalculateEquationElemOperation( element->Operation, valuePrev, valueLast );
+                equationStack.push( typedValue );
+            }
+            break;
+
+        case EQUATION_ELEM_STD_NORM_GPU_DURATION:
+            CLI_ASSERT( equationStack.empty() );
+
+            if( m_GPUCoreClocks != 0 )
+            {
+                float self = CastToFloat( deltaValues[ metricIndex ] );
+                float gpuCoreClocks = (float) m_GPUCoreClocks;
+
+                typedValue.ValueFloat = 100.0f * self / gpuCoreClocks;
+                typedValue.ValueType = VALUE_TYPE_FLOAT;
+                return typedValue;
+            }
+            else
+            {
+                DebugPrint( "Waring: GpuCoreClocks is 0" );
+                typedValue.ValueFloat = 0.0f;
+                typedValue.ValueType = VALUE_TYPE_FLOAT;
+                return typedValue;
+            }
+
+        case EQUATION_ELEM_STD_NORM_EU_AGGR_DURATION:
+            CLI_ASSERT( equationStack.empty() );
+
+            if( m_GPUCoreClocks != 0 )
+            {
+                float self = CastToFloat( deltaValues[ metricIndex ] );
+                float gpuCoreClocks = (float) (m_GPUCoreClocks * m_EUCoresCount);
+
+                typedValue.ValueFloat = 100.0f * self / gpuCoreClocks;
+                typedValue.ValueType = VALUE_TYPE_FLOAT;
+                return typedValue;
+            }
+            else
+            {
+                DebugPrint( "Warning: GpuCoreClocks is 0" );
+                typedValue.ValueFloat = 0.0f;
+                typedValue.ValueType = VALUE_TYPE_FLOAT;
+                return typedValue;
+            }
+
+        default:
+            CLI_ASSERT( false );
+            break;
+        }
+    }
+
+    typedValue = equationStack.top();
+    equationStack.pop();
+
+    CLI_ASSERT( equationStack.empty() );
+
+    return typedValue;
+}
+
+/************************************************************************/
+/* CalculateEquationElemOperation                                       */
+/************************************************************************/
+TTypedValue_1_0 MDHelper::CalculateEquationElemOperation(
+    TEquationOperation operation,
+    TTypedValue_1_0 valuePrev,
+    TTypedValue_1_0 valueLast )
+{
+    TTypedValue_1_0 value;
+    value.ValueUInt64 = 0;
+    value.ValueType   = VALUE_TYPE_UINT64;
+
+    switch( operation )
+    {
+    case EQUATION_OPER_AND:
+        value.ValueUInt64 = CastToUInt64(valuePrev) & CastToUInt64(valueLast);
+        value.ValueType = VALUE_TYPE_UINT64;
+        break;
+
+    case EQUATION_OPER_OR:
+        value.ValueUInt64 = CastToUInt64(valuePrev) | CastToUInt64(valueLast);
+        value.ValueType = VALUE_TYPE_UINT64;
+        break;
+
+    case EQUATION_OPER_RSHIFT:
+        value.ValueUInt64 = CastToUInt64(valuePrev) >> CastToUInt64(valueLast);
+        value.ValueType = VALUE_TYPE_UINT64;
+        break;
+
+    case EQUATION_OPER_LSHIFT:
+        value.ValueUInt64 = CastToUInt64(valuePrev) << CastToUInt64(valueLast);
+        value.ValueType = VALUE_TYPE_UINT64;
+        break;
+
+    case EQUATION_OPER_XOR:
+        value.ValueUInt64 = CastToUInt64( valuePrev ) ^ CastToUInt64( valueLast );
+        value.ValueType = VALUE_TYPE_UINT64;
+        break;
+
+    case EQUATION_OPER_XNOR:
+        value.ValueUInt64 = ~(CastToUInt64( valuePrev ) ^ CastToUInt64( valueLast ));
+        value.ValueType = VALUE_TYPE_UINT64;
+        break;
+
+    case EQUATION_OPER_AND_L:
+        value.ValueBool = CastToUInt64( valuePrev ) && CastToUInt64( valueLast );
+        value.ValueType = VALUE_TYPE_BOOL;
+        break;
+
+    case EQUATION_OPER_EQUALS:
+        value.ValueBool = CastToUInt64( valuePrev ) == CastToUInt64( valueLast );
+        value.ValueType = VALUE_TYPE_BOOL;
+        break;
+
+    case EQUATION_OPER_UADD:
+        value.ValueUInt64 = CastToUInt64(valuePrev) + CastToUInt64(valueLast);
+        value.ValueType = VALUE_TYPE_UINT64;
+        break;
+
+    case EQUATION_OPER_USUB:
+        value.ValueUInt64 = CastToUInt64(valuePrev) - CastToUInt64(valueLast);
+        value.ValueType = VALUE_TYPE_UINT64;
+        break;
+
+    case EQUATION_OPER_UDIV:
+        if(CastToUInt64(valueLast) != 0LL)
+        {
+            value.ValueUInt64 = CastToUInt64(valuePrev) / CastToUInt64(valueLast);
+            value.ValueType = VALUE_TYPE_UINT64;
+        }
+        else
+        {
+            value.ValueUInt64 = 0ULL;
+            value.ValueType = VALUE_TYPE_UINT64;
+        }
+        break;
+
+    case EQUATION_OPER_UMUL:
+        value.ValueUInt64 = CastToUInt64(valuePrev) * CastToUInt64(valueLast);
+        value.ValueType = VALUE_TYPE_UINT64;
+        break;
+
+    case EQUATION_OPER_FADD:
+        value.ValueFloat = CastToFloat(valuePrev) + CastToFloat(valueLast);
+        value.ValueType = VALUE_TYPE_FLOAT;
+        break;
+
+    case EQUATION_OPER_FSUB:
+        value.ValueFloat = CastToFloat(valuePrev) - CastToFloat(valueLast);
+        value.ValueType = VALUE_TYPE_FLOAT;
+        break;
+
+    case EQUATION_OPER_FMUL:
+        value.ValueFloat = CastToFloat(valuePrev) * CastToFloat(valueLast);
+        value.ValueType = VALUE_TYPE_FLOAT;
+        break;
+
+    case EQUATION_OPER_FDIV:
+        if( CastToFloat(valueLast) != 0LL )
+        {
+            value.ValueFloat = CastToFloat( valuePrev ) / CastToFloat( valueLast );
+            value.ValueType = VALUE_TYPE_FLOAT;
+        }
+        else
+        {
+            value.ValueFloat = 0.0f;
+            value.ValueType = VALUE_TYPE_FLOAT;
+        }
+        break;
+
+    case EQUATION_OPER_UGT:
+        value.ValueBool = CastToUInt64( valuePrev ) > CastToUInt64( valueLast );
+        value.ValueType = VALUE_TYPE_BOOL;
+        break;
+
+    case EQUATION_OPER_ULT:
+        value.ValueBool = CastToUInt64( valuePrev ) < CastToUInt64( valueLast );
+        value.ValueType = VALUE_TYPE_BOOL;
+        break;
+
+    case EQUATION_OPER_UGTE:
+        value.ValueBool = CastToUInt64( valuePrev ) >= CastToUInt64( valueLast );
+        value.ValueType = VALUE_TYPE_BOOL;
+        break;
+
+    case EQUATION_OPER_ULTE:
+        value.ValueBool = CastToUInt64( valuePrev ) <= CastToUInt64( valueLast );
+        value.ValueType = VALUE_TYPE_BOOL;
+        break;
+
+    case EQUATION_OPER_FGT:
+        value.ValueBool = CastToFloat( valuePrev ) > CastToFloat( valueLast );
+        value.ValueType = VALUE_TYPE_BOOL;
+        break;
+
+    case EQUATION_OPER_FLT:
+        value.ValueBool = CastToFloat( valuePrev ) < CastToFloat( valueLast );
+        value.ValueType = VALUE_TYPE_BOOL;
+        break;
+
+    case EQUATION_OPER_FGTE:
+        value.ValueBool = CastToFloat( valuePrev ) >= CastToFloat( valueLast );
+        value.ValueType = VALUE_TYPE_BOOL;
+        break;
+
+    case EQUATION_OPER_FLTE:
+        value.ValueBool = CastToFloat( valuePrev ) <= CastToFloat( valueLast );
+        value.ValueType = VALUE_TYPE_BOOL;
+        break;
+
+    case EQUATION_OPER_UMIN:
+        value.ValueUInt64 = std::min<uint64_t>(CastToUInt64( valuePrev ), CastToUInt64( valueLast ));
+        value.ValueType = VALUE_TYPE_UINT64;
+        break;
+
+    case EQUATION_OPER_UMAX:
+        value.ValueUInt64 = std::max<uint64_t>(CastToUInt64( valuePrev ), CastToUInt64( valueLast ));
+        value.ValueType = VALUE_TYPE_UINT64;
+        break;
+
+    case EQUATION_OPER_FMIN:
+        value.ValueFloat = std::min<float>(CastToFloat( valuePrev ), CastToFloat( valueLast ));
+        value.ValueType = VALUE_TYPE_FLOAT;
+        break;
+
+    case EQUATION_OPER_FMAX:
+        value.ValueFloat = std::max<float>(CastToFloat( valuePrev ), CastToFloat( valueLast ));
+        value.ValueType = VALUE_TYPE_FLOAT;
+        break;
+
+    default:
+        CLI_ASSERT( false );
+        value.ValueUInt64 = 0;
+        value.ValueType   = VALUE_TYPE_UINT64;
+        break;
+    }
+
+    return value;
+}
+
+/************************************************************************/
+/* ReadBitfield                                                         */
+/************************************************************************/
+uint64_t MDHelper::ReadBitfield(
+    const char *pUnalignedData,
+    uint32_t bitOffset,
+    uint32_t bitsCount )
+{
+    if( (bitsCount > 32) || (bitsCount == 0) || (bitsCount + bitOffset > 32) ) return 0;
+
+    uint32_t mask = 0;
+    for( uint32_t i = 0; i < bitsCount; i++) mask |= 1 << i;
+    for( uint32_t i = 0; i < bitOffset; i++) mask = mask << 1;
+
+    uint32_t data =
+        (*pUnalignedData) |
+        ((*(pUnalignedData + 1)) << 8) |
+        ((*(pUnalignedData + 2)) << 16) |
+        ((*(pUnalignedData + 3)) << 24);
+
+    return (uint64_t)((data & mask) >> bitOffset);
+}
+
+/************************************************************************/
+/* CastToUInt64                                                         */
+/************************************************************************/
+uint64_t MDHelper::CastToUInt64(TTypedValue_1_0 value)
+{
+    switch( value.ValueType )
+    {
+    case VALUE_TYPE_BOOL:
+        return ( value.ValueBool ) ? 1LL : 0LL;
+
+    case VALUE_TYPE_UINT32:
+        return (uint64_t)value.ValueUInt32;
+
+    case VALUE_TYPE_UINT64:
+        return value.ValueUInt64;
+
+    case VALUE_TYPE_FLOAT:
+        return (uint64_t)value.ValueFloat;
+
+    default:
+        CLI_ASSERT( false );
+        break;
+    }
+
+    return 0;
+}
+
+/************************************************************************/
+/* CastToFloat                                                          */
+/************************************************************************/
+float MDHelper::CastToFloat(TTypedValue_1_0 value)
+{
+    switch( value.ValueType )
+    {
+    case VALUE_TYPE_BOOL:
+        return ( value.ValueBool ) ? 1.0f : 0.0f;
+
+    case VALUE_TYPE_UINT32:
+        return (float)value.ValueUInt32;
+
+    case VALUE_TYPE_UINT64:
+        return (float)value.ValueUInt64;
+
+    case VALUE_TYPE_FLOAT:
+        return value.ValueFloat;
+
+    default:
+        CLI_ASSERT( false );
+        break;
+    }
+
+    return 0.0f;
+}
+
+}

--- a/mdapi/MetricsDiscoveryHelper.h
+++ b/mdapi/MetricsDiscoveryHelper.h
@@ -1,0 +1,168 @@
+/*
+// Copyright (c) 2018 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+*/
+
+#pragma once
+
+#include "metrics_discovery_api.h"
+
+#include <ostream>
+#include <map>
+#include <vector>
+
+#include <limits.h>
+#include <stdint.h>
+
+namespace MetricsDiscovery
+{
+
+struct SMetricAggregationData
+{
+    SMetricAggregationData() :
+        Count(0),
+        Sum(0),
+        Min(ULLONG_MAX),
+        Max(0) {}
+
+    uint64_t Count;
+    uint64_t Sum;
+    uint64_t Min;
+    uint64_t Max;
+};
+
+// This is a map of a metric name to sum/min/max/count data:
+typedef std::map<const std::string, SMetricAggregationData> CMetricAggregationsForKernel;
+
+// This is a map of kernel names to aggregated metrics:
+typedef std::map<const std::string, CMetricAggregationsForKernel> CMetricAggregations;
+
+class MDHelper
+{
+public:
+    MDHelper();
+    ~MDHelper();
+
+    bool InitMetricsDiscovery(
+        const std::string& metricSetSymbolName,
+        const std::string& metricsFileName );
+
+    uint32_t GetMetricsConfiguration();
+    uint32_t GetQueryReportSize();
+
+    void    ActivateMetricSet();
+    void    DeactivateMetricSet();
+
+    void    SetMetricSetFiltering(
+                TMetricApiType apiMask );
+
+    void    GetMetricsFromReport(
+                const char* pData,
+                std::vector<TTypedValue_1_0>& results,
+                std::vector<TTypedValue_1_0>& information );
+
+    void    PrintMetricNames(
+                std::ostream& os );
+    void    PrintMetricValues(
+                std::ostream& os,
+                const std::string& name,
+                const std::vector<TTypedValue_1_0>& results,
+                const std::vector<TTypedValue_1_0>& information );
+
+    void    AggregateMetrics(
+                CMetricAggregations& aggregations,
+                const std::string& name,
+                const std::vector<TTypedValue_1_0>& results );
+
+private:
+    void    ReadMetrics(
+                const char* pData,
+                std::vector<TTypedValue_1_0>& deltaValues );
+    void    NormalizeMetrics(
+                std::vector<TTypedValue_1_0>& deltaValues,
+                std::vector<TTypedValue_1_0>& results );
+
+    void    ReadInformation(
+                const char* pData,
+                std::vector<TTypedValue_1_0>& results );
+    void    ReadSingleInformation(
+                const char* pData,
+                IInformation_1_0* information,
+                TTypedValue_1_0* result );
+
+    void    PrintValue(
+                std::ostream& os,
+                const TTypedValue_1_0& value );
+
+    TTypedValue_1_0* GetGlobalSymbolValue(
+        const char*         symbolName );
+    TTypedValue_1_0 CalculateReadEquation(
+        IEquation_1_0*      equation,
+        const char*         pRawReport );
+    TTypedValue_1_0 CalculateLocalNormalizationEquation(
+        IEquation_1_0*      equation,
+        TTypedValue_1_0*    deltaValues,
+        TTypedValue_1_0*    results,
+        uint32_t            metricIndex );
+    TTypedValue_1_0 CalculateEquationElemOperation(
+        TEquationOperation  operation,
+        TTypedValue_1_0     valuePrev,
+        TTypedValue_1_0     valueLast );
+
+    static uint64_t ReadBitfield( const char *pUnalignedData, uint32_t bitOffset, uint32_t bitsCount );
+    static uint64_t CastToUInt64(TTypedValue_1_0 value );
+    static float    CastToFloat(TTypedValue_1_0 value );
+
+    OpenMetricsDevice_fn            OpenMetricsDevice;
+    CloseMetricsDevice_fn           CloseMetricsDevice;
+    OpenMetricsDeviceFromFile_fn    OpenMetricsDeviceFromFile;
+
+    bool                    m_Initialized;
+    uint32_t                m_APIMask;
+    uint32_t                m_CategoryMask;
+
+    IMetricsDevice_1_5*     m_MetricsDevice;
+    IMetricSet_1_1*         m_MetricSet;
+
+    uint32_t                m_EUCoresCount;
+    uint64_t                m_GPUCoreClocks;
+
+private:
+    MDHelper(MDHelper const&);
+    void operator=(MDHelper const&);
+};
+
+/************************************************************************/
+/* GetMetricsConfiguration                                              */
+/************************************************************************/
+inline uint32_t MDHelper::GetMetricsConfiguration()
+{
+    return ( m_MetricSet != NULL ) ? m_MetricSet->GetParams()->ApiSpecificId.OCL : 0;
+}
+
+/************************************************************************/
+/* GetQueryReportSize                                                   */
+/************************************************************************/
+inline uint32_t MDHelper::GetQueryReportSize()
+{
+    return ( m_MetricSet != NULL ) ? m_MetricSet->GetParams()->QueryReportSize : 0;
+}
+
+}

--- a/mdapi/intercept_mdapi.cpp
+++ b/mdapi/intercept_mdapi.cpp
@@ -1,0 +1,287 @@
+/*
+// Copyright (c) 2018 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+*/
+
+#include <fstream>
+#include <iomanip>
+
+#include "common.h"
+#include "intercept.h"
+
+#define CL_PROFILING_COMMAND_PERFCOUNTERS_INTEL 0x407F
+
+///////////////////////////////////////////////////////////////////////////////
+//
+static bool convertPropertiesToOCL1_2(
+    const cl_queue_properties* properties,
+    cl_command_queue_properties& ocl1_2_properties )
+{
+    if( properties )
+    {
+        // Convert properties from array of pairs (OCL2.0) to bitfield (OCL1.2)
+        for( int i = 0; properties[ i ] != 0; i += 2 )
+        {
+            if( properties[ i ] == CL_QUEUE_PROPERTIES )
+            {
+                switch( properties[ i + 1 ] )
+                {
+                case CL_QUEUE_PROFILING_ENABLE:
+                    ocl1_2_properties |= CL_QUEUE_PROFILING_ENABLE;
+                    break;
+                case CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE:
+                    ocl1_2_properties |= CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE;
+                    break;
+                default:
+                    return false;
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+cl_uint CLIntercept::initCustomPerfCounters()
+{
+    const std::string& metricSetSymbolName = config().DevicePerfCounterCustom;
+    const std::string& metricsFileName = config().DevicePerfCounterFile;
+
+    cl_uint configuration = 0;
+
+    CLI_ASSERT( !metricSetSymbolName.empty() );
+
+    if( m_pMDHelper == NULL )
+    {
+        m_pMDHelper = new MetricsDiscovery::MDHelper();
+        if( m_pMDHelper )
+        {
+            bool initialized = m_pMDHelper->InitMetricsDiscovery(
+                metricSetSymbolName,
+                metricsFileName );
+            if( initialized  )
+            {
+                log( "Metric Discovery initialized.\n" );
+            }
+            else
+            {
+                log( "Metric Discovery failed to initialize.\n" );
+            }
+        }
+    }
+
+    if( m_pMDHelper )
+    {
+        configuration = m_pMDHelper->GetMetricsConfiguration();
+        // TODO: This doesn't appear to be necessary?
+        //m_pMDHelper->SetMetricSetFiltering( API_TYPE_OCL );
+        m_pMDHelper->ActivateMetricSet( );
+
+        // Get the dump directory name and register dump file name
+        {
+            std::string fileName = "";
+            OS().GetDumpDirectoryName( sc_DumpDirectoryName, fileName );
+            fileName += '/';
+            fileName += sc_DumpPerfCountersFileNamePrefix;
+            fileName += "_";
+            fileName += metricSetSymbolName;
+            fileName += ".csv";
+
+            OS().MakeDumpDirectories( fileName );
+
+            m_MetricDump.open( fileName.c_str(), std::ios::out );
+
+            m_pMDHelper->PrintMetricNames( m_MetricDump );
+        }
+    }
+
+    return configuration;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+cl_command_queue CLIntercept::createMDAPICommandQueue(
+    cl_context context,
+    cl_device_id device,
+    cl_command_queue_properties properties,
+    cl_int* errcode_ret )
+{
+    cl_command_queue    retVal = NULL;
+
+    getExtensionFunctionAddress(
+        NULL,
+        "clCreatePerfCountersCommandQueueINTEL" );
+
+    if( dispatch().clCreatePerfCountersCommandQueueINTEL )
+    {
+        m_OS.EnterCriticalSection();
+
+        cl_uint configuration = initCustomPerfCounters();
+
+        retVal = dispatch().clCreatePerfCountersCommandQueueINTEL(
+            context,
+            device,
+            properties,
+            configuration,
+            errcode_ret );
+        if( retVal == NULL )
+        {
+            log( "clCreatePerfCountersCommandQueueINTEL() returned NULL!\n" );
+        }
+
+        if( m_pMDHelper )
+        {
+            m_pMDHelper->DeactivateMetricSet();
+        }
+
+        m_OS.LeaveCriticalSection();
+    }
+
+    return retVal;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+cl_command_queue CLIntercept::createMDAPICommandQueue(
+    cl_context context,
+    cl_device_id device,
+    const cl_queue_properties* properties,
+    cl_int* errcode_ret )
+{
+    cl_command_queue    retVal = NULL;
+
+    // This is a temporary workaround until we have a
+    // clCreatePerfCountersCommandQueueWithPropertiesINTEL API.
+    // It converts the OpenCL 2.0 command queue properties to
+    // OpenLC 1.2 command queue properties, unless an unsupported
+    // command queue property is specified.  If an unsupported
+    // property is specified then we cannot create an MDAPI command
+    // queue.
+
+    cl_command_queue_properties ocl1_2_properties = 0;
+    if( convertPropertiesToOCL1_2( properties, ocl1_2_properties ) )
+    {
+        retVal = createMDAPICommandQueue(
+            context,
+            device,
+            ocl1_2_properties,
+            errcode_ret );
+    }
+
+    return retVal;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+void CLIntercept::saveMDAPICounters(
+    const std::string& name,
+    const cl_event event )
+{
+    if( m_pMDHelper )
+    {
+        const size_t reportSize = std::max< unsigned int >(
+            1024,
+            m_pMDHelper->GetQueryReportSize() ); //work around for driver/MDAPI bug
+
+        char*   pReport = new char[ reportSize ];
+        if( pReport )
+        {
+            size_t  outputSize = 0;
+            cl_int  errorCode = dispatch().clGetEventProfilingInfo(
+                event,
+                CL_PROFILING_COMMAND_PERFCOUNTERS_INTEL,
+                reportSize,
+                pReport,
+                &outputSize );
+
+            if( errorCode == CL_SUCCESS )
+            {
+                std::vector<MetricsDiscovery::TTypedValue_1_0> results;
+                std::vector<MetricsDiscovery::TTypedValue_1_0> information;
+                m_pMDHelper->GetMetricsFromReport(
+                    pReport,
+                    results,
+                    information );
+                m_pMDHelper->PrintMetricValues(
+                    m_MetricDump,
+                    name,
+                    results,
+                    information );
+                m_pMDHelper->AggregateMetrics(
+                    m_MetricAggregations,
+                    name,
+                    results );
+            }
+            else
+            {
+                logf("Couldn't get MDAPI data!  clGetEventProfilingInfo returned '%s' (%08X)!\n",
+                    enumName().name(errorCode).c_str(),
+                    errorCode );
+            }
+
+            delete [] pReport;
+            pReport = NULL;
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+void CLIntercept::reportMDAPICounters( std::ostream& os )
+{
+    if( config().DevicePerfCounterTiming &&
+        !m_MetricAggregations.empty() )
+    {
+        std::string header;
+        std::vector<uint32_t> headerWidths;
+        for( auto& metric : m_MetricAggregations.begin()->second )
+        {
+            const std::string& metricName = metric.first;
+
+            header += metricName + ", ";
+            headerWidths.push_back((uint32_t)metricName.length());
+        }
+
+        os << std::endl << "Device Performance Counter Timing: (Average metric per enqueue)" << std::endl;
+        os << "                                FunctionName,  Calls, " << header;
+
+        for( auto& metricsForKernel : m_MetricAggregations )
+        {
+            const std::string& kernelName = metricsForKernel.first;
+            const MetricsDiscovery::CMetricAggregationsForKernel& kernelMetrics = metricsForKernel.second;
+
+            uint64_t count = kernelMetrics.begin()->second.Count;
+            os << std::endl << std::right << std::setw( 44 ) << kernelName << ", ";
+            os << std::right << std::setw( 6 ) << count << ", ";
+
+            int numMetric = 0;
+            for( auto& metric : kernelMetrics )
+            {
+                const MetricsDiscovery::SMetricAggregationData& aggregationData = metric.second;
+                os << std::right << std::setw( headerWidths[ numMetric++ ] );
+                os << aggregationData.Sum / aggregationData.Count << ", ";
+            }
+        }
+
+        os << std::endl;
+    }
+}

--- a/mdapi/metrics_discovery_api.h
+++ b/mdapi/metrics_discovery_api.h
@@ -1,0 +1,1167 @@
+/*****************************************************************************\
+
+    Copyright © 2018, Intel Corporation
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+
+    File Name:  metrics_discovery_api.h
+
+    Abstract:   Interface for metrics discovery DLL
+
+    Notes:
+
+\*****************************************************************************/
+#include <stdint.h>
+
+#ifndef __METRICS_DISCOVERY_H_
+#define __METRICS_DISCOVERY_H_
+
+#ifdef _MSC_VER
+  #define MD_STDCALL __stdcall
+#else
+  #define MD_STDCALL
+#endif // _MSC_VER
+
+namespace MetricsDiscovery
+{
+//*****************************************************************************/
+// API major version number:
+//*****************************************************************************/
+    typedef enum EMD_API_MAJOR_VERSION
+    {
+        MD_API_MAJOR_NUMBER_1       = 1,
+        MD_API_MAJOR_NUMBER_CURRENT = MD_API_MAJOR_NUMBER_1,
+        MD_API_MAJOR_NUMBER_CEIL    = 0xFFFFFFFF
+
+    } MD_API_MAJOR_VERSION;
+
+//*****************************************************************************/
+// API minor version number:
+//*****************************************************************************/
+    typedef enum EMD_API_MINOR_VERSION
+    {
+        MD_API_MINOR_NUMBER_0       = 0,
+        MD_API_MINOR_NUMBER_1       = 1,         // CalculationAPI
+        MD_API_MINOR_NUMBER_2       = 2,         // OverridesAPI
+        MD_API_MINOR_NUMBER_3       = 3,         // BatchBuffer Sampling (aka DMA Sampling)
+        MD_API_MINOR_NUMBER_4       = 4,         // GT dependent MetricSets
+        MD_API_MINOR_NUMBER_5       = 5,         // MaxValue calculation for CalculationAPI
+        MD_API_MINOR_NUMBER_CURRENT = MD_API_MINOR_NUMBER_5,
+        MD_API_MINOR_NUMBER_CEIL    = 0xFFFFFFFF
+
+    } MD_API_MINOR_VERSION;
+
+//*****************************************************************************/
+// API build number:
+//*****************************************************************************/
+    #define MD_API_BUILD_NUMBER_CURRENT 96
+
+//*****************************************************************************/
+// Completion codes:
+//*****************************************************************************/
+    typedef enum ECompletionCode
+    {
+        CC_OK                      = 0,
+        CC_READ_PENDING            = 1,
+        CC_ALREADY_INITIALIZED     = 2,
+        CC_STILL_INITIALIZED       = 3,
+        CC_CONCURRENT_GROUP_LOCKED = 4,
+        CC_WAIT_TIMEOUT            = 5,
+        CC_TRY_AGAIN               = 6,
+        CC_INTERRUPTED             = 7,
+        // ...
+        CC_ERROR_INVALID_PARAMETER = 40,
+        CC_ERROR_NO_MEMORY         = 41,
+        CC_ERROR_GENERAL           = 42,
+        CC_ERROR_FILE_NOT_FOUND    = 43,
+        CC_ERROR_NOT_SUPPORTED     = 44,
+        // ...
+        CC_LAST_1_0                = 45
+
+    } TCompletionCode;
+
+
+/* Forward declarations */
+
+//*******************************************************************************/
+// Abstract interface for the GPU metrics root object.
+//*******************************************************************************/
+    class IMetricsDevice_1_0;
+    class IMetricsDevice_1_1;
+    class IMetricsDevice_1_2;
+    class IMetricsDevice_1_5;
+
+//*******************************************************************************/
+// Abstract interface for Metrics Device overrides.
+//*******************************************************************************/
+    class IOverride_1_2;
+
+//*******************************************************************************/
+// Abstract interface for the metrics groups that can be collected concurrently
+// to another group.
+//*******************************************************************************/
+    class IConcurrentGroup_1_0;
+    class IConcurrentGroup_1_1;
+    class IConcurrentGroup_1_5;
+
+//*******************************************************************************/
+// Abstract interface for the metric sets mapping to different HW configuration
+// that should be used exclusively to each other metric set in the concurrent
+// group.
+//*******************************************************************************/
+    class IMetricSet_1_0;
+    class IMetricSet_1_1;
+    class IMetricSet_1_4;
+    class IMetricSet_1_5;
+
+//*******************************************************************************/
+// Abstract interface for the metric that is sampled.
+//*******************************************************************************/
+    class IMetric_1_0;
+
+//*******************************************************************************/
+// Abstract interface for the measurement information (report reason, etc.).
+//*******************************************************************************/
+    class IInformation_1_0;
+
+//*******************************************************************************/
+// Abstract interface for the metric read and normalization equation.
+//*******************************************************************************/
+    class IEquation_1_0;
+
+
+//*******************************************************************************/
+// Value types:
+//*******************************************************************************/
+    typedef enum EValueType
+    {
+        VALUE_TYPE_UINT32,
+        VALUE_TYPE_UINT64,
+        VALUE_TYPE_FLOAT,
+        VALUE_TYPE_BOOL,
+        VALUE_TYPE_CSTRING,
+        // ...
+        VALUE_TYPE_LAST,
+
+    } TValueType;
+
+//*******************************************************************************/
+// Typed value:
+//*******************************************************************************/
+    typedef struct STypedValue_1_0
+    {
+        TValueType ValueType;
+        union {
+            uint32_t ValueUInt32;
+            uint64_t ValueUInt64;
+            struct
+            {
+                uint32_t Low;
+                uint32_t High;
+            } ValueUInt64Fields;
+            float    ValueFloat;
+            bool     ValueBool;
+            char*    ValueCString;
+        };
+
+    } TTypedValue_1_0;
+
+//*******************************************************************************/
+// Global symbol:
+//     Global symbols will be available to describe SKU specific information.
+//     Example global symbols:
+//     "EuCoresTotalCount", "EuThreadsCount", "EuSlicesTotalCount", "EuSubslicesTotalCount",
+//     "SamplersTotalCount", "PciDeviceId", "NumberOfShadingUnits", "GpuTimestampFrequency",
+//     "MaxTimestamp", "GpuMinFrequencyMHz", "GpuMaxFrequencyMHz"
+//*******************************************************************************/
+    typedef struct SGlobalSymbol_1_0
+    {
+        const char*     SymbolName;
+        TTypedValue_1_0 SymbolTypedValue;
+
+    } TGlobalSymbol_1_0;
+
+//*******************************************************************************/
+// Global parameters of Metrics Device:
+//*******************************************************************************/
+    typedef struct SMetricsDeviceParams_1_0
+    {
+        // API version
+        struct SApiVersion
+        {
+            uint32_t MajorNumber;
+            uint32_t MinorNumber;
+            uint32_t BuildNumber;
+        } Version;
+
+        uint32_t ConcurrentGroupsCount;
+
+        uint32_t GlobalSymbolsCount;
+        uint32_t DeltaFunctionsCount;
+        uint32_t EquationElementTypesCount;
+        uint32_t EquationOperationsCount;
+
+        const char*  DeviceName;
+
+    } TMetricsDeviceParams_1_0;
+
+//*******************************************************************************/
+// Global parameters of Metrics Device 1.2:
+//*******************************************************************************/
+    typedef struct SMetricsDeviceParams_1_2 : public SMetricsDeviceParams_1_0
+    {
+        uint32_t OverrideCount;
+
+    } TMetricsDeviceParams_1_2;
+
+//*******************************************************************************/
+// Metric API types:
+//*******************************************************************************/
+    typedef enum EMetricApiType
+    {
+        API_TYPE_IOSTREAM   = 0x00000001,        // API independent method
+        API_TYPE_DX9        = 0x00000002,
+        API_TYPE_DX10       = 0x00000004,
+        API_TYPE_DX11       = 0x00000008,
+        API_TYPE_OGL        = 0x00000010,
+        API_TYPE_OGL4_X     = 0x00000020,
+        API_TYPE_OCL        = 0x00000040,
+        API_TYPE_MEDIA      = 0x00000080,        // Only option would be using DmaBuffer sampling
+        API_TYPE_DX12       = 0x00000100,
+        API_TYPE_BBSTREAM   = 0x00000200,
+        API_TYPE_VULKAN     = 0x00000400,
+        API_TYPE_RESERVED   = 0x00000800,
+        API_TYPE_ALL        = 0xffffffff
+
+    } TMetricApiType;
+
+//*******************************************************************************/
+// Measurement types:
+//*******************************************************************************/
+    typedef enum EMeasurementType
+    {
+        MEASUREMENT_TYPE_SNAPSHOT_IO    = 0x00000001,
+        MEASUREMENT_TYPE_SNAPSHOT_QUERY = 0x00000002,
+        MEASUREMENT_TYPE_DELTA_QUERY    = 0x00000004,
+        MEASUREMENT_TYPE_ALL            = 0x0000ffff,
+
+    } TMeasurementType;
+
+//*******************************************************************************/
+// Usage flags:
+//*******************************************************************************/
+    typedef enum EMetricUsageFlag
+    {
+        USAGE_FLAG_OVERVIEW   = 0x00000001,      // GPU system overview metric
+                                                 // Useful for high level workload characterization
+        USAGE_FLAG_INDICATE   = 0x00000002,      // Metric indicating a performance problem
+                                                 // Useful when comparing with threshold
+        USAGE_FLAG_CORRELATE  = 0x00000004,      // Metric correlating with performance problem
+                                                 // Useful for proving to false only
+        //...
+        USAGE_FLAG_SYSTEM     = 0x00000020,      // Metric useful at system level
+        USAGE_FLAG_FRAME      = 0x00000040,      // Metric useful at frame level
+        USAGE_FLAG_BATCH      = 0x00000080,      // Metric useful at batch level
+        USAGE_FLAG_DRAW       = 0x00000100,      // Metric useful at draw level
+
+        // ...
+        USAGE_FLAG_TIER_1     = 0x00000400,
+        USAGE_FLAG_TIER_2     = 0x00000800,
+        USAGE_FLAG_TIER_3     = 0x00001000,
+        USAGE_FLAG_TIER_4     = 0x00002000,
+        USAGE_FLAG_GLASS_JAW  = 0x00004000,
+
+        USAGE_FLAG_ALL        = 0x0000ffff,
+
+    } TMetricUsageFlag;
+
+//*******************************************************************************/
+// Sampling types:
+//*******************************************************************************/
+    typedef enum ESamplingType
+    {
+        SAMPLING_TYPE_OA_TIMER      = 0x00000001,
+        SAMPLING_TYPE_OA_EVENT      = 0x00000002,
+        SAMPLING_TYPE_GPU_QUERY     = 0x00000004,
+        SAMPLING_TYPE_DMA_BUFFER    = 0x00000008,// Possible future extension for media
+        SAMPLING_TYPE_ALL           = 0x0000ffff,
+
+    } TSamplingType;
+
+//*******************************************************************************/
+// Metric categories:
+//*******************************************************************************/
+    typedef enum EMetricCategory
+    {
+        GPU_RENDER  = 0x0001,
+        GPU_COMPUTE = 0x0002,
+        GPU_MEDIA   = 0x0004,
+        GPU_GENERIC = 0x0008,                    // Does not belong to any specific category like memory traffic
+
+    } TMetricCategory;
+
+//*******************************************************************************/
+// IoStream read flags:
+//*******************************************************************************/
+    typedef enum EIoReadFlag
+    {
+        IO_READ_FLAG_DROP_OLD_REPORTS    = 0x00000001,
+        IO_READ_FLAG_GET_CONTEXT_ID_TAGS = 0x00000002,
+
+    } TIoReadFlag;
+
+//*******************************************************************************/
+// Override modes:
+//*******************************************************************************/
+    typedef enum EOverrideMode
+    {
+        OVERRIDE_MODE_GLOBAL = 0x0001,
+        OVERRIDE_MODE_LOCAL  = 0x0002,
+
+    } TOverrideMode;
+
+//*******************************************************************************/
+// Global parameters of Concurrent Group:
+//*******************************************************************************/
+    typedef struct SConcurrentGroupParams_1_0
+    {
+        const char*         SymbolName;          // For example "PerfMon" or "OA" or "PipeStats"
+        const char*         Description;         // For example "PerfMon and ODLAT Uncore ring counters"
+
+        uint32_t            MeasurementTypeMask;
+
+        uint32_t            MetricSetsCount;
+        uint32_t            IoMeasurementInformationCount;
+        uint32_t            IoGpuContextInformationCount;
+
+    } TConcurrentGroupParams_1_0;
+
+//*******************************************************************************/
+// Global parameters of an Override:
+//*******************************************************************************/
+    typedef struct SOverrideParams_1_2
+    {
+        const char*         SymbolName;          // For example "FrequencyOverride"
+        const char*         Description;         // For example "Overrides device GPU frequency with a static value."
+
+        uint32_t            ApiMask;
+        uint32_t            PlatformMask;
+
+        uint32_t            OverrideModeMask;
+
+    } TOverrideParams_1_2;
+
+//*******************************************************************************/
+// Base params of SetOverride method:
+//*******************************************************************************/
+    typedef struct SSetOverrideParams_1_2
+    {
+        bool Enable;
+
+    } TSetOverrideParams_1_2;
+
+//*******************************************************************************/
+// Frequency override specific SetOverride params:
+//*******************************************************************************/
+    typedef struct SSetFrequencyOverrideParams_1_2 : SSetOverrideParams_1_2
+    {
+        uint32_t FrequencyMhz;
+        uint32_t Pid;
+
+    } TSetFrequencyOverrideParams_1_2;
+
+
+//*******************************************************************************/
+// Query override specific SetOverride params:
+//*******************************************************************************/
+    typedef struct SSetQueryOverrideParams_1_2 : SSetOverrideParams_1_2
+    {
+        uint32_t Period;    // Nanoseconds
+
+    } TSetQueryOverrideParams_1_2;
+
+//*******************************************************************************/
+// Driver override params:
+//*******************************************************************************/
+    typedef struct SSetDriverOverrideParams_1_2 : SSetOverrideParams_1_2
+    {
+        uint32_t Value;
+
+    } SSetDriverOverrideParams_1_2;
+
+//*******************************************************************************/
+// API specific id:
+//*******************************************************************************/
+    typedef struct SApiSpecificId_1_0
+    {
+        uint32_t     D3D9QueryId;                // D3D9 Query ID
+        uint32_t     D3D9Fourcc;                 // D3D9 FourCC
+        uint32_t     D3D1XQueryId;               // D3D1X Query ID
+        uint32_t     D3D1XDevDependentId;        // D3D1X device dependent counter ID
+        const char*  D3D1XDevDependentName;      // Device dependent counter name
+        uint32_t     OGLQueryIntelId;            // Intel OGL query extension ID
+        const char*  OGLQueryIntelName;          // Intel OGL query extension name
+        uint32_t     OGLQueryARBTargetId;        // ARB OGL Query Target ID
+        uint32_t     OCL;                        // OCL configuration ID
+        uint32_t     HwConfigId;                 // Config ID for IO stream
+        uint32_t     placeholder[1];
+
+    } TApiSpecificId_1_0;
+
+//*******************************************************************************/
+// Global parameters of Metric set:
+//*******************************************************************************/
+    typedef struct SMetricSetParams_1_0
+    {
+        const char*         SymbolName;          // For example "Dx11Tessellation"
+        const char*         ShortName;           // For example "DX11 Tessellation Metrics Set"
+
+        uint32_t            ApiMask;
+        uint32_t            CategoryMask;
+
+        uint32_t            RawReportSize;       // As in HW
+        uint32_t            QueryReportSize;     // As in Query API
+
+        uint32_t            MetricsCount;
+        uint32_t            InformationCount;
+        uint32_t            ComplementarySetsCount;
+
+        TApiSpecificId_1_0  ApiSpecificId;
+
+        uint32_t            PlatformMask;
+        //...
+
+    } TMetricSetParams_1_0;
+
+//*******************************************************************************/
+// GT differenced MetricSet params:
+//*******************************************************************************/
+    typedef struct SMetricSetParams_1_4 : SMetricSetParams_1_0
+    {
+        uint32_t GtMask;
+
+    } TMetricSetParams_1_4;
+
+//*******************************************************************************/
+// Metric result types:
+//*******************************************************************************/
+    typedef enum EMetricResultType
+    {
+        RESULT_UINT32,
+        RESULT_UINT64,
+        RESULT_BOOL,
+        RESULT_FLOAT,
+        // ...
+        RESULT_LAST
+
+    } TMetricResultType;
+
+//*******************************************************************************/
+// Metric types:
+//*******************************************************************************/
+    typedef enum EMetricType
+    {
+        METRIC_TYPE_DURATION,
+        METRIC_TYPE_EVENT,
+        METRIC_TYPE_EVENT_WITH_RANGE,
+        METRIC_TYPE_THROUGHPUT,
+        METRIC_TYPE_TIMESTAMP,
+        METRIC_TYPE_FLAG,
+        METRIC_TYPE_RATIO,
+        METRIC_TYPE_RAW,
+        // ...
+        METRIC_TYPE_LAST
+
+    } TMetricType;
+
+//*******************************************************************************/
+// Information types:
+//*******************************************************************************/
+    typedef enum EInformationType
+    {
+        INFORMATION_TYPE_REPORT_REASON,
+        INFORMATION_TYPE_VALUE,
+        INFORMATION_TYPE_FLAG,
+        INFORMATION_TYPE_TIMESTAMP,
+        INFORMATION_TYPE_CONTEXT_ID_TAG,
+        INFORMATION_TYPE_SAMPLE_PHASE,
+        INFORMATION_TYPE_GPU_NODE,
+        // ...
+        INFORMATION_TYPE_LAST
+
+    } TInformationType;
+
+//*******************************************************************************/
+// Report reasons:
+//*******************************************************************************/
+    typedef enum EReportReason
+    {
+        REPORT_REASON_UNDEFINED                 = 0x0000,
+        REPORT_REASON_INTERNAL_TIMER            = 0x0001,
+        REPORT_REASON_INTERNAL_TRIGGER1         = 0x0002,
+        REPORT_REASON_INTERNAL_TRIGGER2         = 0x0004,
+        REPORT_REASON_INTERNAL_CONTEXT_SWITCH   = 0x0008,
+        REPORT_REASON_INTERNAL_GO               = 0x0010,
+        REPORT_REASON_INTERNAL_FREQUENCY_CHANGE = 0x0020,
+        REPORT_REASON_QUERY_DEFAULT             = 0x0100,
+        REPORT_REASON_QUERY_INTERNAL_RESOLVE    = 0x0200,
+        REPORT_REASON_QUERY_INTERNAL_CLEAR      = 0x0400,
+
+    } TReportReason;
+
+//*******************************************************************************/
+// Sample phase:
+//*******************************************************************************/
+    typedef enum ESamplePhase
+    {
+        SAMPLE_PHASE_END,
+        SAMPLE_PHASE_BEGIN,
+        // ...
+        SAMPLE_PHASE_LAST
+
+    } TSamplePhase;
+
+//*******************************************************************************/
+// Gpu Node:
+//*******************************************************************************/
+    typedef enum EInformationGpuNode
+    {
+        INFORMATION_GPUNODE_3D       = 0,        // Available by default on all platform
+        INFORMATION_GPUNODE_VIDEO    = 1,        // Available on CTG+
+        INFORMATION_GPUNODE_BLT      = 2,        // Available on GT
+        INFORMATION_GPUNODE_VE       = 3,        // Available on HSW+ (VideoEnhancement)
+        INFORMATION_GPUNODE_VCS2     = 4,        // Available on BDW+ GT3+
+        INFORMATION_GPUNODE_REAL_MAX = 5,        // All nodes beyond this are virtual nodes - they don't have an actual GPU engine
+        // ...
+        INFORMATION_GPUNODE_LAST
+
+    } TInformationGpuNode;
+
+//*******************************************************************************/
+// Hardware unit types:
+//*******************************************************************************/
+    typedef enum EHwUnitType
+    {
+        HW_UNIT_GPU,
+        HW_UNIT_SLICE,
+        HW_UNIT_SUBSLICE,
+        HW_UNIT_SUBSLICE_BANK,
+        HW_UNIT_EU_UNIT,
+        HW_UNIT_UNCORE,
+        // ...
+        HW_UNIT_LAST
+
+    } THwUnitType;
+
+//*******************************************************************************/
+// Delta function types:
+//*******************************************************************************/
+    typedef enum EDeltaFunctionType
+    {
+        DELTA_FUNCTION_NULL = 0,
+        DELTA_N_BITS,
+        DELTA_BOOL_OR,                           // Logic OR - good for exceptions
+        DELTA_BOOL_XOR,                          // Logic XOR - good to check if bits were changed
+        DELTA_GET_PREVIOUS,                      // Preserve previous value
+        DELTA_GET_LAST,                          // Preserve last value
+        DELTA_NS_TIME,                           // Delta for nanosecond timestamps (GPU timestamp wraps at 32 bits but was value multiplied by 80)
+        DELTA_FUNCTION_LAST_1_0
+
+    } TDeltaFunctionType;
+
+//*******************************************************************************/
+// Delta function:
+//*******************************************************************************/
+    typedef struct SDeltaFunction_1_0
+    {
+        TDeltaFunctionType   FunctionType;
+        union {
+            uint32_t         BitsCount;          // Used for DELTA_N_BITS to specify bits count
+        };
+
+    } TDeltaFunction_1_0;
+
+//*******************************************************************************/
+// Equation element types:
+//*******************************************************************************/
+    typedef enum EEquationElementType
+    {
+        EQUATION_ELEM_OPERATION,                 // See TEquationOperation enumeration
+
+        EQUATION_ELEM_RD_BITFIELD,
+        EQUATION_ELEM_RD_UINT8,
+        EQUATION_ELEM_RD_UINT16,
+        EQUATION_ELEM_RD_UINT32,
+        EQUATION_ELEM_RD_UINT64,
+        EQUATION_ELEM_RD_FLOAT,
+
+        // Extended RD operation
+        EQUATION_ELEM_RD_40BIT_CNTR,             // Assemble 40 bit counter that is in two locations, result in unsigned integer 64b
+
+        EQUATION_ELEM_IMM_UINT64,
+        EQUATION_ELEM_IMM_FLOAT,
+        EQUATION_ELEM_SELF_COUNTER_VALUE,        // Defined by $Self token, the UINT64 result of DeltaFunction for IO or QueryReadEquation
+        EQUATION_ELEM_GLOBAL_SYMBOL,             // Defined by $"SymbolName", available in MetricsDevice SymbolTable
+        EQUATION_ELEM_LOCAL_COUNTER_SYMBOL,      // Defined by $"SymbolName", refers to counter delta value in the local set
+        EQUATION_ELEM_OTHER_SET_COUNTER_SYMBOL,  // Defined by concatenated string of $"setSymbolName/SymbolName", refers to counter
+                                                 // Delta value in the other set
+
+        EQUATION_ELEM_LOCAL_METRIC_SYMBOL,       // Defined by $$"SymbolName", refers to metric normalized value in the local set
+        EQUATION_ELEM_OTHER_SET_METRIC_SYMBOL,   // Defined by concatenated string of $$"setSymbolName/SymbolName", refers to metric
+                                                 // Normalized value in the other set
+
+        EQUATION_ELEM_INFORMATION_SYMBOL,        // Defined by i$"SymbolName", refers to information value type only
+
+        // Extended types - standard normalization functions
+        EQUATION_ELEM_STD_NORM_GPU_DURATION,     // Action is $Self $GpuCoreClocks FDIV 100 FMUL
+        EQUATION_ELEM_STD_NORM_EU_AGGR_DURATION, // Action is $Self $GpuCoreClocks $EuCoresTotalCount UMUL FDIV 100 FMUL
+
+        EQUATION_ELEM_LAST_1_0
+
+    } TEquationElementType;
+
+//*******************************************************************************/
+// Equation operations:
+//*******************************************************************************/
+    typedef enum EEquationOperation
+    {
+        EQUATION_OPER_RSHIFT,                    // 64b unsigned integer right shift
+        EQUATION_OPER_LSHIFT,                    // 64b unsigned integer left shift
+        EQUATION_OPER_AND,                       // Bitwise AND of two unsigned integers, 64b each
+        EQUATION_OPER_OR,                        // Bitwise OR of two unsigned integers, 64b each
+        EQUATION_OPER_XOR,                       // Bitwise XOR of two unsigned integers, 64b each
+        EQUATION_OPER_XNOR,                      // Bitwise XNOR of two unsigned integers, 64b each
+        EQUATION_OPER_AND_L,                     // Logical AND (C-like "&&") of two unsigned integers, 64b each, result is true(1) if both values are true(greater than 0)
+        EQUATION_OPER_EQUALS,                    // Equality (C-like "==") of two unsigned integers, 64b each, result is true(1) or false(0)
+        EQUATION_OPER_UADD,                      // Unsigned integer add, arguments are casted to be 64b unsigned integers, result is unsigned integer 64b
+        EQUATION_OPER_USUB,                      // Unsigned integer subtract, arguments are casted to be 64b unsigned integers, result is unsigned integer 64b
+        EQUATION_OPER_UMUL,                      // Unsigned integer mul, arguments are casted to be 64b unsigned integers, result is unsigned integer 64b
+        EQUATION_OPER_UDIV,                      // Unsigned integer div, arguments are casted to be 64b unsigned integers, result is unsigned integer 64b
+        EQUATION_OPER_FADD,                      // Floating point add, arguments are casted to be 32b floating points, result is a 32b float
+        EQUATION_OPER_FSUB,                      // Floating point subtract, arguments are casted to be 32b floating points, result is a 32b float
+        EQUATION_OPER_FMUL,                      // Floating point multiply, arguments are casted to be 32b floating points, result is a 32b float
+        EQUATION_OPER_FDIV,                      // Floating point divide, arguments are casted to be 32b floating points, result is a 32b float
+
+        EQUATION_OPER_UGT,                       // 64b unsigned integers comparison of is greater than, result is bool true(1) or false(0)
+        EQUATION_OPER_ULT,                       // 64b unsigned integers comparison of is less than, result is bool true(1) or false(0)
+        EQUATION_OPER_UGTE,                      // 64b unsigned integers comparison of is greater than or equal, result is bool true(1) or false(0)
+        EQUATION_OPER_ULTE,                      // 64b unsigned integers comparison of is less than or equal, result is bool true(1) or false(0)
+
+        EQUATION_OPER_FGT,                       // 32b floating point numbers comparison of is greater than, result is bool true(1) or false(0)
+        EQUATION_OPER_FLT,                       // 32b floating point numbers comparison of is less than, result is bool true(1) or false(0)
+        EQUATION_OPER_FGTE,                      // 32b floating point numbers comparison of is greater than or equal, result is bool true(1) or false(0)
+        EQUATION_OPER_FLTE,                      // 32b floating point numbers comparison of is less than or equal, result is bool true(1) or false(0)
+
+        EQUATION_OPER_UMIN,                      // Unsigned integer MIN function, arguments are casted to be 64b unsigned integers, result is unsigned integer 64b
+        EQUATION_OPER_UMAX,                      // Unsigned integer MAX function, arguments are casted to be 64b unsigned integers, result is unsigned integer 64b
+
+        EQUATION_OPER_FMIN,                      // Floating point MIN function, arguments are casted to be 32b floating points, result is a 32b float
+        EQUATION_OPER_FMAX,                      // Floating point MAX function, arguments are casted to be 32b floating points, result is a 32b float
+
+        EQUATION_OPER_LAST_1_0
+
+    } TEquationOperation;
+
+//*******************************************************************************/
+// Read params:
+//*******************************************************************************/
+    typedef struct SReadParams_1_0
+    {
+        uint32_t                 ByteOffset;
+        uint32_t                 BitOffset;
+        uint32_t                 BitsCount;
+        uint32_t                 ByteOffsetExt;
+
+    } TReadParams_1_0;
+
+//*******************************************************************************/
+// Equation element:
+//*******************************************************************************/
+    typedef struct SEquationElement_1_0
+    {
+        TEquationElementType     Type;
+        union
+        {
+            uint64_t             ImmediateUInt64;
+            float                ImmediateFloat;
+            TEquationOperation   Operation;
+            TReadParams_1_0      ReadParams;
+        };
+        char*                    SymbolName;
+
+    } TEquationElement_1_0;
+
+/*****************************************************************************\
+
+Class:
+    IEquation_1_0
+
+Description:
+    Abstract interface for the equation object.
+
+\*****************************************************************************/
+    class IEquation_1_0
+    {
+    public:
+        virtual ~IEquation_1_0();
+
+        virtual uint32_t              GetEquationElementsCount( void );
+        virtual TEquationElement_1_0* GetEquationElement( uint32_t index );
+    };
+
+//*******************************************************************************/
+// Global parameters of Metric:
+//*******************************************************************************/
+    typedef struct SMetricParams_1_0
+    {
+        uint32_t                IdInSet;         // Position in the set
+        uint32_t                GroupId;         // Specific metric group id
+        const char*             SymbolName;      // Symbol name, used in equations
+        const char*             ShortName;       // Consistent metric name, not changed platform to platform
+        const char*             GroupName;       // VertexShader for example
+        const char*             LongName;        // Hint about the metric shown to users
+
+        const char*             DxToOglAlias;    // To replace DX pixels with OGL fragments
+
+        uint32_t                UsageFlagsMask;
+        uint32_t                ApiMask;
+
+        TMetricResultType       ResultType;
+        const char*             MetricResultUnits;
+        TMetricType             MetricType;
+
+        uint64_t                LowWatermark;    // Low watermark for hotspot indication (USAGE_FLAG_INDICATE only)
+        uint64_t                HighWatermark;   // High watermark for hotspot indication (USAGE_FLAG_INDICATE only)
+
+        THwUnitType             HwUnitType;
+
+        // Read equation specification for IO stream (accessing raw values potentially spread in report in several locations)
+        IEquation_1_0*          IoReadEquation;
+        // Read equation specification for query (accessing calculated delta values)
+        IEquation_1_0*          QueryReadEquation;
+
+        TDeltaFunction_1_0      DeltaFunction;
+
+        // Normalization equation to get normalized value to bytes transfered or to a percentage of utilization
+        IEquation_1_0*          NormEquation;
+
+        // To calculate metrics max value as a function of other metrics and device parameters (e.g. 100 for percentage)
+        IEquation_1_0*          MaxValueEquation;
+
+    } TMetricParams_1_0;
+
+//*******************************************************************************/
+// Global parameters of Information:
+//*******************************************************************************/
+    typedef struct SInformationParams_1_0
+    {
+        uint32_t                IdInSet;         // Position in the set
+        const char*             SymbolName;      // Symbol name, used in equations
+        const char*             ShortName;       // Consistent name, not changed platform to platform
+        const char*             GroupName;       // Some more global context of the information
+        const char*             LongName;        // Hint about the information shown to users
+
+        uint32_t                ApiMask;
+
+        TInformationType        InfoType;
+        const char*             InfoUnits;
+
+        // Read equation specification for IO stream (accessing raw values potentially spread in report in several locations)
+        IEquation_1_0*          IoReadEquation;
+        // Read equation specification for query (accessing calculated delta values)
+        IEquation_1_0*          QueryReadEquation;
+
+        TDeltaFunction_1_0      OverflowFunction;
+
+    } TInformationParams_1_0;
+
+/*****************************************************************************\
+
+Class:
+    IInformation_1_0
+
+Description:
+    Abstract interface for the measurement information parameter.
+
+\*****************************************************************************/
+    class IInformation_1_0
+    {
+    public:
+        virtual ~IInformation_1_0();
+
+        virtual TInformationParams_1_0* GetParams();
+    };
+
+/*****************************************************************************\
+
+Class:
+    IMetric_1_0
+
+Description:
+    Abstract interface for the metric that is sampled.
+
+\*****************************************************************************/
+    class IMetric_1_0
+    {
+    public:
+        virtual ~IMetric_1_0();
+
+        virtual TMetricParams_1_0*    GetParams();
+    };
+
+/*****************************************************************************\
+
+Class:
+    IMetricSet_1_0
+
+Description:
+    Abstract interface for the metric sets mapping to different HW configuration that should be used
+    exclusively to each other metric set in the concurrent group.
+
+\*****************************************************************************/
+    class IMetricSet_1_0
+    {
+    public:
+        virtual ~IMetricSet_1_0();
+
+        virtual TMetricSetParams_1_0* GetParams( void );
+
+        // To get particular metric
+        virtual IMetric_1_0*          GetMetric( uint32_t index );
+
+        // To get particular information about measurement
+        virtual IInformation_1_0*     GetInformation( uint32_t index );
+
+        // Below proposal to address multi-passes at the set level
+        virtual IMetricSet_1_0*       GetComplementaryMetricSet( uint32_t index );
+
+        // To enable this configuration before query instance is created
+        virtual TCompletionCode       Activate( void );
+
+        // To disable this configuration after query instance is created
+        virtual TCompletionCode       Deactivate( void );
+
+        // To add an additional custom metric to this set
+        virtual IMetric_1_0*          AddCustomMetric(
+            const char* symbolName, const char* shortName, const char* groupName, const char* longName, const char* dxToOglAlias,
+            uint32_t usageFlagsMask, uint32_t apiMask, TMetricResultType resultType, const char* resultUnits, TMetricType metricType,
+            int64_t loWatermark, int64_t hiWatermark, THwUnitType hwType, const char* ioReadEquation, const char* deltaFunction,
+            const char* queryReadEquation, const char* normalizationEquation, const char* maxValueEquation, const char* signalName );
+    };
+
+/*****************************************************************************\
+
+Class:
+    IMetricSet_1_1
+
+Description:
+    Updated 1.0 version to use with 1.1 interface version.
+    Introduces an ability to calculate metrics from raw data.
+
+    New:
+        - SetApiFiltering
+        - CalculateMetrics
+        - CalculateIoMeasurementInformation
+
+\*****************************************************************************/
+    class IMetricSet_1_1 : public IMetricSet_1_0
+    {
+    public:
+        virtual ~IMetricSet_1_1();
+
+        // To filter available metrics/information for the given API. Use TMetricApiType to build the mask.
+        virtual TCompletionCode       SetApiFiltering( uint32_t apiMask );
+
+        // To calculate normalized metrics/information from the raw data.
+        virtual TCompletionCode       CalculateMetrics( const unsigned char* rawData, uint32_t rawDataSize, TTypedValue_1_0* out,
+            uint32_t outSize, uint32_t* outReportCount, bool enableContextFiltering );
+
+        // To calculate additional information for stream measurements.
+        virtual TCompletionCode       CalculateIoMeasurementInformation( TTypedValue_1_0* out, uint32_t outSize );
+    };
+
+/*****************************************************************************\
+
+Class:
+    IMetricSet_1_4
+
+Description:
+    Updated 1.1 version to use with 1.4 interface version.
+    Extends set params with gtType information.
+
+    Updates:
+        - GetParams
+
+\*****************************************************************************/
+    class IMetricSet_1_4 : public IMetricSet_1_1
+    {
+    public:
+        virtual ~IMetricSet_1_4();
+
+        virtual TMetricSetParams_1_4* GetParams( void );
+    };
+
+/*****************************************************************************\
+
+Class:
+    IMetricSet_1_5
+
+Description:
+    Updated 1.4 version to use with 1.5 interface version.
+    Adds an ability to calculate MaxValueEquations (maximal value) for each metric.
+    Param 'enableContextFiltering' becomes deprecated.
+
+    Updates:
+        - GetComplementaryMetricSet
+        - CalculateMetrics
+
+\*****************************************************************************/
+    class IMetricSet_1_5 : public IMetricSet_1_4
+    {
+    public:
+        // Update to 1.5 interface
+        virtual IMetricSet_1_5*       GetComplementaryMetricSet( uint32_t index );
+
+        // CalculateMetrics extended with max values calculation.
+        // Optional param 'outMaxValues' should have a memory for at least 'MetricCount * RawReportCount' values, can be NULL.
+        virtual TCompletionCode       CalculateMetrics( const unsigned char* rawData, uint32_t rawDataSize, TTypedValue_1_0* out,
+            uint32_t outSize, uint32_t* outReportCount, TTypedValue_1_0* outMaxValues, uint32_t outMaxValuesSize );
+    };
+
+/*****************************************************************************\
+
+Class:
+    IConcurrentGroup_1_0
+
+Description:
+    Abstract interface for the metrics groups that can be collected concurrently to another group.
+
+\*****************************************************************************/
+    class IConcurrentGroup_1_0
+    {
+    public:
+        virtual ~IConcurrentGroup_1_0();
+
+        virtual TConcurrentGroupParams_1_0* GetParams( void );
+        virtual IMetricSet_1_0*       GetMetricSet( uint32_t index );
+
+        virtual TCompletionCode       OpenIoStream( IMetricSet_1_0* metricSet, uint32_t processId, uint32_t* nsTimerPeriod, uint32_t* oaBufferSize );
+        virtual TCompletionCode       ReadIoStream( uint32_t* reportsCount, char* reportData, uint32_t readFlags );
+        virtual TCompletionCode       CloseIoStream( void );
+        virtual TCompletionCode       WaitForReports( uint32_t milliseconds );
+        virtual IInformation_1_0*     GetIoMeasurementInformation( uint32_t index );
+        virtual IInformation_1_0*     GetIoGpuContextInformation( uint32_t index );
+    };
+
+/*****************************************************************************\
+
+Class:
+    IConcurrentGroup_1_1
+
+Description:
+    Updated 1.0 version to use with 1.1 interface version.
+
+    Updates:
+        - GetMetricSet
+
+\*****************************************************************************/
+    class IConcurrentGroup_1_1 : public IConcurrentGroup_1_0
+    {
+    public:
+        // Update to 1.1 interface
+        virtual IMetricSet_1_1*       GetMetricSet( uint32_t index );
+    };
+
+/*****************************************************************************\
+
+Class:
+    IConcurrentGroup_1_3
+
+Description:
+    Updated 1.1 version to use with 1.3 interface version.
+    Introduces setting Stream Sampling Type.
+
+    New:
+        - SetIoStreamSamplingType
+
+\*****************************************************************************/
+    class IConcurrentGroup_1_3 : public IConcurrentGroup_1_1
+    {
+    public:
+        // To set sampling type during IoStream measurements
+        virtual TCompletionCode       SetIoStreamSamplingType( TSamplingType type );
+    };
+
+/*****************************************************************************\
+
+Class:
+    IConcurrentGroup_1_5
+
+Description:
+    Updated 1.3 version to use with 1.5 interface version.
+
+    Updates:
+        - GetMetricSet
+
+\*****************************************************************************/
+    class IConcurrentGroup_1_5 : public IConcurrentGroup_1_3
+    {
+    public:
+        // Update to 1.5 interface
+        virtual IMetricSet_1_5*       GetMetricSet( uint32_t index );
+    };
+
+/*****************************************************************************\
+
+Class:
+    IOverride_1_2
+
+Description:
+    Abstract interface for Metrics Device overrides.
+
+\*****************************************************************************/
+    class IOverride_1_2
+    {
+    public:
+        virtual ~IOverride_1_2();
+
+        // To get this Override params
+        virtual TOverrideParams_1_2*  GetParams( void );
+
+        // To enable/disable this Override
+        virtual TCompletionCode       SetOverride( TSetOverrideParams_1_2* params, uint32_t paramsSize );
+    };
+
+/*****************************************************************************\
+
+Class:
+    IMetricsDevice_1_0
+
+Description:
+    Abstract interface for the GPU metrics root object.
+
+\*****************************************************************************/
+    class IMetricsDevice_1_0
+    {
+    public:
+        virtual ~IMetricsDevice_1_0();
+
+        // To get MetricsDevice params
+        virtual TMetricsDeviceParams_1_0* GetParams( void );
+
+        // Child objects are of IConcurrentGroup
+        virtual IConcurrentGroup_1_0* GetConcurrentGroup( uint32_t index );
+
+        // To get GlobalSymbol at the given index
+        virtual TGlobalSymbol_1_0*    GetGlobalSymbol( uint32_t index );
+
+        // To get GlobalSymbol with the given name
+        virtual TTypedValue_1_0*      GetGlobalSymbolValueByName( const char* name );
+
+        // To get last error from TCompletionCode enum
+        virtual TCompletionCode       GetLastError( void );
+
+        // To get both GPU and CPU timestamp at the same time
+        virtual TCompletionCode       GetGpuCpuTimestamps( uint64_t* gpuTimestampNs, uint64_t* cpuTimestampNs,
+            uint32_t* cpuId );
+    };
+
+/*****************************************************************************\
+
+Class:
+    IMetricsDevice_1_1
+
+Description:
+    Updated 1.0 version to use with 1.1 interface version.
+
+    Updates:
+        - GetConcurrentGroup
+
+\*****************************************************************************/
+    class IMetricsDevice_1_1 : public IMetricsDevice_1_0
+    {
+    public:
+        // Update to 1.1 interface
+        virtual IConcurrentGroup_1_1* GetConcurrentGroup( uint32_t index );
+    };
+
+/*****************************************************************************\
+
+Class:
+    IMetricsDevice_1_2
+
+Description:
+    Updated 1.1 version to use with 1.2 interface version.
+    Introduces an interface for getting overrides.
+
+    Updates:
+        - GetParams
+    New:
+        - GetOverride
+        - GetOverrideByName
+
+\*****************************************************************************/
+    class IMetricsDevice_1_2 : public IMetricsDevice_1_1
+    {
+    public:
+        // Update returned params
+        virtual TMetricsDeviceParams_1_2* GetParams( void );
+
+        // To get override at the given index
+        virtual IOverride_1_2*        GetOverride( uint32_t index );
+
+        // To get override with the given name
+        virtual IOverride_1_2*        GetOverrideByName( const char* symbolName );
+    };
+
+/*****************************************************************************\
+
+Class:
+    IMetricsDevice_1_5
+
+Description:
+    Updated 1.2 version to use with 1.5 interface version.
+
+    Updates:
+        - GetConcurrentGroup
+
+\*****************************************************************************/
+    class IMetricsDevice_1_5 : public IMetricsDevice_1_2
+    {
+    public:
+        // Update to 1.5 interface
+        virtual IConcurrentGroup_1_5* GetConcurrentGroup( uint32_t index );
+    };
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+    // Factory functions
+    typedef TCompletionCode (MD_STDCALL *OpenMetricsDevice_fn)(IMetricsDevice_1_5** device);
+    typedef TCompletionCode (MD_STDCALL *OpenMetricsDeviceFromFile_fn)(const char* fileName, void* openParams, IMetricsDevice_1_5** device);
+    typedef TCompletionCode (MD_STDCALL *CloseMetricsDevice_fn)(IMetricsDevice_1_5* device);
+    typedef TCompletionCode (MD_STDCALL *SaveMetricsDeviceToFile_fn)(const char* fileName, void* saveParams, IMetricsDevice_1_5* device);
+
+#ifdef __cplusplus
+    }
+#endif
+
+};
+#endif // __METRICS_DISCOVERY_H_


### PR DESCRIPTION
## Description of Changes

This change adds the ability to query, log, and report hardware counters for Intel GPU OpenCL devices using the metrics discovery API.  See:

https://github.com/intel/metrics-discovery

## Testing Done

Verified that counters are correctly logged and reported on both Windows and Linux.  Settings tested:

````
DevicePerfCounterCustom = ComputeBasic
DevicePerfCounterTiming = true
````
