### PR TITLE
comment out now-unused variable numberOfCalls

### DIFF
--- a/Src/intercept.cpp
+++ b/Src/intercept.cpp
@@ -4486,7 +4486,7 @@ void CLIntercept::checkTimingEvents()
                         deviceTimingStats.MinNS = std::min< cl_ulong >( deviceTimingStats.MinNS, delta );
                         deviceTimingStats.MaxNS = std::max< cl_ulong >( deviceTimingStats.MaxNS, delta );
 
-                        uint64_t    numberOfCalls = deviceTimingStats.NumberOfCalls;
+                        //uint64_t    numberOfCalls = deviceTimingStats.NumberOfCalls;
 
                         if( config().DevicePerformanceTimeLogging )
                         {
@@ -4510,7 +4510,7 @@ void CLIntercept::checkTimingEvents()
                             std::ostringstream  ss;
 
                             ss << "Device Timeline for "
-                                //<< call " << numberOfCalls << " to "
+                                //<< "call " << numberOfCalls << " to "
                                 << key << " (enqueue " << pNode->EnqueueCounter << ") = "
                                 << commandQueued << " ns (queued), "
                                 << commandSubmit << " ns (submit), "


### PR DESCRIPTION
## Description of Changes

Removes a now-unused variable to eliminate a compiler warning.

## Testing Done

No functional changes.
