### PR TITLE
fix spurious MDAPI assert

### DIFF
--- a/mdapi/intercept_mdapi.cpp
+++ b/mdapi/intercept_mdapi.cpp
@@ -210,10 +210,11 @@ void CLIntercept::saveMDAPICounters(
                 pReport,
                 &outputSize );
 
-            CLI_ASSERT( outputSize == reportSize );
-
             if( errorCode == CL_SUCCESS )
             {
+                // Check: The size of the queried report should be the expected size.
+                CLI_ASSERT( outputSize == reportSize );
+
                 std::vector<MetricsDiscovery::TTypedValue_1_0> results;
                 m_pMDHelper->GetMetricsFromReport(
                     pReport,


### PR DESCRIPTION
## Description of Changes

If the MDAPI query failed, the returned "report size" is unchanged, hence an ASSERT was firing.  This isn't particularly useful, since the MDAPI query can fail for unsupported devices or if an MDAPI command queue could not be created.  So, only check and ASSERT if the MDAPI query call is successfully.

## Testing Done

Ran an app using a debug DLL that failed MDAPI queue creation.  Observed that no ASSERT occurred, and the app correctly ran to completion.
