### PR TITLE
added instructions to dump CPU ISA

### DIFF
--- a/docs/kernel_isa.md
+++ b/docs/kernel_isa.md
@@ -1,98 +1,12 @@
 # Kernel ISA
 
 This document describes how to use the Intercept Layer for OpenCL Applications to
-retrieve kernel ISA.  This feature currently works with most Intel GPU OpenCL
-devices and most driver versions.  Support for other devices may be added at a
-later date.
+retrieve kernel ISA.  This feature currently works with most Intel CPU OpenCL
+devices and most Intel GPU OpenCL devices, with most driver versions.  Support
+for other devices may be added at a later date.
 
-## Tools
-
-You will need:
-
-* The Intercept Layer for OpenCL Applications
-* A Kernel ISA Binary Disassembler
-
-## Process
-
-Retrieving kernel ISA is a two step process:  The first step is to dump kernel
-ISA in binary form.  Then, the kernel ISA binaries can be disassembled to view
-the kernel ISA in text form.
-
-### Dumping Kernel ISA Binaries
-
-Dumping kernel ISA binaries is the easy part!  Simply install the Intercept
-Layer for OpenCL Applications, set `DumpKernelISABinaries`, and execute your
-application.  Then, every time our application calls `clBuildProgram`, the
-Intercept Layer for OpenCL Applications will dump an ISA binary for each
-kernel in the program.
-
-How does this work?  Drivers for Intel GPU OpenCL devices support a kernel
-query for the kernel ISA binary.
-
-### Building an Intel GPU ISA Disassembler
-
-This section describes how to build an Intel GPU ISA disassembler, which can
-be used to disassemble a kernel ISA binary to view the kernel ISA in text form.
-The particular Intel GPU ISA disassembler we'll be using is `IGA`, which is
-part of the Intel Graphics Compiler (IGC).
-
-The first step is to get the Intel Graphics Compiler source code.  From a
-directory where you want to build `IGA`:
-
-    git clone https://github.com/intel/intel-graphics-compiler.git
-
-We're only going to build `IGA`, and not all of IGC.  So, change to the
-`IGA` directory in the repo we just cloned:
-
-    cd intel-graphics-compiler/visa/iga
-
-`IGA` creates its build files using CMake, just like the Intercept Layer for
-OpenCL Applications.  So, create a `build` directory for build files, and
-run cmake from this build directory:
-
-    mkdir build
-    cd build
-    cmake .. -DCMAKE_BUILD_TYPE=Release
-
-This should create build files without errors or warnings.  After build
-files have been created, either use them directly to build `IGA`, or invoke
-CMake to perform the build.  For example:
-
-    cmake --build . --config Release
-
-If all goes well, this will successfully build an `IGA` executable.
-Note that the exact location of the executable will be dependent on
-the operating system you are building on, and the configuration you
-are building.
-
-### Using the Intel GPU ISA Disassembler
-
-Disassembling a kernel ISA binary using `IGA` is a mostly straightforward
-process.  You'll want to tell `IGA` to disassemble your file (`-d`), the
-device your kernel ISA binary was compiled for (`-p`), and your kernel ISA
-binary file name.  For example:
-
-    ./iga32 -d -p 8 CLI_0000_3F40E1CD_0000_GPU_GenerateJuliaSet.isabin
-
-The table below describes the mapping between Intel processor code names and
-GPU devices:
-
-| Processor | Code Name | Device |
-|:----------|:---------:|:------:|
-|[Broadwell](https://ark.intel.com/products/codename/38530/Broadwell) | BDW | GEN8 |
-|[Cherry Trail](https://ark.intel.com/products/codename/46629/Cherry-Trail) | CHV | GEN8LP |
-|[Skylake](https://ark.intel.com/products/codename/37572/Skylake) | SKL | GEN9 |
-|[Apollo Lake](https://ark.intel.com/products/codename/80644/Apollo-Lake) | BXT | GEN9LP |
-|[Kaby Lake](https://ark.intel.com/products/codename/82879/Kaby-Lake) | KBL | GEN9.5 |
-
-Here is a helpful link that describes the Intel GPU ISA:
-
-https://software.intel.com/en-us/articles/introduction-to-gen-assembly
-
-### Disassembling Many Kernel ISA Binaries
-
-The Python script [../scripts/disassemble_all.py](../scripts/disassemble_all.py)
-may be useful to invoke a disassembler on all ISA binaries in a specified directory.
+* [Retrieving Intel CPU ISA](docs/kernel_isa_cpu.md)
+* [Retrieving Intel GPU ISA](docs/kernel_isa_gpu.md)
 
 ---
 

--- a/docs/kernel_isa_cpu.md
+++ b/docs/kernel_isa_cpu.md
@@ -1,0 +1,48 @@
+# Kernel ISA
+
+This document describes how to use the Intercept Layer for OpenCL Applications to
+retrieve kernel ISA for Intel CPU Devices.
+
+## Tools
+
+You will need:
+
+* The Intercept Layer for OpenCL Applications
+* `readelf`, `dd`, and `objdump` Utilities (or equivalents)
+
+## Process
+
+Retrieving kernel ISA is a two step process:  The first step is to dump program
+binaries while your application is executing.  Then, the program binaries can be
+disassembled to view the kernel ISA in text form.
+
+### Dumping Program Binaries
+
+Dumping program binaries is the easy part!  Simply install the Intercept
+Layer for OpenCL Applications, set `DumpProgramBinaries`, and execute your
+application.  Then, every time our application calls `clBuildProgram`, the
+Intercept Layer for OpenCL Applications will dump the program binary.
+
+### Disassembling Program Binaries
+
+For the Intel CPU device, the program binary is an ELF file.  ELF files consist
+of multiple "sections".  The kernel ISA is stored in the ".ocl.obj" section.
+So, the steps to dissemble the program binary consists of:
+
+1. Extracting the kernel ISA from the ".ocl.obj" section of the program binary.
+1. Disassembling the extracted kernel ISA.
+
+There are many possible ways to do this, but the script
+[disassemble_cpu.sh](../scripts/disassemble_cpu.sh) shows one method using the
+common tools `readelf`, `dd`, and `objdump`.
+
+### Disassembling Many Kernel ISA Binaries
+
+The Python script [../scripts/disassemble_all_cpu.py](../scripts/disassemble_all_cpu.py)
+may be useful to disassemble all program binaries in a specified directory.
+
+---
+
+\* Other names and brands may be claimed as the property of others.
+
+Copyright (c) 2018, Intel(R) Corporation

--- a/docs/kernel_isa_gpu.md
+++ b/docs/kernel_isa_gpu.md
@@ -1,0 +1,99 @@
+# Kernel ISA
+
+This document describes how to use the Intercept Layer for OpenCL Applications to
+retrieve kernel ISA for Intel GPU devices.
+
+## Tools
+
+You will need:
+
+* The Intercept Layer for OpenCL Applications
+* A Kernel ISA Binary Disassembler
+
+## Process
+
+Retrieving kernel ISA is a two step process:  The first step is to dump kernel
+ISA in binary form.  Then, the kernel ISA binaries can be disassembled to view
+the kernel ISA in text form.
+
+### Dumping Kernel ISA Binaries
+
+Dumping kernel ISA binaries is the easy part!  Simply install the Intercept
+Layer for OpenCL Applications, set `DumpKernelISABinaries`, and execute your
+application.  Then, every time our application calls `clBuildProgram`, the
+Intercept Layer for OpenCL Applications will dump an ISA binary for each
+kernel in the program.
+
+How does this work?  Drivers for Intel GPU OpenCL devices support a kernel
+query for the kernel ISA binary.
+
+### Building an Intel GPU ISA Disassembler
+
+This section describes how to build an Intel GPU ISA disassembler, which can
+be used to disassemble a kernel ISA binary to view the kernel ISA in text form.
+The particular Intel GPU ISA disassembler we'll be using is `IGA`, which is
+part of the Intel Graphics Compiler (IGC).
+
+The first step is to get the Intel Graphics Compiler source code.  From a
+directory where you want to build `IGA`:
+
+    git clone https://github.com/intel/intel-graphics-compiler.git
+
+We're only going to build `IGA`, and not all of IGC.  So, change to the
+`IGA` directory in the repo we just cloned:
+
+    cd intel-graphics-compiler/visa/iga
+
+`IGA` creates its build files using CMake, just like the Intercept Layer for
+OpenCL Applications.  So, create a `build` directory for build files, and
+run cmake from this build directory:
+
+    mkdir build
+    cd build
+    cmake .. -DCMAKE_BUILD_TYPE=Release
+
+This should create build files without errors or warnings.  After build
+files have been created, either use them directly to build `IGA`, or invoke
+CMake to perform the build.  For example:
+
+    cmake --build . --config Release
+
+If all goes well, this will successfully build an `IGA` executable.
+Note that the exact location of the executable will be dependent on
+the operating system you are building on, and the configuration you
+are building.
+
+### Using the Intel GPU ISA Disassembler
+
+Disassembling a kernel ISA binary using `IGA` is a mostly straightforward
+process.  You'll want to tell `IGA` to disassemble your file (`-d`), the
+device your kernel ISA binary was compiled for (`-p`), and your kernel ISA
+binary file name.  For example:
+
+    ./iga32 -d -p 8 CLI_0000_3F40E1CD_0000_GPU_GenerateJuliaSet.isabin
+
+The table below describes the mapping between Intel processor code names and
+GPU devices:
+
+| Processor | Code Name | Device |
+|:----------|:---------:|:------:|
+|[Broadwell](https://ark.intel.com/products/codename/38530/Broadwell) | BDW | GEN8 |
+|[Cherry Trail](https://ark.intel.com/products/codename/46629/Cherry-Trail) | CHV | GEN8LP |
+|[Skylake](https://ark.intel.com/products/codename/37572/Skylake) | SKL | GEN9 |
+|[Apollo Lake](https://ark.intel.com/products/codename/80644/Apollo-Lake) | BXT | GEN9LP |
+|[Kaby Lake](https://ark.intel.com/products/codename/82879/Kaby-Lake) | KBL | GEN9.5 |
+
+Here is a helpful link that describes the Intel GPU ISA:
+
+https://software.intel.com/en-us/articles/introduction-to-gen-assembly
+
+### Disassembling Many Kernel ISA Binaries
+
+The Python script [../scripts/disassemble_all_gpu.py](../scripts/disassemble_all_gpu.py)
+may be useful to invoke a disassembler on all ISA binaries in a specified directory.
+
+---
+
+\* Other names and brands may be claimed as the property of others.
+
+Copyright (c) 2018, Intel(R) Corporation

--- a/scripts/disassemble_all_cpu.py
+++ b/scripts/disassemble_all_cpu.py
@@ -32,13 +32,13 @@ else:
 if len(sys.argv) > 2:
     commandToRun = sys.argv[2]
 else:
-    commandToRun = 'iga32 -d -p 9'
+    commandToRun = './disassemble_cpu.sh'
 
 if ( len(sys.argv) == 2 ) and ( sys.argv[1] == '-h' or sys.argv[1] == '-?' ):
     printHelp = True
 
 if printHelp:
-    print('usage: disassemble_all.py {required: directory with isabin files} {optional: command to run, default: "iga32 -d -p 9"}')
+    print('usage: disassemble_all_cpu.py {required: directory with .bin files} {optional: command to run, default: "disassemble_cpu.sh"}')
 elif not os.path.exists(isabinDir):
     print('error: directory ' + isabinDir + ' does not exist!')
 else:
@@ -47,11 +47,12 @@ else:
     numberOfFiles = 0
 
     for file in os.listdir(isabinDir):
-        if file.endswith(".isabin"):
-            numberOfFiles = numberOfFiles = 1
+        if file.endswith("_CPU.bin"):
+            numberOfFiles = numberOfFiles + 1
             binFileName = isabinDir + '/' + file;
-            isaFileName = isabinDir + '/' + file[:-7] + '.isa';	# strip .isabin, add .isa
+            objFileName = isabinDir + '/' + file[:-8] + '.obj';	# strip _CPU.bin, add .obj
+            isaFileName = isabinDir + '/' + file[:-8] + '.isa';	# strip _CPU.bin, add .isa
             print('Disassembling ' + binFileName)
-            subprocess.call(commandToRun.split() + [binFileName, '-o', isaFileName])
+            subprocess.call(commandToRun.split() + [binFileName, objFileName, isaFileName])
 
     print('Found ' + str(numberOfFiles) + ' file(s) to disassemble.')

--- a/scripts/disassemble_all_gpu.py
+++ b/scripts/disassemble_all_gpu.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2018 Intel Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import subprocess
+import sys
+
+printHelp = False
+
+if len(sys.argv) > 1:
+    isabinDir = sys.argv[1]
+else:
+    printHelp = True
+
+if len(sys.argv) > 2:
+    commandToRun = sys.argv[2]
+else:
+    commandToRun = 'iga32 -d -p 9'
+
+if ( len(sys.argv) == 2 ) and ( sys.argv[1] == '-h' or sys.argv[1] == '-?' ):
+    printHelp = True
+
+if printHelp:
+    print('usage: disassemble_all_gpu.py {required: directory with isabin files} {optional: command to run, default: "iga32 -d -p 9"}')
+elif not os.path.exists(isabinDir):
+    print('error: directory ' + isabinDir + ' does not exist!')
+else:
+    print('Running "' + commandToRun + '" to disassemble all isabin files in: ' + isabinDir + ':')
+
+    numberOfFiles = 0
+
+    for file in os.listdir(isabinDir):
+        if file.endswith(".isabin"):
+            numberOfFiles = numberOfFiles + 1
+            binFileName = isabinDir + '/' + file;
+            isaFileName = isabinDir + '/' + file[:-7] + '.isa';	# strip .isabin, add .isa
+            print('Disassembling ' + binFileName)
+            subprocess.call(commandToRun.split() + [binFileName, '-o', isaFileName])
+
+    print('Found ' + str(numberOfFiles) + ' file(s) to disassemble.')

--- a/scripts/disassemble_cpu.sh
+++ b/scripts/disassemble_cpu.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# Copyright (c) 2018 Intel Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -e
+
+if [ "$#" -ne 3 ]; then
+    echo "Usage: disassemble_cpu.sh <opencl_binary.bin> <opencl_binary.isabin> <opencl_binary.isa>"
+    exit 1
+fi
+
+ocl_elf=$1
+ocl_obj=$2
+ocl_isa=$3
+section=.ocl.obj
+
+start_hex=$(readelf -a $ocl_elf | grep $section | tr -s ' ' | cut -f7 -d' ')
+size_hex=$(readelf -a $ocl_elf | grep $section -A1 | tail -n1 | tr -s ' ' | cut -f2 -d' ')
+
+start=$(printf "%d" 0x$start_hex)
+size=$(printf "%d" 0x$size_hex)
+
+dd skip=$start count=$size if=$ocl_elf of=$ocl_obj bs=1
+objdump -d -m i386:x86-64 $ocl_obj > $ocl_isa


### PR DESCRIPTION
## Description of Changes

Extends "kernel ISA" documentation to describe how to retrieve ISA for Intel CPU devices in addition to Intel GPU devices.

## Testing Done

Followed the directions and used the provided scripts to dump Intel CPU ISA in addition to Intel GPU ISA.