### PR TITLE
CallLogging Error Status

### DIFF
--- a/Src/dispatch.cpp
+++ b/Src/dispatch.cpp
@@ -460,7 +460,7 @@ CL_API_ENTRY cl_context CL_API_CALL CLIRN(clCreateContext)(
         CREATE_CONTEXT_OVERRIDE_CLEANUP( retVal, newProperties );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
 #ifdef __ANDROID__
         mContextCount.lock();
@@ -542,7 +542,7 @@ CL_API_ENTRY cl_context CL_API_CALL CLIRN(clCreateContextFromType)(
         CREATE_CONTEXT_OVERRIDE_CLEANUP( retVal, newProperties );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -770,7 +770,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL CLIRN(clCreateCommandQueue)(
         ITT_REGISTER_COMMAND_QUEUE( retVal, false );
         CHROME_REGISTER_COMMAND_QUEUE( retVal );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -999,7 +999,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateBuffer)(
         DUMP_BUFFER_AFTER_CREATE( retVal, flags, host_ptr, size );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -1055,7 +1055,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateSubBuffer)(
         ADD_BUFFER( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -1138,7 +1138,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateImage)(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -1211,7 +1211,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateImage2D)(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -1293,7 +1293,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateImage3D)(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -1625,7 +1625,7 @@ CL_API_ENTRY cl_sampler CL_API_CALL CLIRN(clCreateSampler)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
         ADD_SAMPLER(retVal, samplerProperties);
 
         return retVal;
@@ -1852,7 +1852,7 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clCreateProgramWithSource)(
             count,
             strings,
             lengths );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p, program number = %04d",
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p, program number = %04d",
             retVal,
             pIntercept->getProgramNumber() );
 
@@ -1922,7 +1922,7 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clCreateProgramWithBinary)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         DUMP_INPUT_PROGRAM_BINARIES(
             retVal,
@@ -1991,7 +1991,7 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clCreateProgramWithBuiltInKernels)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -2546,7 +2546,7 @@ CL_API_ENTRY cl_kernel CL_API_CALL CLIRN(clCreateKernel)(
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
         SIMD_SURVEY_CREATE_KERNEL( program, retVal, kernel_name );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         if( retVal != NULL )
         {
@@ -3068,7 +3068,7 @@ CL_API_ENTRY cl_event CL_API_CALL CLIRN(clCreateUserEvent)(
             CPU_PERFORMANCE_TIMING_END();
             CHECK_ERROR( errcode_ret[0] );
             ADD_OBJECT_ALLOCATION( retVal );
-            CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
         }
 
         return retVal;
@@ -4617,7 +4617,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapBuffer)(
                     &map_count,
                     NULL );
             }
-            CALL_LOGGING_EXIT_EVENT( errcode_ret[0], event, "[ map count = %d ] mapped %p",
+            CALL_LOGGING_EXIT_EVENT( errcode_ret[0], event, "[ map count = %d ] returned %p",
                 map_count,
                 retVal );
 
@@ -4745,7 +4745,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapImage)(
                     &map_count,
                     NULL );
             }
