### PR TITLE
added support for loading controls from a system directory

### DIFF
--- a/OS/OS_linux_common.h
+++ b/OS/OS_linux_common.h
@@ -65,6 +65,7 @@ class Services_Common
 public:
     static const char* ENV_PREFIX;
     static const char* CONFIG_FILE;
+    static const char* SYSTEM_DIR;
     static const char* LOG_DIR;
     static bool        APPEND_PID;
 
@@ -81,7 +82,7 @@ public:
 
     std::string GetProcessName() const;
 
-    bool    ReadRegistry(
+    bool    GetControl(
                 const std::string& name,
                 void* pValue,
                 size_t size ) const;
@@ -117,6 +118,12 @@ public:
 private:
     Timer           m_Timer;
     pthread_mutex_t m_CriticalSection;
+
+    bool    GetControlFromFile(
+                const std::string& fileName,
+                const std::string& controlName,
+                void* pValue,
+                size_t size ) const;
 
     DISALLOW_COPY_AND_ASSIGN( Services_Common );
 };

--- a/OS/OS_mac_common.cpp
+++ b/OS/OS_mac_common.cpp
@@ -27,6 +27,7 @@ namespace OS
 
 const char* Services_Common::ENV_PREFIX = "";
 const char* Services_Common::CONFIG_FILE = "config.conf";
+const char* Services_Common::SYSTEM_DIR = "/etc";
 const char* Services_Common::LOG_DIR = NULL;
 bool Services_Common::APPEND_PID = false;
 
@@ -39,7 +40,7 @@ Services_Common::~Services_Common()
     pthread_mutex_destroy( &m_CriticalSection );
 }
 
-bool Services_Common::ReadRegistry(
+bool Services_Common::GetControl(
     const std::string& name,
     void* pValue,
     size_t size ) const
@@ -63,19 +64,52 @@ bool Services_Common::ReadRegistry(
         }
     }
 
