### PR TITLE
Add ability to append Process ID to log dir

### DIFF
--- a/OS/OS_linux_common.cpp
+++ b/OS/OS_linux_common.cpp
@@ -33,6 +33,7 @@ namespace OS
 const char* Services_Common::ENV_PREFIX = "";
 const char* Services_Common::CONFIG_FILE = "config.conf";
 const char* Services_Common::LOG_DIR = NULL;
+bool Services_Common::APPEND_PID = false;
 
 Services_Common::Services_Common()
 {

--- a/OS/OS_linux_common.h
+++ b/OS/OS_linux_common.h
@@ -66,6 +66,7 @@ public:
     static const char* ENV_PREFIX;
     static const char* CONFIG_FILE;
     static const char* LOG_DIR;
+    static bool        APPEND_PID;
 
     Services_Common();
     ~Services_Common();
@@ -102,6 +103,9 @@ public:
                 const std::string& functionName ) const;
 
     void    GetDumpDirectoryName(
+                const std::string& subDir,
+                std::string& directoryName ) const;
+    void    GetDumpDirectoryNameWithoutPid(
                 const std::string& subDir,
                 std::string& directoryName ) const;
     void    GetDumpDirectoryNameWithoutProcessName(
@@ -224,7 +228,7 @@ inline void* Services_Common::GetFunctionPointer(
     }
 }
 
