### PR TITLE
log when a short kernel name mapping is created

### DIFF
--- a/Src/intercept.cpp
+++ b/Src/intercept.cpp
@@ -893,6 +893,10 @@ void CLIntercept::addShortKernelName(
         shortKernelName += std::to_string(m_KernelID);
         m_LongKernelNameMap[ kernelName ] = shortKernelName;
 
+        logf( "Added kernel name mapping: %s to %s\n",
+            kernelName.c_str(),
+            shortKernelName.c_str() );
+
         m_KernelID++;
     }
 }


### PR DESCRIPTION
## Description of Changes

Adds a line to the log when the length of a kernel name exceeded the "long kernel name cutoff" so a short kernel name mapping was created.

## Testing Done

Set the "long kernel name cutoff" to a relatively small value, ran an application, and observed that the mapping between the long and short kernel name was logged when it was created.