-            CALL_LOGGING_EXIT_EVENT( errcode_ret[0], event, "[ map count = %d ] mapped %p",
+            CALL_LOGGING_EXIT_EVENT( errcode_ret[0], event, "[ map count = %d ] returned %p",
                 map_count,
                 retVal );
 
@@ -5605,7 +5605,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLBuffer)(
         ADD_BUFFER( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -5666,7 +5666,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture)(
 
         pIntercept->logCL_GLTextureDetails( retVal, target, miplevel, texture );
 
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -5727,7 +5727,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture2D)(
 
         pIntercept->logCL_GLTextureDetails( retVal, target, miplevel, texture );
 
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -5788,7 +5788,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture3D)(
 
         pIntercept->logCL_GLTextureDetails( retVal, target, miplevel, texture );
 
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -5834,7 +5834,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLRenderbuffer)(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -6076,7 +6076,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clSVMAlloc) (
         // if ErrorLogging is enabled.
         cl_int  errorCode = ( retVal != NULL ) ? CL_SUCCESS : CL_INVALID_OPERATION;
         CHECK_ERROR( errorCode );
-        CALL_LOGGING_EXIT( errorCode, "allocated %p", retVal );
+        CALL_LOGGING_EXIT( errorCode, "returned %p", retVal );
 
         return retVal;
     }
@@ -6672,7 +6672,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL CLIRN(clCreateCommandQueueWithProperti
         CREATE_COMMAND_QUEUE_OVERRIDE_CLEANUP( retVal, newProperties );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -6755,7 +6755,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithPropertiesKHR(
         CREATE_COMMAND_QUEUE_OVERRIDE_CLEANUP( retVal, newProperties );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -6801,7 +6801,7 @@ CL_API_ENTRY cl_sampler CL_API_CALL CLIRN(clCreateSamplerWithProperties) (
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
         ADD_SAMPLER( retVal, samplerProperties );
 
         return retVal;
@@ -6951,7 +6951,7 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clCreateProgramWithIL) (
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         DUMP_PROGRAM_SPIRV( retVal, length, il, hash );
         SAVE_PROGRAM_HASH( retVal, hash );
@@ -7005,7 +7005,7 @@ CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithILKHR(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         DUMP_PROGRAM_SPIRV( retVal, length, il, hash );
         SAVE_PROGRAM_HASH( retVal, hash );
@@ -7044,7 +7044,7 @@ CL_API_ENTRY cl_kernel CL_API_CALL CLIRN(clCloneKernel) (
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -7279,7 +7279,7 @@ CL_API_ENTRY cl_event CL_API_CALL clCreateEventFromGLsyncKHR(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -7367,7 +7367,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10BufferKHR(
         ADD_BUFFER( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -7414,7 +7414,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture2DKHR(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -7461,7 +7461,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture3DKHR(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -7655,7 +7655,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11BufferKHR(
         ADD_BUFFER( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -7702,7 +7702,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture2DKHR(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -7749,7 +7749,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture3DKHR(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -7949,7 +7949,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceKHR(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -8149,7 +8149,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceINTEL(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -8315,7 +8315,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreatePerfCountersCommandQueueINTEL(
         ADD_OBJECT_ALLOCATION( retVal );
         ITT_REGISTER_COMMAND_QUEUE( retVal, true );
         CHROME_REGISTER_COMMAND_QUEUE( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -8411,7 +8411,7 @@ CL_API_ENTRY cl_accelerator_intel CL_API_CALL clCreateAcceleratorINTEL(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         //ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -8635,7 +8635,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromVA_APIMediaSurfaceINTEL(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }

--- a/Src/dispatch.cpp
+++ b/Src/dispatch.cpp
@@ -47,7 +47,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetPlatformIDs)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -105,7 +105,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetPlatformInfo)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -159,7 +159,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetDeviceIDs)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -220,7 +220,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetDeviceInfo)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -270,7 +270,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clCreateSubDevices)(
                 ADD_OBJECT_ALLOCATION( out_devices[d] );
             }
         }
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -327,8 +327,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainDevice)(
                 &ref_count,
                 NULL );
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
     }
@@ -377,8 +376,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseDevice)(
             // avoids crashes in some cases for bad implementations.
             --ref_count;
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
     }
@@ -462,7 +460,7 @@ CL_API_ENTRY cl_context CL_API_CALL CLIRN(clCreateContext)(
         CREATE_CONTEXT_OVERRIDE_CLEANUP( retVal, newProperties );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
 #ifdef __ANDROID__
         mContextCount.lock();
@@ -544,7 +542,7 @@ CL_API_ENTRY cl_context CL_API_CALL CLIRN(clCreateContextFromType)(
         CREATE_CONTEXT_OVERRIDE_CLEANUP( retVal, newProperties );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -600,8 +598,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainContext)(
                 &ref_count,
                 NULL );
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
     }
@@ -649,8 +646,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseContext)(
             // avoids crashes in some cases for bad implementations.
             --ref_count;
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
 #if 0
         pIntercept->report();
@@ -702,7 +698,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetContextInfo)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -774,7 +770,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL CLIRN(clCreateCommandQueue)(
         ITT_REGISTER_COMMAND_QUEUE( retVal, false );
         CHROME_REGISTER_COMMAND_QUEUE( retVal );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -829,8 +825,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainCommandQueue)(
                 &ref_count,
                 NULL );
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
     }
@@ -879,8 +874,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseCommandQueue)(
             // avoids crashes in some cases for bad implementations.
             --ref_count;
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
     }
@@ -918,7 +912,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetCommandQueueInfo)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -956,7 +950,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetCommandQueueProperty)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -1005,7 +999,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateBuffer)(
         DUMP_BUFFER_AFTER_CREATE( retVal, flags, host_ptr, size );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -1061,7 +1055,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateSubBuffer)(
         ADD_BUFFER( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -1144,7 +1138,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateImage)(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -1217,7 +1211,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateImage2D)(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -1299,7 +1293,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateImage3D)(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -1360,8 +1354,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainMemObject)(
                 &ref_count,
                 NULL );
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
     }
@@ -1411,8 +1404,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseMemObject)(
             // avoids crashes in some cases for bad implementations.
             --ref_count;
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
     }
@@ -1454,7 +1446,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetSupportedImageFormats)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -1498,7 +1490,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetMemObjectInfo)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -1541,7 +1533,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetImageInfo)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -1578,7 +1570,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetMemObjectDestructorCallback)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -1633,7 +1625,7 @@ CL_API_ENTRY cl_sampler CL_API_CALL CLIRN(clCreateSampler)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
         ADD_SAMPLER(retVal, samplerProperties);
 
         return retVal;
