### PR TITLE
basic travis-ci testing for tabs and trailing whitespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,13 @@ os:
   - linux
   - osx
 
+# Basic coding standard checks:
+# - Uses spaces, not tabs.
+# - No trailing whitespace.
+before_install:
+  - "if git grep -n $'\t'          *.cpp *.c *.hpp *.h; then echo 'Please replace tabs with spaces in source files.';     false; fi"
+  - "if git grep -n '[[:blank:]]$' *.cpp *.c *.hpp *.h; then echo 'Please remove trailing whitespace from source files.'; false; fi"
+
 script:
   - mkdir -p build
   - cd build

--- a/mdapi/intercept_mdapi.cpp
+++ b/mdapi/intercept_mdapi.cpp
@@ -211,7 +211,7 @@ void CLIntercept::saveMDAPICounters(
 
                 std::vector<MetricsDiscovery::TTypedValue_1_0> results;
                 std::vector<MetricsDiscovery::TTypedValue_1_0> maxValues;
-                
+
                 m_pMDHelper->GetMetricsFromReport(
                     pReport,
                     results,


### PR DESCRIPTION
Fixes #54 

## Description of Changes

Adds basic travis-ci tests for tabs and trailing whitespace in source files, defined as anything with a cpp, c, hpp, or h file extension.

## Testing Done

No functional changes.  Verified that travis-ci builds succeeded after this change.  This did require removing trailing whitespace from one file.