### PR TITLE
handle the case where HOME is not set on Linux

### DIFF
--- a/OS/OS_linux_common.cpp
+++ b/OS/OS_linux_common.cpp
@@ -78,7 +78,8 @@ bool Services_Common::ReadRegistry(
 
     const char *envVal = getenv("HOME");
 #ifdef __ANDROID__
-    // if ho HOME on Android then use sdcard folder
+    // If there is no HOME environment variable on Android,
+    // default to the sdcard folder:
     if( envVal == NULL )
     {
         configFile = "/sdcard";
@@ -88,7 +89,12 @@ bool Services_Common::ReadRegistry(
         configFile = envVal;
     }
 #else
-    configFile = envVal;
+    // For non-Android, default to the root directory if there
+    // is no HOME environment variable.
+    if( envVal != NULL )
+    {
+        configFile = envVal;
+    }
 #endif
     configFile += "/";
     configFile += CONFIG_FILE;


### PR DESCRIPTION
## Description of Changes

It's possible that the HOME environment variable is not set in some rare cases.  On Linux, this results in a crash, since it tries to assign a NULL pointer to a std::string.  This change handles the case where the HOME environment variable is not set.  It'll search the root directory for the config file instead, which will probably fail, but it will not result in a crash.

## Testing Done

None - making this change as a result of a bug report where a test was executed via `execve`, without setting the HOME environment variable.