@@ -1690,8 +1682,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainSampler)(
                 &ref_count,
                 NULL );
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
     }
@@ -1743,8 +1734,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseSampler)(
             // avoids crashes in some cases for bad implementations.
             --ref_count;
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
     }
@@ -1782,7 +1772,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetSamplerInfo)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -1862,7 +1852,7 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clCreateProgramWithSource)(
             count,
             strings,
             lengths );
-        CALL_LOGGING_EXIT( "returned %p, program number = %04d",
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p, program number = %04d",
             retVal,
             pIntercept->getProgramNumber() );
 
@@ -1932,7 +1922,7 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clCreateProgramWithBinary)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         DUMP_INPUT_PROGRAM_BINARIES(
             retVal,
@@ -2001,7 +1991,7 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clCreateProgramWithBuiltInKernels)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -2057,8 +2047,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainProgram)(
                 &ref_count,
                 NULL );
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
     }
@@ -2106,8 +2095,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseProgram)(
             // avoids crashes in some cases for bad implementations.
             --ref_count;
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
     }
@@ -2157,7 +2145,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clBuildProgram)(
             num_devices,
             device_list,
             options );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         DUMP_OUTPUT_PROGRAM_BINARIES( program );
         DUMP_KERNEL_ISA_BINARIES( program );
@@ -2219,7 +2207,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clCompileProgram)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
         BUILD_LOGGING( program, num_devices, device_list );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         INCREMENT_PROGRAM_COMPILE_COUNT( program );
 
@@ -2279,7 +2267,7 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clLinkProgram)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         BUILD_LOGGING( retVal, num_devices, device_list );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( errcode_ret[0] );
 
         // TODO: Is the resulting program ("retVal") the one that should be
         // used here, to determine the hash for dumped options?
@@ -2325,7 +2313,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetProgramReleaseCallback)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -2362,7 +2350,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetProgramSpecializationConstant)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -2394,7 +2382,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clUnloadPlatformCompiler)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -2420,7 +2408,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clUnloadCompiler)( void )
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -2457,7 +2445,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetProgramInfo)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -2501,7 +2489,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetProgramBuildInfo)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -2558,7 +2546,7 @@ CL_API_ENTRY cl_kernel CL_API_CALL CLIRN(clCreateKernel)(
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
         SIMD_SURVEY_CREATE_KERNEL( program, retVal, kernel_name );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         if( retVal != NULL )
         {
@@ -2633,7 +2621,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clCreateKernelsInProgram)(
                 num_kernels_ret,
                 retString );
         }
-        CALL_LOGGING_EXIT( "%s", retString.c_str() );
+        CALL_LOGGING_EXIT( retVal, "%s", retString.c_str() );
 
         if( ( retVal == CL_SUCCESS ) &&
             ( kernels != NULL ) )
@@ -2702,8 +2690,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainKernel)(
                 &ref_count,
                 NULL );
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
     }
@@ -2753,8 +2740,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseKernel)(
             // avoids crashes in some cases for bad implementations.
             --ref_count;
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
     }
@@ -2813,7 +2799,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetKernelArg)(
             arg_index,
             arg_size,
             arg_value );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -2854,7 +2840,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetKernelInfo)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -2899,7 +2885,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetKernelArgInfo)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -2944,7 +2930,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetKernelWorkGroupInfo)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -2993,7 +2979,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clWaitForEvents)(
 
             CPU_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            CALL_LOGGING_EXIT();
+            CALL_LOGGING_EXIT( retVal );
 
             DEVICE_PERFORMANCE_TIMING_CHECK();
         }
