### PR TITLE
add missing MDAPI cleanup call

### DIFF
--- a/Src/intercept.cpp
+++ b/Src/intercept.cpp
@@ -178,6 +178,13 @@ CLIntercept::~CLIntercept()
     // the process is terminating, that's probably OK.
     m_Dispatch = dummyDispatch;
 
+#if defined(USE_MDAPI)
+    if( m_pMDHelper )
+    {
+        MetricsDiscovery::MDHelper::Delete( m_pMDHelper );
+    }
+#endif
+
     if( m_OpenCLLibraryHandle != NULL )
     {
         OS().UnloadLibrary( m_OpenCLLibraryHandle );


### PR DESCRIPTION
## Description of Changes

When the metrics discovery helper was allocated it was never cleaned up.  Added the missing call to deallocate and tear down the metrics discovery helper when the intercept layer is unloading.

## Testing Done

Enabled perf counters and verified that perf counters were correctly collected and that the metrics helper was correctly destroyed.
