### PR TITLE
Adding `cliloader` in build.md

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -54,6 +54,7 @@ See your CMake documentation for more details.
 | CMAKE\_BUILD\_TYPE | STRING | Build type.  Does not affect multi-configuration generators, such as Visual Studio solution files.  Default: `Release`.  Other options: `Debug`
 | CMAKE\_INSTALL\_PREFIX | PATH | Install directory prefix.
 | ENABLE_CLIPROF | BOOL | Enables building the cliprof loader utility.  Additionally, when required, enables code in the Intercept Layer for OpenCL Applications itself to enable cliprof functionality.  Default: `FALSE`
+| ENABLE_CLILOADER | BOOL | Enables building the cliloader utilty (cliloader is intended to replace the old cliprof utility).  Additionally, when required, enables code in the Intercept Layer for OpenCL Applications itself to enable cliloader functionality.  Default: `FALSE`
 | ENABLE_ITT | BOOL | Enables support for Instrumentation and Tracing Techology APIs, which can be used to display OpenCL events on Intel(R) VTune(tm) timegraphs.  Default: `FALSE`
 | ENABLE_KERNEL_OVERRIDES | BOOL | Enables embedding kernel strings to override precompiled kernels and built-in kernels.  Supported for Linux and Android builds only, since Windows builds always embeds kernel strings, and embedding kernel strings is not support for OSX (yet!).  Default: `TRUE`
 | ENABLE_MDAPI | BOOL | For internal use only.  Default: `FALSE`


### PR DESCRIPTION
Fixes #

Build.md doest not document the `ENABLE_CLILOADER` option (documented here: https://github.com/intel/opencl-intercept-layer/blob/master/docs/cliloader.md).

## Description of Changes

Add `ENABLE_CLILOADER` to the list of options table.

## Aditional comments

>Additionally, when required, enables code in the Intercept Layer for OpenCL Applications itself to enable cliloader functionality.
Not sure if this sentence is still needed.
