### PR TITLE
query for the device platform vs. passing NULL to get MDAPI queue

### DIFF
--- a/mdapi/intercept_mdapi.cpp
+++ b/mdapi/intercept_mdapi.cpp
@@ -120,8 +120,19 @@ cl_command_queue CLIntercept::createMDAPICommandQueue(
 {
     cl_command_queue    retVal = NULL;
 
+    // Note: This works fine for one device, but if there are two
+    // devices then we will need a different mechanism to get a
+    // device-specific function pointer.
+
+    cl_platform_id  platform = NULL;
+    dispatch().clGetDeviceInfo(
+        device,
+        CL_DEVICE_PLATFORM,
+        sizeof(platform),
+        &platform,
+        NULL );
     getExtensionFunctionAddress(
-        NULL,
+        platform,
         "clCreatePerfCountersCommandQueueINTEL" );
 
     if( dispatch().clCreatePerfCountersCommandQueueINTEL && m_pMDHelper )


### PR DESCRIPTION
## Description of Changes

Previously, the code to get a function pointer to the "create a command queue that supports MDAPI" function passed NULL for the platform.  This is fine if there is only one platform installed on the system, but it isn't if there are multiple platforms installed on the system.  To fix this issue, query the platform first (using either the passed-in context or device, either is fine) and pass it instead of NULL.

## Testing Done

Enabled MDAPI counters and verified that they were properly collected (tested on Windows).