@@ -3040,7 +3026,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetEventInfo)(
 
             CPU_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            CALL_LOGGING_EXIT();
+            CALL_LOGGING_EXIT( retVal );
         }
 
         return retVal;
@@ -3082,7 +3068,7 @@ CL_API_ENTRY cl_event CL_API_CALL CLIRN(clCreateUserEvent)(
             CPU_PERFORMANCE_TIMING_END();
             CHECK_ERROR( errcode_ret[0] );
             ADD_OBJECT_ALLOCATION( retVal );
-            CALL_LOGGING_EXIT( "returned %p", retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
         }
 
         return retVal;
@@ -3136,8 +3122,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainEvent)(
                 &ref_count,
                 NULL );
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
     }
@@ -3185,8 +3170,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseEvent)(
             // avoids crashes in some cases for bad implementations.
             --ref_count;
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
     }
@@ -3217,7 +3201,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetUserEventStatus)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -3258,7 +3242,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetEventCallback)(
         CPU_PERFORMANCE_TIMING_END();
         EVENT_CALLBACK_OVERRIDE_CLEANUP( retVal );
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -3303,7 +3287,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetEventProfilingInfo)(
 
             CPU_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            CALL_LOGGING_EXIT();
+            CALL_LOGGING_EXIT( retVal );
         }
 
         return retVal;
@@ -3336,7 +3320,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clFlush)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         DEVICE_PERFORMANCE_TIMING_CHECK();
 
@@ -3366,7 +3350,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clFinish)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         DEVICE_PERFORMANCE_TIMING_CHECK();
 
@@ -3447,7 +3431,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReadBuffer)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
 
             if( blocking_read )
             {
@@ -3553,7 +3537,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReadBufferRect)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
 
             if( blocking_read )
             {
@@ -3654,7 +3638,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueWriteBuffer)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
 
             if( blocking_write )
             {
@@ -3760,7 +3744,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueWriteBufferRect)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
 
             if( blocking_write )
             {
@@ -3837,7 +3821,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueFillBuffer)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -3925,7 +3909,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueCopyBuffer)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -4020,7 +4004,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueCopyBufferRect)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -4134,7 +4118,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReadImage)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
 
             if( blocking_read )
             {
@@ -4234,7 +4218,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueWriteImage)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
 
             if( blocking_write )
             {
@@ -4306,7 +4290,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueFillImage)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -4387,7 +4371,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueCopyImage)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -4453,7 +4437,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueCopyImageToBuffer)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -4519,7 +4503,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueCopyBufferToImage)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -4633,7 +4617,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapBuffer)(
                     &map_count,
                     NULL );
             }
-            CALL_LOGGING_EXIT_EVENT(event, "[ map count = %d ] returned %p",
+            CALL_LOGGING_EXIT_EVENT( errcode_ret[0], event, "[ map count = %d ] mapped %p",
                 map_count,
                 retVal );
 
@@ -4761,7 +4745,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapImage)(
                     &map_count,
                     NULL );
             }
-            CALL_LOGGING_EXIT_EVENT(event, "[ map count = %d ] returned %p",
+            CALL_LOGGING_EXIT_EVENT( errcode_ret[0], event, "[ map count = %d ] mapped %p",
                 map_count,
                 retVal );
 
@@ -4870,8 +4854,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueUnmapMemObject)(
                     &map_count,
                     NULL );
             }
-            CALL_LOGGING_EXIT_EVENT(event, "[ map count = %d ]",
-                map_count );
+            CALL_LOGGING_EXIT_EVENT( retVal, event, "[ map count = %d ]", map_count );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -4931,7 +4914,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueMigrateMemObjects)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -5072,7 +5055,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueNDRangeKernel)(
                 local_work_size );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         DUMP_BUFFERS_AFTER_ENQUEUE( kernel, command_queue );
@@ -5138,7 +5121,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueTask)(
                 NULL );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -5202,7 +5185,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueNativeKernel)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -5255,7 +5238,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueMarker)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -5313,7 +5296,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueWaitForEvents)(
 
             CPU_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            CALL_LOGGING_EXIT();
+            CALL_LOGGING_EXIT( retVal );
 
             DEVICE_PERFORMANCE_TIMING_CHECK();
         }
