### PR TITLE
export OpenCL 2.2 APIs on Windows

### DIFF
--- a/Src/clIntercept.def
+++ b/Src/clIntercept.def
@@ -132,6 +132,8 @@ EXPORTS
     clSetKernelArgSVMPointer
     clSetKernelExecInfo
     clSetMemObjectDestructorCallback
+    clSetProgramReleaseCallback
+    clSetProgramSpecializationConstant
     clSetUserEventStatus
     clSVMAlloc
     clSVMFree


### PR DESCRIPTION
## Description of Changes

The OpenCL 2.2 entry points were exported from the Linux .so but not from the Windows DLL.  This fixes the exports so the OpenCL 2.2 entry points are exported on Windows, also. 

## Testing Done

Checked that entry points are correctly exported using "dumpbin /exports".