### PR TITLE
short kernel names - alternate implementation

### DIFF
--- a/Src/controls.h
+++ b/Src/controls.h
@@ -52,6 +52,7 @@ CLI_CONTROL( bool,          EventChecking,                          false, "If s
 CLI_CONTROL( bool,          LeakChecking,                           false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will check for leaks of various OpenCL objects, such as memory objects and events." )
 CLI_CONTROL( bool,          CLInfoLogging,                          false, "If set to a nonzero value, logs information about the platforms and devices in the system on the first call to clGetPlatformIDs()." )
 CLI_CONTROL( std::string,   LogDir,                                 "",    "If set, the Intercept Layer for OpenCL Applications will emit logs to this directory instead of the default log directory." )
+CLI_CONTROL( cl_uint,       LongKernelNameCutoff,                   UINT_MAX, "If an OpenCL application uses kernels with very long names, the Intercept Layer for OpenCL Applications can substitute a \"short\" kernel identifier for a \"long\" kernel name in logs and reports.  This control defines how long a kernel name must be (in characters) before it is replaced by a \"short\" kernel identifier." )
 
 CLI_CONTROL_SEPARATOR( Reporting Controls: )
 CLI_CONTROL( bool,          ReportToStderr,                         false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will emit reports to stderr." )

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -174,6 +174,10 @@ If set to a nonzero value, logs information about the platforms and devices in t
 
 If set, the Intercept Layer for OpenCL Applications will emit logs to this directory instead of the default log directory.
 
+##### `LongKernelNameCutoff` (cl_uint)
+
+If an OpenCL application uses kernels with very long names, the Intercept Layer for OpenCL Applications can substitute a "short" kernel identifier for a "long" kernel name in logs and reports.  This control defines how long a kernel name must be (in characters) before it is replaced by a "short" kernel identifier.
+
 ### Reporting Controls
 
 ##### `ReportToStderr` (bool)


### PR DESCRIPTION
## Description of Changes

This is a slightly different implementation of the changes in #21: It should be functionally similar, but the implementation is a bit more straightforward: instead of maintaining separate "kernel names" and "kernel IDs" for e.g. device timing, instead a single mapping between a "long" kernel name and its "short" equivalent is maintained, which can be queried when the "short" equivalent is preferred.

Additionally, instead of a single switch to control converting between "long" and "short" kernel names, I've added a "cutoff" control to define when a kernel name is too long and a shorter identifier should be substituted instead.  This allows all kernel names to be substituted (cutoff == 0) or no kernels to be substituted (cutoff == max_uint, this is the default), or any number in between.

## Testing Done

Ran a test app with varying cutoff controls.  Observed that the kernel name was correctly substituted in the logs and reports when the kernel name was longer than the cutoff control.