### PR TITLE
add dumping for clLinkProgram

### DIFF
--- a/Src/dispatch.cpp
+++ b/Src/dispatch.cpp
@@ -2226,7 +2226,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clCompileProgram)(
 
         DUMP_PROGRAM_OPTIONS( program, options );
 
-        CALL_LOGGING_ENTER();
+        CALL_LOGGING_ENTER( "program = %p, pfn_notify = %p", program, pfn_notify );
         BUILD_LOGGING_INIT();
         CPU_PERFORMANCE_TIMING_START();
 
@@ -2285,7 +2285,10 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clLinkProgram)(
     {
         const bool  modified = false;
 
-        CALL_LOGGING_ENTER();
+        CALL_LOGGING_ENTER( "context = %p, num_input_programs = %u, pfn_notify = %p",
+            context,
+            num_input_programs,
+            pfn_notify );
         CHECK_ERROR_INIT( errcode_ret );
         BUILD_LOGGING_INIT();
         CPU_PERFORMANCE_TIMING_START();
@@ -2308,7 +2311,10 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clLinkProgram)(
 
         // TODO: Is the resulting program ("retVal") the one that should be
         // used here, to determine the hash for dumped options?
+        SAVE_PROGRAM_OPTIONS_HASH( retVal, options );
         DUMP_PROGRAM_OPTIONS( retVal, options );
+        DUMP_OUTPUT_PROGRAM_BINARIES( retVal );
+        DUMP_KERNEL_ISA_BINARIES( retVal );
         INCREMENT_PROGRAM_COMPILE_COUNT( retVal );
 
         return retVal;
@@ -2376,7 +2382,10 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetProgramSpecializationConstant)(
 
     if( pIntercept )
     {
-        CALL_LOGGING_ENTER( "program = %p, spec_id = %u, spec_size = %u", program );
+        CALL_LOGGING_ENTER( "program = %p, spec_id = %u, spec_size = %u",
+            program,
+            spec_id,
+            (cl_uint)spec_size );
         CPU_PERFORMANCE_TIMING_START();
 
         cl_int  retVal = pIntercept->dispatch().clSetProgramSpecializationConstant(
@@ -3912,13 +3921,13 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueCopyBuffer)(
 
         if( pIntercept->nullEnqueue() == false )
         {
-            CALL_LOGGING_ENTER("queue = %p, src_buffer = %p, dst_buffer = %p, src_offset = %u, dst_offset = %u, cb = %d",
+            CALL_LOGGING_ENTER("queue = %p, src_buffer = %p, dst_buffer = %p, src_offset = %u, dst_offset = %u, cb = %u",
                 command_queue,
                 src_buffer,
                 dst_buffer,
-                src_offset,
-                dst_offset,
-                cb );
+                (cl_uint)src_offset,
+                (cl_uint)dst_offset,
+                (cl_uint)cb );
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list );
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
@@ -7049,7 +7058,7 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clCreateProgramWithIL) (
 
         CALL_LOGGING_ENTER( "context = %p, length = %u",
             context,
-            length );
+            (cl_uint)length );
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
@@ -8529,7 +8538,7 @@ CL_API_ENTRY cl_accelerator_intel CL_API_CALL clCreateAcceleratorINTEL(
         {
             CALL_LOGGING_ENTER( "context = %p, accelerator_type = %u",
                 context,
-                accelerator_type );
+                (cl_uint)accelerator_type );
         }
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();

--- a/Src/dispatch.cpp
+++ b/Src/dispatch.cpp
@@ -2309,8 +2309,9 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clLinkProgram)(
         BUILD_LOGGING( retVal, num_devices, device_list );
         CALL_LOGGING_EXIT( errcode_ret[0] );
 
-        // TODO: Is the resulting program ("retVal") the one that should be
-        // used here, to determine the hash for dumped options?
+        // TODO: How do we compute a hash for the linked program?
+        // This is a new program object, so we don't currently have a hash for it.
+        SAVE_PROGRAM_NUMBER( retVal );
         SAVE_PROGRAM_OPTIONS_HASH( retVal, options );
         DUMP_PROGRAM_OPTIONS( retVal, options );
         DUMP_OUTPUT_PROGRAM_BINARIES( retVal );

--- a/Src/intercept.h
+++ b/Src/intercept.h
@@ -1664,6 +1664,11 @@ inline bool CLIntercept::checkAubCaptureEnqueueLimits() const
     delete [] _injectedSPIRV;                                               \
     _injectedSPIRV = NULL;
 
+// Called from clLinkProgram:
+
+#define SAVE_PROGRAM_NUMBER( program )                                      \
+    pIntercept->saveProgramNumber( program );
+
 // Called from clBuildProgram:
 
 #define MODIFY_PROGRAM_OPTIONS( program, options, newOptions )              \


### PR DESCRIPTION
## Description of Changes

clLinkProgram can create an executable program object similar to clBuildProgram, so it needs to support similar functionality for dumping program binaries, ISA binaries, etc.

## Testing Done

Ran a simple application that creates an executable program object using clCompileProgram and clLinkProgram instead of clBuildProgram.  Verified that program binaries and kernel ISA binaries are correctly dumped using this code path.

Note, clLinkProgram creates a new program object, and it's not clear how to compute the hash it.  The program number is incremented and set for programs created by clLinkProgram, so the dumped program binaries and kernel ISA binaries have a unique name, but the hash value is always zero for them.  We can look into enhancing this in the future, if desired.
