### PR TITLE
fix typo breaking Linux cliloader build

### DIFF
--- a/cliloader/cliloader.cpp
+++ b/cliloader/cliloader.cpp
@@ -557,7 +557,7 @@ int main(int argc, char *argv[])
     if( found == false )
     {
         // Next, check a lib directory.
-        std::string libPath = path + "/../" + CLIPROF_LIB_DIR;
+        std::string libPath = path + "/../" + CLILOADER_LIB_DIR;
         found = getEnvVars( libPath, ld_preload, ld_library_path );
     }
     if( found )


### PR DESCRIPTION
## Description of Changes

I changed the LIB_DIR define for cliloader at the last minute and forgot to update the code for the Linux build.

## Testing Done

Built cliloader on Linux.