### PR TITLE
initialize MDAPI as part of init vs. creating command queues

### DIFF
--- a/Src/intercept.cpp
+++ b/Src/intercept.cpp
@@ -570,6 +570,11 @@ bool CLIntercept::init()
 #include "controls.h"
 #undef CLI_CONTROL
 
+    if( !m_Config.DevicePerfCounterCustom.empty() )
+    {
+        initCustomPerfCounters();
+    }
+
     m_StartTime = m_OS.GetTimer();
     log( "Timer Started!\n" );
 

--- a/Src/intercept.h
+++ b/Src/intercept.h
@@ -581,7 +581,7 @@ public:
                 const std::string& func_name ) const;
 
 #if defined(USE_MDAPI)
-    cl_uint initCustomPerfCounters();
+    void    initCustomPerfCounters();
 
     cl_command_queue    createMDAPICommandQueue(
                 cl_context context,


### PR DESCRIPTION
## Description of Changes

Moved MDAPI initialization out of command queue creation so it is initialized with the rest of the intercept layer.  This avoids a potential race condition causing the MDAPI command queue creation to fail in some rare cases, such as if an application is run with metrics collection enabled immediately after a reboot.

## Testing Done

Ran several applications and verified that metrics are collected correctly.  Also verified that applications run correctly on devices that do not support metrics collection, and when the MDAPI library is not present.