### PR TITLE
add enqueue counter to device timeline logging

### DIFF
--- a/Src/intercept.cpp
+++ b/Src/intercept.cpp
@@ -2592,11 +2592,6 @@ void CLIntercept::incrementEnqueueCounter()
     m_OS.LeaveCriticalSection();
 }
 
-uint64_t CLIntercept::getEnqueueCounter()
-{
-    return m_EnqueueCounter;
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 //
 void CLIntercept::overrideNullLocalWorkSize(
@@ -4399,6 +4394,7 @@ void CLIntercept::addTimingEvent(
                 pNode->KernelName += ss.str();
             }
         }
+        pNode->EnqueueCounter = m_EnqueueCounter;
         pNode->QueuedTime = queuedTime;
         pNode->Kernel = kernel; // Note: no retain, so cannot count on this value...
         pNode->Event = event;
@@ -4499,7 +4495,9 @@ void CLIntercept::checkTimingEvents()
 
                             std::ostringstream  ss;
 
-                            ss << "Device Time for call " << numberOfCalls << " to " << key << " = "
+                            ss << "Device Time for "
+                                //<< "call " << numberOfCalls << " to "
+                                << key << " (enqueue " << pNode->EnqueueCounter << ") = "
                                 << queuedDelta << " ns (queued -> submit), "
                                 << submitDelta << " ns (submit -> start), "
                                 << delta << " ns (start -> end)\n";
@@ -4511,7 +4509,9 @@ void CLIntercept::checkTimingEvents()
                         {
                             std::ostringstream  ss;
 
-                            ss << "Device Timeline for call " << numberOfCalls << " to " << key << " = "
+                            ss << "Device Timeline for "
+                                //<< call " << numberOfCalls << " to "
+                                << key << " (enqueue " << pNode->EnqueueCounter << ") = "
                                 << commandQueued << " ns (queued), "
                                 << commandSubmit << " ns (submit), "
                                 << commandStart << " ns (start), "

--- a/Src/intercept.h
+++ b/Src/intercept.h
@@ -217,7 +217,6 @@ public:
                 cl_int status );
 
     void    incrementEnqueueCounter();
-    uint64_t getEnqueueCounter();
 
     void    overrideNullLocalWorkSize(
                 const cl_uint work_dim,
@@ -816,6 +815,7 @@ private:
     {
         std::string FunctionName;
         std::string KernelName;
+        uint64_t    EnqueueCounter;
         uint64_t    QueuedTime;
         cl_kernel   Kernel;
         cl_event    Event;


### PR DESCRIPTION
See #41

## Description of Changes

Adds the enqueue counter to `DevicePerformanceTimeLogging` and `DevicePerformanceTmelineLogging`, to allow easy tracing to a particular enqueue command.  For example:

````
Device Time for Intersect$0001_BFE31CD2_0000_23D61775 (enqueue 20) = 118272 ns (queued -> submit), 1059872 ns (submit -> start), 4843296 ns (start -> end)
Device Timeline for Intersect$0001_BFE31CD2_0000_23D61775 (enqueue 20) = 1538454136434723328 ns (queued), 1538454136434841600 ns (submit), 1538454136435901472 ns (start), 1538454136440744768 ns (end)
````

Note that the call number is no longer logged as seemed to be extraneous with the enqueue counter, but I can easily add it back, if desired.

## Testing Done

Enabled `DevicePerformanceTiming`, `DevicePerformanceTimeLogging`, and `DevicePerformanceTimelineLogging` and verified that the enqueue counter is added to the log, as expected.