@@ -5356,7 +5339,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueBarrier)(
 
             CPU_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            CALL_LOGGING_EXIT();
+            CALL_LOGGING_EXIT( retVal );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -5418,7 +5401,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueMarkerWithWaitList)(
             CPU_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -5482,7 +5465,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueBarrierWithWaitList)(
             CPU_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -5528,7 +5511,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clGetExtensionFunctionAddress)(
         }
 
         CPU_PERFORMANCE_TIMING_END();
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( CL_SUCCESS, "returned %p", retVal );
 
         return retVal;
     }
@@ -5578,7 +5561,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clGetExtensionFunctionAddressForPlatform)(
         }
 
         CPU_PERFORMANCE_TIMING_END();
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( CL_SUCCESS, "returned %p", retVal );
 
         return retVal;
     }
@@ -5622,7 +5605,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLBuffer)(
         ADD_BUFFER( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -5683,7 +5666,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture)(
 
         pIntercept->logCL_GLTextureDetails( retVal, target, miplevel, texture );
 
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -5744,7 +5727,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture2D)(
 
         pIntercept->logCL_GLTextureDetails( retVal, target, miplevel, texture );
 
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -5805,7 +5788,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture3D)(
 
         pIntercept->logCL_GLTextureDetails( retVal, target, miplevel, texture );
 
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -5851,7 +5834,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLRenderbuffer)(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -5887,7 +5870,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetGLObjectInfo)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -5926,7 +5909,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetGLTextureInfo)(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -5979,7 +5962,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueAcquireGLObjects)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -6037,7 +6020,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReleaseGLObjects)(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -6093,7 +6076,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clSVMAlloc) (
         // if ErrorLogging is enabled.
         cl_int  errorCode = ( retVal != NULL ) ? CL_SUCCESS : CL_INVALID_OPERATION;
         CHECK_ERROR( errorCode );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errorCode, "allocated %p", retVal );
 
         return retVal;
     }
@@ -6128,7 +6111,7 @@ CL_API_ENTRY void CL_API_CALL CLIRN(clSVMFree) (
 
         CPU_PERFORMANCE_TIMING_END();
         REMOVE_SVM_ALLOCATION( svm_pointer );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( CL_SUCCESS );
     }
     else
     {
@@ -6184,7 +6167,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMFree) (
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -6248,7 +6231,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMMemcpy) (
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -6312,7 +6295,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMMemFill) (
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -6376,7 +6359,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMMap) (
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -6434,7 +6417,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMUnmap) (
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -6481,7 +6464,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetKernelArgSVMPointer) (
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -6518,7 +6501,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetKernelExecInfo) (
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -6562,7 +6545,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreatePipe) (
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( errcode_ret[0] );
 
         return retVal;
     }
