### PR TITLE
minor fix for creating MDAPI command queues with properties

### DIFF
--- a/Src/dispatch.cpp
+++ b/Src/dispatch.cpp
@@ -6703,11 +6703,22 @@ CL_API_ENTRY cl_command_queue CL_API_CALL CLIRN(clCreateCommandQueueWithProperti
 #if defined(USE_MDAPI)
         if( !pIntercept->config().DevicePerfCounterCustom.empty() )
         {
-            retVal = pIntercept->createMDAPICommandQueue(
-                context,
-                device,
-                properties,
-                errcode_ret );
+            if( ( retVal == NULL ) && newProperties )
+            {
+                retVal = pIntercept->createMDAPICommandQueue(
+                    context,
+                    device,
+                    newProperties,
+                    errcode_ret );
+            }
+            if( retVal == NULL )
+            {
+                retVal = pIntercept->createMDAPICommandQueue(
+                    context,
+                    device,
+                    properties,
+                    errcode_ret );
+            }
         }
 #endif
 
@@ -6787,11 +6798,22 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithPropertiesKHR(
 #if defined(USE_MDAPI)
         if( !pIntercept->config().DevicePerfCounterCustom.empty() )
         {
-            retVal = pIntercept->createMDAPICommandQueue(
-                context,
-                device,
-                properties,
-                errcode_ret );
+            if( ( retVal == NULL ) && newProperties )
+            {
+                retVal = pIntercept->createMDAPICommandQueue(
+                    context,
+                    device,
+                    newProperties,
+                    errcode_ret );
+            }
+            if( retVal == NULL )
+            {
+                retVal = pIntercept->createMDAPICommandQueue(
+                    context,
+                    device,
+                    properties,
+                    errcode_ret );
+            }
         }
 #endif
 

--- a/mdapi/intercept_mdapi.cpp
+++ b/mdapi/intercept_mdapi.cpp
@@ -43,6 +43,7 @@ static bool convertPropertiesToOCL1_2(
             {
                 switch( properties[ i + 1 ] )
                 {
+                case 0: // no special queue properties
                 case CL_QUEUE_PROFILING_ENABLE:
                 case CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE:
                 case CL_QUEUE_PROFILING_ENABLE | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE:

--- a/mdapi/intercept_mdapi.cpp
+++ b/mdapi/intercept_mdapi.cpp
@@ -44,10 +44,9 @@ static bool convertPropertiesToOCL1_2(
                 switch( properties[ i + 1 ] )
                 {
                 case CL_QUEUE_PROFILING_ENABLE:
-                    ocl1_2_properties |= CL_QUEUE_PROFILING_ENABLE;
-                    break;
                 case CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE:
-                    ocl1_2_properties |= CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE;
+                case CL_QUEUE_PROFILING_ENABLE | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE:
+                    ocl1_2_properties |= properties[ i + 1 ];
                     break;
                 default:
                     return false;


### PR DESCRIPTION
## Description of Changes

When creating a command queue using clCreateCommandQueueWithProperties, an MDAPI command queue cannot be created in some cases, specifically if profiling is not enabled in the passed-in properties.  This is a minor fix to use overridden command queue properties instead, which will have profiling enabled if MDAPI is enabled.

## Testing Done

Verified that an MDAPI command queue may be created from properties.