### PR TITLE
fix OSX warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     target_link_libraries( OpenCL ${CMAKE_THREAD_LIBS_INIT} )
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
     find_package(OpenCL REQUIRED)
-    set_target_properties(OpenCL PROPERTIES COMPILE_FLAGS "-g -Wall -std=c++11 -stdlib=libc++ -Weverything -arch i386 -arch x86_64")
+    set_target_properties(OpenCL PROPERTIES COMPILE_FLAGS "-g -Wall -std=c++11 -stdlib=libc++ -arch i386 -arch x86_64")
     target_link_libraries( OpenCL OpenCL::OpenCL )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     target_link_libraries( OpenCL ${CMAKE_THREAD_LIBS_INIT} )
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
     find_package(OpenCL REQUIRED)
-    set_target_properties(OpenCL PROPERTIES COMPILE_FLAGS "-g -Wall -arch i386 -arch x86_64")
+    set_target_properties(OpenCL PROPERTIES COMPILE_FLAGS "-g -Wall -std=c++11 -stdlib=libc++ -Weverything -arch i386 -arch x86_64")
     target_link_libraries( OpenCL OpenCL::OpenCL )
 endif()
 

--- a/mdapi/metrics_discovery_api.h
+++ b/mdapi/metrics_discovery_api.h
@@ -942,6 +942,9 @@ Description:
         // Optional param 'outMaxValues' should have a memory for at least 'MetricCount * RawReportCount' values, can be NULL.
         virtual TCompletionCode       CalculateMetrics( const unsigned char* rawData, uint32_t rawDataSize, TTypedValue_1_0* out,
             uint32_t outSize, uint32_t* outReportCount, TTypedValue_1_0* outMaxValues, uint32_t outMaxValuesSize );
+
+    private:
+        using IMetricSet_1_1::CalculateMetrics;
     };
 
 /*****************************************************************************\

--- a/mdapi/metrics_discovery_api.h
+++ b/mdapi/metrics_discovery_api.h
@@ -940,11 +940,9 @@ Description:
 
         // CalculateMetrics extended with max values calculation.
         // Optional param 'outMaxValues' should have a memory for at least 'MetricCount * RawReportCount' values, can be NULL.
+        using IMetricSet_1_1::CalculateMetrics;
         virtual TCompletionCode       CalculateMetrics( const unsigned char* rawData, uint32_t rawDataSize, TTypedValue_1_0* out,
             uint32_t outSize, uint32_t* outReportCount, TTypedValue_1_0* outMaxValues, uint32_t outMaxValuesSize );
-
-    private:
-        using IMetricSet_1_1::CalculateMetrics;
     };
 
 /*****************************************************************************\


### PR DESCRIPTION
## Description of Changes

This change fixes a few warnings in the CI OSX build.  There is still one warning, but we're better off now than we used to be.

## Testing Done

Verified that no Linux or Windows warnings were introduced, and that there are fewer OSX warnings.