@@ -6607,7 +6590,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetPipeInfo) (
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -6689,7 +6672,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL CLIRN(clCreateCommandQueueWithProperti
         CREATE_COMMAND_QUEUE_OVERRIDE_CLEANUP( retVal, newProperties );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -6772,7 +6755,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithPropertiesKHR(
         CREATE_COMMAND_QUEUE_OVERRIDE_CLEANUP( retVal, newProperties );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -6818,7 +6801,7 @@ CL_API_ENTRY cl_sampler CL_API_CALL CLIRN(clCreateSamplerWithProperties) (
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
         ADD_SAMPLER( retVal, samplerProperties );
 
         return retVal;
@@ -6854,7 +6837,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetDefaultDeviceCommandQueue) (
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -6889,7 +6872,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetDeviceAndHostTimer) (
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -6922,7 +6905,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetHostTimer) (
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -6968,7 +6951,7 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clCreateProgramWithIL) (
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         DUMP_PROGRAM_SPIRV( retVal, length, il, hash );
         SAVE_PROGRAM_HASH( retVal, hash );
@@ -7022,7 +7005,7 @@ CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithILKHR(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         DUMP_PROGRAM_SPIRV( retVal, length, il, hash );
         SAVE_PROGRAM_HASH( retVal, hash );
@@ -7061,7 +7044,7 @@ CL_API_ENTRY cl_kernel CL_API_CALL CLIRN(clCloneKernel) (
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -7107,7 +7090,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetKernelSubGroupInfo) (
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -7161,7 +7144,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetKernelSubGroupInfoKHR(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -7213,7 +7196,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMMigrateMem(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -7261,7 +7244,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetGLContextInfoKHR(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -7296,7 +7279,7 @@ CL_API_ENTRY cl_event CL_API_CALL clCreateEventFromGLsyncKHR(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -7343,7 +7326,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D10KHR(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -7384,7 +7367,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10BufferKHR(
         ADD_BUFFER( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -7431,7 +7414,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture2DKHR(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -7478,7 +7461,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture3DKHR(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -7531,7 +7514,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D10ObjectsKHR(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -7584,7 +7567,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D10ObjectsKHR(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -7631,7 +7614,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D11KHR(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -7672,7 +7655,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11BufferKHR(
         ADD_BUFFER( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -7719,7 +7702,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture2DKHR(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -7766,7 +7749,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture3DKHR(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -7819,7 +7802,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D11ObjectsKHR(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -7872,7 +7855,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D11ObjectsKHR(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -7921,7 +7904,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromDX9MediaAdapterKHR(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -7966,7 +7949,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceKHR(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -8019,7 +8002,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireDX9MediaSurfacesKHR(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -8072,7 +8055,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseDX9MediaSurfacesKHR(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -8121,7 +8104,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromDX9INTEL(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -8166,7 +8149,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceINTEL(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -8219,7 +8202,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireDX9ObjectsINTEL(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -8272,7 +8255,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseDX9ObjectsINTEL(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -8332,7 +8315,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreatePerfCountersCommandQueueINTEL(
         ADD_OBJECT_ALLOCATION( retVal );
         ITT_REGISTER_COMMAND_QUEUE( retVal, true );
         CHROME_REGISTER_COMMAND_QUEUE( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -8371,7 +8354,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetPerformanceConfigurationINTEL(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -8428,7 +8411,7 @@ CL_API_ENTRY cl_accelerator_intel CL_API_CALL clCreateAcceleratorINTEL(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
         //ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -8470,7 +8453,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetAcceleratorInfoINTEL(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -8521,8 +8504,7 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainAcceleratorINTEL(
                 &ref_count,
                 NULL );
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
     }
@@ -8569,8 +8551,7 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseAcceleratorINTEL(
             // avoids crashes in some cases for bad implementations.
             --ref_count;
         }
-        CALL_LOGGING_EXIT( "[ ref count = %d ]",
-            ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
     }
@@ -8611,7 +8592,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromVA_APIMediaAdapterINTEL(
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT();
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -8654,7 +8635,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromVA_APIMediaSurfaceINTEL(
         ADD_IMAGE( retVal );
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( "returned %p", retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "created %p", retVal );
 
         return retVal;
     }
@@ -8707,7 +8688,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireVA_APIMediaSurfacesINTEL(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
@@ -8760,7 +8741,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseVA_APIMediaSurfacesINTEL(
             DEVICE_PERFORMANCE_TIMING_END( event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( event );
+            CALL_LOGGING_EXIT_EVENT( retVal, event );
         }
 
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );

--- a/Src/intercept.cpp
+++ b/Src/intercept.cpp
@@ -997,7 +997,7 @@ void CLIntercept::callLoggingEnter(
     if( m_Config.CallLoggingEnqueueCounter )
     {
         std::ostringstream  ss;
-        ss << ", EnqueueCounter: ";
+        ss << "; EnqueueCounter: ";
         ss << m_EnqueueCounter;
         str += ss.str();
     }
@@ -1082,7 +1082,7 @@ void CLIntercept::callLoggingInfo(
 //
 void CLIntercept::callLoggingExit(
     const std::string& functionName,
-    const cl_kernel kernel,
+    const cl_int errorCode,
     const cl_event* event )
 {
     m_OS.EnterCriticalSection();
@@ -1092,14 +1092,6 @@ void CLIntercept::callLoggingExit(
 
     str += functionName;
 
-    if( kernel )
-    {
-        const std::string& kernelName = getShortKernelName(kernel);
-        str += "( ";
-        str += kernelName;
-        str += " )";
-    }
-
     if( event )
     {
         char temp[ CLI_MAX_STRING_SIZE ] = "";
@@ -1107,13 +1099,16 @@ void CLIntercept::callLoggingExit(
         str += temp;
     }
 
+    str += " -> ";
+    str += m_EnumNameMap.name( errorCode );
+
     log( "<<<< " + str + "\n" );
 
     m_OS.LeaveCriticalSection();
 }
 void CLIntercept::callLoggingExit(
     const std::string& functionName,
-    const cl_kernel kernel,
+    const cl_int errorCode,
     const cl_event* event,
     const char* formatStr,
     ... )
@@ -1122,18 +1117,6 @@ void CLIntercept::callLoggingExit(
     va_start( args, formatStr );
 
     std::string str = functionName;
-
-    if( kernel )
-    {
-        m_OS.EnterCriticalSection();
-
-        const std::string& kernelName = getShortKernelName(kernel);
-        str += "( ";
-        str += kernelName;
-        str += " )";
-
-        m_OS.LeaveCriticalSection();
-    }
 
     char temp[ CLI_MAX_STRING_SIZE ] = "";
 
@@ -1154,7 +1137,7 @@ void CLIntercept::callLoggingExit(
         str += ": too long";
     }
 
-    callLoggingExit( str, NULL, NULL );
+    callLoggingExit( str, errorCode, NULL );
 
     va_end( args );
 }
@@ -2602,7 +2585,7 @@ void CLIntercept::eventCallbackCaller(
             pEventCallbackInfo->pUserData );
     }
 
-    CALL_LOGGING_EXIT();
+    CALL_LOGGING_EXIT( CL_SUCCESS );
 
     delete pEventCallbackInfo;
 }

--- a/Src/intercept.h
+++ b/Src/intercept.h
@@ -82,11 +82,11 @@ public:
 
     void    callLoggingExit(
                 const std::string& functionName,
-                const cl_kernel kernel,
+                const cl_int errorCode,
                 const cl_event* event );
     void    callLoggingExit(
                 const std::string& functionName,
-                const cl_kernel kernel,
+                const cl_int errorCode,
                 const cl_event* event,
                 const char* formatStr,
                 ... );
@@ -1040,25 +1040,34 @@ inline bool CLIntercept::callLogging() const
         pIntercept->callLoggingInfo( __VA_ARGS__ );                         \
     }                                                                       \
 
-#define CALL_LOGGING_EXIT(...)                                                  \
-    if( pIntercept->config().CallLogging )                                      \
-    {                                                                           \
-        pIntercept->callLoggingExit( __FUNCTION__, NULL, NULL, ##__VA_ARGS__ ); \
-    }                                                                           \
+#define CALL_LOGGING_EXIT(errorCode, ...)                                   \
+    if( pIntercept->config().CallLogging )                                  \
+    {                                                                       \
+        pIntercept->callLoggingExit(                                        \
+            __FUNCTION__,                                                   \
+            errorCode,                                                      \
+            NULL,                                                           \
+            ##__VA_ARGS__ );                                                \
+    }                                                                       \
     ITT_CALL_LOGGING_EXIT();
 
-#define CALL_LOGGING_EXIT_EVENT(event, ...)                                     \
-    if( pIntercept->config().CallLogging )                                      \
-    {                                                                           \
-        pIntercept->callLoggingExit( __FUNCTION__, NULL, event, ##__VA_ARGS__ );\
-    }                                                                           \
+#define CALL_LOGGING_EXIT_EVENT(errorCode, event, ...)                      \
+    if( pIntercept->config().CallLogging )                                  \
+    {                                                                       \
+        pIntercept->callLoggingExit(                                        \
+            __FUNCTION__,                                                   \
+            errorCode,                                                      \
+            event,                                                          \
+            ##__VA_ARGS__ );                                                \
+    }                                                                       \
     ITT_CALL_LOGGING_EXIT();
 
 ///////////////////////////////////////////////////////////////////////////////
 //
 #define CHECK_ERROR_INIT( pErrorCode )                                      \
     cl_int  localErrorCode = CL_SUCCESS;                                    \
-    if( ( pIntercept->config().ErrorLogging ||                              \
+    if( ( pIntercept->config().CallLogging ||                               \
+          pIntercept->config().ErrorLogging ||                              \
           pIntercept->config().ErrorAssert ||                               \
           pIntercept->config().NoErrors ) &&                                \
         ( pErrorCode == NULL ) )                                            \


### PR DESCRIPTION
Fixes #25

## Description of Changes

Adds error status to CallLogging.  Example output:

````
>>>> clCreateBuffer: flags = CL_MEM_WRITE_ONLY | CL_MEM_ALLOC_HOST_PTR (12), size = 4194304, host_ptr = 00000000
<<<< clCreateBuffer: created 06B53790 -> CL_SUCCESS
````

## Testing Done

Enabled CallLogging and verified that error status was displayed on all APIs, both those that return an error code directly as well as APIs that return error status via an optional pointer argument.