-inline void Services_Common::GetDumpDirectoryName(
+inline void Services_Common::GetDumpDirectoryNameWithoutPid(
     const std::string& subDir,
     std::string& directoryName ) const
 {
@@ -261,6 +265,18 @@ inline void Services_Common::GetDumpDirectoryName(
 #ifdef __ANDROID__
     __android_log_print(ANDROID_LOG_INFO, "clIntercept", "dumpDir=%s\n", directoryName.c_str());
 #endif
+}
+
+inline void Services_Common::GetDumpDirectoryName(
+    const std::string& subDir,
+    std::string& directoryName ) const
+{
+    GetDumpDirectoryNameWithoutPid(subDir, directoryName);
+    if( APPEND_PID )
+    {
+        directoryName += ".";
+        directoryName += std::to_string(GetProcessID());
+    }
 }
 
 inline void Services_Common::GetDumpDirectoryNameWithoutProcessName(

--- a/OS/OS_mac_common.cpp
+++ b/OS/OS_mac_common.cpp
@@ -28,6 +28,7 @@ namespace OS
 const char* Services_Common::ENV_PREFIX = "";
 const char* Services_Common::CONFIG_FILE = "config.conf";
 const char* Services_Common::LOG_DIR = NULL;
+bool Services_Common::APPEND_PID = false;
 
 Services_Common::Services_Common()
 {

--- a/OS/OS_mac_common.h
+++ b/OS/OS_mac_common.h
@@ -62,6 +62,7 @@ public:
     static const char* ENV_PREFIX;
     static const char* CONFIG_FILE;
     static const char* LOG_DIR;
+    static bool        APPEND_PID;
 
     Services_Common();
     ~Services_Common();
@@ -98,6 +99,9 @@ public:
                 const std::string& functionName ) const;
 
     void    GetDumpDirectoryName(
+                const std::string& subDir,
+                std::string& directoryName ) const;
+    void    GetDumpDirectoryNameWithoutPid(
                 const std::string& subDir,
                 std::string& directoryName ) const;
     void    GetDumpDirectoryNameWithoutProcessName(
@@ -214,7 +218,7 @@ inline void* Services_Common::GetFunctionPointer(
     }
 }
 
-inline void Services_Common::GetDumpDirectoryName(
+inline void Services_Common::GetDumpDirectoryNameWithoutPid(
     const std::string& subDir,
     std::string& directoryName ) const
 {
@@ -243,6 +247,18 @@ inline void Services_Common::GetDumpDirectoryName(
         }
 
         directoryName += pProcessName;
+    }
+}
+
+inline void Services_Common::GetDumpDirectoryName(
+    const std::string& subDir,
+    std::string& directoryName ) const
+{
+    GetDumpDirectoryNameWithoutPid(subDir, directoryName);
+    if( APPEND_PID )
+    {
+       directoryName += ".";
+       directoryName += std::to_string(GetProcessID());
     }
 }
 

--- a/OS/OS_windows_common.cpp
+++ b/OS/OS_windows_common.cpp
@@ -28,6 +28,7 @@ namespace OS
 const char* Services_Common::ENV_PREFIX = "";
 const char* Services_Common::REGISTRY_KEY = "SOFTWARE\\INTEL\\IGFX";
 const char* Services_Common::LOG_DIR = NULL;
+bool Services_Common::APPEND_PID = false;
 
 Services_Common::Services_Common()
 {

--- a/OS/OS_windows_common.h
+++ b/OS/OS_windows_common.h
@@ -58,6 +58,7 @@ public:
     static const char* ENV_PREFIX;
     static const char* REGISTRY_KEY;
     static const char* LOG_DIR;
+    static bool        APPEND_PID;
 
     Services_Common();
     ~Services_Common();
@@ -94,6 +95,9 @@ public:
                 const std::string& functionName ) const;
 
     void    GetDumpDirectoryName(
+                const std::string& subDir,
+                std::string& directoryName ) const;
+    void    GetDumpDirectoryNameWithoutPid(
                 const std::string& subDir,
                 std::string& directoryName ) const;
     void    GetDumpDirectoryNameWithoutProcessName(
@@ -303,7 +307,7 @@ inline void* Services_Common::GetFunctionPointer(
     }
 }
 
-inline void Services_Common::GetDumpDirectoryName(
+inline void Services_Common::GetDumpDirectoryNameWithoutPid(
     const std::string& subDir,
     std::string& directoryName ) const
 {
@@ -331,6 +335,18 @@ inline void Services_Common::GetDumpDirectoryName(
 
     // Add the process name to the directory name.
     directoryName += GetProcessName();
+}
+
+inline void Services_Common::GetDumpDirectoryName(
+    const std::string& subDir,
+    std::string& directoryName ) const
+{
+    GetDumpDirectoryNameWithoutPid(subDir, directoryName);
+    if( APPEND_PID )
+    {
+        directoryName += ".";
+        directoryName += std::to_string(GetProcessID());
+    }
 }
 
 inline void Services_Common::GetDumpDirectoryNameWithoutProcessName(

--- a/Src/controls.h
+++ b/Src/controls.h
@@ -52,6 +52,7 @@ CLI_CONTROL( bool,          EventChecking,                          false, "If s
 CLI_CONTROL( bool,          LeakChecking,                           false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will check for leaks of various OpenCL objects, such as memory objects and events." )
 CLI_CONTROL( bool,          CLInfoLogging,                          false, "If set to a nonzero value, logs information about the platforms and devices in the system on the first call to clGetPlatformIDs()." )
 CLI_CONTROL( std::string,   LogDir,                                 "",    "If set, the Intercept Layer for OpenCL Applications will emit logs to this directory instead of the default log directory." )
+CLI_CONTROL( bool,   AppendPid,                                     false, "If set, the Intercept Layer for OpenCL Applications will append process ID to the log directory name." )
 CLI_CONTROL( bool,          KernelNameHashTracking,                 false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will append the program and build option hashes to the kernel name in logs and reports." )
 CLI_CONTROL( cl_uint,       LongKernelNameCutoff,                   UINT_MAX, "If an OpenCL application uses kernels with very long names, the Intercept Layer for OpenCL Applications can substitute a \"short\" kernel identifier for a \"long\" kernel name in logs and reports.  This control defines how long a kernel name must be (in characters) before it is replaced by a \"short\" kernel identifier." )
 

--- a/Src/intercept.cpp
+++ b/Src/intercept.cpp
@@ -374,6 +374,8 @@ bool CLIntercept::init()
             std::replace( m_Config.LogDir.begin(), m_Config.LogDir.end(), '\\', '/' );
             OS::Services_Common::LOG_DIR = m_Config.LogDir.c_str();
         }
+
+        OS::Services_Common::APPEND_PID = m_Config.AppendPid;
 #endif
         OS().GetDumpDirectoryName( sc_DumpDirectoryName, fileName );
         fileName += "/";
@@ -2975,7 +2977,7 @@ bool CLIntercept::injectProgramSource(
 
     // Get the dump directory name.
     {
-        OS().GetDumpDirectoryName( sc_DumpDirectoryName, fileName );
+        OS().GetDumpDirectoryNameWithoutPid( sc_DumpDirectoryName, fileName );
         fileName += "/Inject";
     }
 
@@ -3086,7 +3088,7 @@ bool CLIntercept::prependProgramSource(
 
     // Get the dump directory name.
     {
-        OS().GetDumpDirectoryName( sc_DumpDirectoryName, fileName );
+        OS().GetDumpDirectoryNameWithoutPid( sc_DumpDirectoryName, fileName );
         fileName += "/Inject";
     }
 
@@ -3217,7 +3219,7 @@ bool CLIntercept::injectProgramSPIRV(
 
     // Get the dump directory name.
     {
-        OS().GetDumpDirectoryName( sc_DumpDirectoryName, fileName );
+        OS().GetDumpDirectoryNameWithoutPid( sc_DumpDirectoryName, fileName );
         fileName += "/Inject";
     }
 
@@ -3320,7 +3322,7 @@ bool CLIntercept::injectProgramOptions(
 
     // Get the dump directory name.
     {
-        OS().GetDumpDirectoryName( sc_DumpDirectoryName, fileName );
+        OS().GetDumpDirectoryNameWithoutPid( sc_DumpDirectoryName, fileName );
         fileName += "/Inject";
     }
     // Make four candidate filenames.  They will have the form:
@@ -6553,7 +6555,7 @@ cl_program CLIntercept::createProgramWithInjectionBinaries(
 
         // Get the dump directory name.
         {
-            OS().GetDumpDirectoryName( sc_DumpDirectoryName, fileName );
+            OS().GetDumpDirectoryNameWithoutPid( sc_DumpDirectoryName, fileName );
             fileName += "/Inject";
         }
         // Make two candidate filenames.  They will have the form:
@@ -7197,7 +7199,7 @@ cl_program CLIntercept::createProgramWithInjectionSPIRV(
 
         // Get the dump directory name.
         {
-            OS().GetDumpDirectoryName(sc_DumpDirectoryName, fileName);
+            OS().GetDumpDirectoryNameWithoutPid(sc_DumpDirectoryName, fileName);
             fileName += "/Inject";
         }
 

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -174,6 +174,10 @@ If set to a nonzero value, logs information about the platforms and devices in t
 
 If set, the Intercept Layer for OpenCL Applications will emit logs to this directory instead of the default log directory.
 
+##### `AppendPid` (bool)
+
+If set, the Intercept Layer for OpenCL Applications will append process ID to log directory name.
+
 ##### `KernelNameHashTracking` (bool)
 
 If set to a nonzero value, the Intercept Layer for OpenCL Applications will append the program and build option hashes to the kernel name in logs and reports.

--- a/docs/injecting_programs.md
+++ b/docs/injecting_programs.md
@@ -18,6 +18,8 @@ or:
 
 This directory will also be used for program injection.
 
+**Note.** If `AppendPid` option is enabled, dumps will be saved to the `<Process Name>.PID` directory, but `<Process Name>` directory will be used for program injection.
+
 ## Step 2: Find the Program or Program Options to Modify
 
 Look through the dump directory to find the program(s) or program options you'd


### PR DESCRIPTION
## Description of Changes

This PR adds an option to add PID to output directory name. When enabled, log dir name will look like `myprocess.exe.3089`. But for injecting purposes the directory without PID will be used (e.g. `myprocess.exe`). This has two major applications:
1.  One does a lot of sequential runs of the same application.
2. A program starts several processes with the same name.

## Testing Done

I successfully used it on my Windows machine to debug application.
