### PR TITLE
add case sensitivity description to controls doc

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -66,6 +66,18 @@ To list all environment variable controls, you could type:
 
     env | grep CLI_
 
+### Case Sensitivity
+
+Controls should generally be considered case sensitive.  Some methods of
+setting controls on some operating systems may treat controls as case
+insensitive, but it is unsafe to rely on case insensitive behavior.
+
+### Control Verification
+
+To verify that a control has been set correctly and is taking effect,
+please check the Intercept Layer for OpenCL Applications log file, which
+will record any controls that are set to non-default values.
+
 ### Setup and Loading Controls
 
 ##### `DllName` (string)

--- a/scripts/generate_controls_doc.py
+++ b/scripts/generate_controls_doc.py
@@ -92,6 +92,18 @@ To list all environment variable controls, you could type:
 
     env | grep CLI_
 
+### Case Sensitivity
+
+Controls should generally be considered case sensitive.  Some methods of
+setting controls on some operating systems may treat controls as case
+insensitive, but it is unsafe to rely on case insensitive behavior.
+
+### Control Verification
+
+To verify that a control has been set correctly and is taking effect,
+please check the Intercept Layer for OpenCL Applications log file, which
+will record any controls that are set to non-default values.
+
 ### Setup and Loading Controls
 
 ##### `DllName` (string)


### PR DESCRIPTION
## Description of Changes

Commit 3d536ee04a847ac3d890cac2ab575e7366bf8e37 fixed a case sensitivity typo in one of the controls docs.  This commit further updates the controls doc to explicitly say that controls should be considered case sensitive, and that the log file will describe controls which are set to non-default values to verify that a control is correctly set.

## Testing Done

No functional changes, doc update.