### PR TITLE
add missing USE_MDAPI ifdef

### DIFF
--- a/Src/intercept.cpp
+++ b/Src/intercept.cpp
@@ -570,10 +570,12 @@ bool CLIntercept::init()
 #include "controls.h"
 #undef CLI_CONTROL
 
+#if defined(USE_MDAPI)
     if( !m_Config.DevicePerfCounterCustom.empty() )
     {
         initCustomPerfCounters();
     }
+#endif
 
     m_StartTime = m_OS.GetTimer();
     log( "Timer Started!\n" );


### PR DESCRIPTION
## Description of Changes

When MDAPI initialization was refactored I missed an ifdef around a section of MDAPI code.  This change re-adds the missing MDAPI ifdef, so the intercept layer will build even if ENABLE_MDAPI is not selected.

## Testing Done

Verified that builds are successful even when ENABLE_MDAPI is de-selected.