### PR TITLE
extend Android context tracking to clCreateContextFromType

### DIFF
--- a/Src/dispatch.cpp
+++ b/Src/dispatch.cpp
@@ -544,6 +544,11 @@ CL_API_ENTRY cl_context CL_API_CALL CLIRN(clCreateContextFromType)(
         ADD_OBJECT_ALLOCATION( retVal );
         CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
+#ifdef __ANDROID__
+        mContextCount.lock();
+        contextCount ++;
+        mContextCount.unlock();
+#endif
         return retVal;
     }
     else


### PR DESCRIPTION
## Description of Changes

As a workaround, the Intercept Layer currently issues its report by tracking the number of active contexts and reporting when the number of active contexts goes to zero, vs. reporting as part of the shared library destructor.  The code to increment the number of shared contexts existed in the clCreateContext API, but not as part of the clCreateContextFromType API.  This change adds the missing code to the clCreateContextFromType API.

## Testing Done

I've only verified that Windows and Linux builds are unaffected.