### PR TITLE
don't remove the short kernel name from the map

### DIFF
--- a/Src/intercept.cpp
+++ b/Src/intercept.cpp
@@ -4747,7 +4747,12 @@ void CLIntercept::removeKernel(
     {
         if( refCount == 1 )
         {
+#if 0
+            // We shouldn't remove the kernel name from the local kernel name map
+            // here since the mapping may be included in the device performance
+            // time report.
             m_LongKernelNameMap.erase( m_KernelInfoMap[ kernel ].KernelName );
+#endif
 
             m_KernelInfoMap.erase( kernel );
 


### PR DESCRIPTION
## Description of Changes

Since the short kernel name mapping is included in the device performance timing report, the short kernel name should not be removed from the map when a kernel is destroyed.

## Testing Done

Ran an application that properly cleaned up all OpenCL kernels and verified that the mapping between short and long kernel names still appeared correctly in the device performance timing report.