-    // Look at the config file second:
+    // Look at config files second:
+    bool    found = false;
+    std::string fileName;
+
+    // First, check for a config file in the HOME directory.
+    const char *envVal = getenv("HOME");
+    if( !found && envVal != NULL )
+    {
+        fileName = envVal;
+        fileName += "/";
+        fileName += CONFIG_FILE;
+        found = GetControlFromFile(
+            fileName,
+            name,
+            pValue,
+            size );
+    }
+
+    // Finally, check the "system" directory.
+    if( !found )
+    {
+        fileName = SYSTEM_DIR;
+        fileName += "/";
+        fileName += CONFIG_FILE;
+        found = GetControlFromFile(
+            fileName,
+            name,
+            pValue,
+            size );
+    }
+
+    return found;
+}
+
+bool Services_Common::GetControlFromFile(
+    const std::string& fileName,
+    const std::string& controlName,
+    void* pValue,
+    size_t size ) const
+{
     bool    found = false;
 
     std::ifstream   is;
     std::string     s;
 
-    std::string     configFile;
-
-    configFile = getenv("HOME");
-    configFile += "/";
-    configFile += CONFIG_FILE;
-
-    is.open( configFile.c_str() );
+    is.open( fileName.c_str() );
     if( is.fail() )
     {
         return false;
@@ -100,12 +134,12 @@ bool Services_Common::ReadRegistry(
         if( pos != std::string::npos )
         {
             std::string var = s.substr( 0, pos );
-            var.erase(remove_if(var.begin(), var.end(), ::isspace), var.end());
+            var.erase(std::remove_if(var.begin(), var.end(), ::isspace), var.end());
 
             std::string value = s.substr( pos + 1 );
-            value.erase(remove_if(value.begin(), value.end(), ::isspace), value.end());
+            value.erase(std::remove_if(value.begin(), value.end(), ::isspace), value.end());
 
-            if( var == name )
+            if( var == controlName )
             {
                 if( size == sizeof(unsigned int) )
                 {

--- a/OS/OS_mac_common.h
+++ b/OS/OS_mac_common.h
@@ -61,6 +61,7 @@ class Services_Common
 public:
     static const char* ENV_PREFIX;
     static const char* CONFIG_FILE;
+    static const char* SYSTEM_DIR;
     static const char* LOG_DIR;
     static bool        APPEND_PID;
 
@@ -77,7 +78,7 @@ public:
 
     std::string GetProcessName() const;
 
-    bool    ReadRegistry(
+    bool    GetControl(
                 const std::string& name,
                 void* pValue,
                 size_t size ) const;
@@ -112,6 +113,12 @@ public:
 
 private:
     pthread_mutex_t m_CriticalSection;
+
+    bool    GetControlFromFile(
+                const std::string& fileName,
+                const std::string& controlName,
+                void* pValue,
+                size_t size ) const;
 
     DISALLOW_COPY_AND_ASSIGN( Services_Common );
 };

--- a/OS/OS_windows_common.h
+++ b/OS/OS_windows_common.h
@@ -73,7 +73,7 @@ public:
 
     std::string GetProcessName() const;
 
-    bool    ReadRegistry(
+    bool    GetControl(
                 const std::string& name,
                 void* pValue,
                 size_t size ) const;
@@ -168,7 +168,7 @@ inline std::string Services_Common::GetProcessName() const
     return std::string(pProcessName);
 }
 
-inline bool Services_Common::ReadRegistry(
+inline bool Services_Common::GetControl(
     const std::string& name,
     void* pValue,
     size_t size ) const

--- a/Src/intercept.cpp
+++ b/Src/intercept.cpp
@@ -275,13 +275,13 @@ CLIntercept::~CLIntercept()
 ///////////////////////////////////////////////////////////////////////////////
 //
 template <class T>
-static bool ReadRegistry(
+static bool GetControl(
     const OS::Services& OS,
     const char* name,
     T& value )
 {
     unsigned int    readValue = 0;
-    bool success = OS.ReadRegistry( name, &readValue, sizeof(readValue) );
+    bool success = OS.GetControl( name, &readValue, sizeof(readValue) );
     if( success )
     {
         value = readValue;
@@ -290,13 +290,13 @@ static bool ReadRegistry(
     return success;
 }
 template <>
-bool ReadRegistry<bool>(
+bool GetControl<bool>(
     const OS::Services& OS,
     const char* name,
     bool& value )
 {
     unsigned int    readValue = 0;
-    bool success = OS.ReadRegistry( name, &readValue, sizeof(readValue) );
+    bool success = OS.GetControl( name, &readValue, sizeof(readValue) );
     if( success )
     {
         value = ( readValue != 0 );
@@ -305,13 +305,13 @@ bool ReadRegistry<bool>(
     return success;
 }
 template <>
-bool ReadRegistry<std::string>(
+bool GetControl<std::string>(
     const OS::Services& OS,
     const char* name,
     std::string& value )
 {
     char    readValue[256] = "";
-    bool success = OS.ReadRegistry( name, readValue, sizeof(readValue) );
+    bool success = OS.GetControl( name, readValue, sizeof(readValue) );
     if( success )
     {
         value = readValue;
@@ -340,10 +340,11 @@ bool CLIntercept::init()
 #elif defined(__linux__) || defined(__APPLE__)
     OS::Services_Common::ENV_PREFIX = "CLI_";
     OS::Services_Common::CONFIG_FILE = "clintercept.conf";
+    OS::Services_Common::SYSTEM_DIR = "/etc/OpenCL";
 #endif
 
     bool    breakOnLoad = false;
-    ReadRegistry( m_OS, "BreakOnLoad", breakOnLoad );
+    GetControl( m_OS, "BreakOnLoad", breakOnLoad );
 
     if( breakOnLoad )
     {
@@ -351,17 +352,17 @@ bool CLIntercept::init()
     }
 
     std::string dllName = "";
-    ReadRegistry( m_OS, "DllName", dllName );
+    GetControl( m_OS, "DllName", dllName );
 
     // A few control aliases, for backwards compatibility:
-    ReadRegistry( m_OS, "DevicePerformanceTimeHashTracking",m_Config.KernelNameHashTracking );
-    ReadRegistry( m_OS, "SimpleDumpProgram",                m_Config.SimpleDumpProgramSource );
-    ReadRegistry( m_OS, "DumpProgramsScript",               m_Config.DumpProgramSourceScript );
-    ReadRegistry( m_OS, "DumpProgramsInject",               m_Config.DumpProgramSource );
-    ReadRegistry( m_OS, "InjectPrograms",                   m_Config.InjectProgramSource );
-    ReadRegistry( m_OS, "LogDir",                           m_Config.DumpDir );
+    GetControl( m_OS, "DevicePerformanceTimeHashTracking",m_Config.KernelNameHashTracking );
+    GetControl( m_OS, "SimpleDumpProgram",                m_Config.SimpleDumpProgramSource );
+    GetControl( m_OS, "DumpProgramsScript",               m_Config.DumpProgramSourceScript );
+    GetControl( m_OS, "DumpProgramsInject",               m_Config.DumpProgramSource );
+    GetControl( m_OS, "InjectPrograms",                   m_Config.InjectProgramSource );
+    GetControl( m_OS, "LogDir",                           m_Config.DumpDir );
 
-#define CLI_CONTROL( _type, _name, _init, _desc ) ReadRegistry( m_OS, #_name, m_Config . _name );
+#define CLI_CONTROL( _type, _name, _init, _desc ) GetControl( m_OS, #_name, m_Config . _name );
 #include "controls.h"
 #undef CLI_CONTROL
 

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -36,17 +36,25 @@ will still read registry keys from:
 
 If a registry is set in both HKCU and HKLM, the setting in HKCU will "win".
 
-### Linux Configuration Files
+### Linux, Android, and OSX Configuration Files
 
 On Linux, the Intercept Layer for OpenCL Applications will read control values
-from ~/clintercept.conf.  Controls may be set by putting the control on its own
-line, followed by an equals sign, followed by the value you'd like to set the
-option to.  Lines that begin with a semi-colon(";"), a hash mark ("#"), or a
-C++-style comment ("//") are ignored.  For example, to enable CallLogging, put
-a line in your ~/clintercept.conf that looks like:
+from a config file named clintercept.conf.  Controls in a config file may be
+set by putting the control on its own line, followed by an equals sign,
+followed by the value to set the control to.  Lines that begin with a
+semi-colon (";"), a hash mark ("#"), or a C++-style comment ("//") are
+ignored.  For example, to enable CallLogging, put a line in your 
+clintercept.conf that looks like:
 
     // Enable CallLogging:
     CallLogging=1
+
+The Intercept Layer for OpenCL Applications will search for config files in
+the following directories, in order:
+
+* The current user's HOME directory (`~`).
+* The `sdcard` directory (for Android only).
+* The system directory `/etc/OpenCL`.
 
 ### Environment Variables
 

--- a/scripts/generate_controls_doc.py
+++ b/scripts/generate_controls_doc.py
@@ -62,17 +62,25 @@ will still read registry keys from:
 
 If a registry is set in both HKCU and HKLM, the setting in HKCU will "win".
 
-### Linux Configuration Files
+### Linux, Android, and OSX Configuration Files
 
 On Linux, the Intercept Layer for OpenCL Applications will read control values
-from ~/clintercept.conf.  Controls may be set by putting the control on its own
-line, followed by an equals sign, followed by the value you'd like to set the
-option to.  Lines that begin with a semi-colon(";"), a hash mark ("#"), or a
-C++-style comment ("//") are ignored.  For example, to enable CallLogging, put
-a line in your ~/clintercept.conf that looks like:
+from a config file named clintercept.conf.  Controls in a config file may be
+set by putting the control on its own line, followed by an equals sign,
+followed by the value to set the control to.  Lines that begin with a
+semi-colon (";"), a hash mark ("#"), or a C++-style comment ("//") are
+ignored.  For example, to enable CallLogging, put a line in your 
+clintercept.conf that looks like:
 
     // Enable CallLogging:
     CallLogging=1
+
+The Intercept Layer for OpenCL Applications will search for config files in
+the following directories, in order:
+
+* The current user's HOME directory (`~`).
+* The `sdcard` directory (for Android only).
+* The system directory `/etc/OpenCL`.
 
 ### Environment Variables
 


### PR DESCRIPTION
Fixes #72 

## Description of Changes

Refactors the logic for config files to search a config file in the user's home directory first, then a system config file in `/etc/OpenCL` if the control (or the config file itself) wasn't found in the user's home directory.

## Testing Done

Checked different combinations of controls in system files and controls in per-user config files on Linux.  I don't have a setup to test OSX or Android at the moment.