### PR TITLE
switch to lock_guards and std mutexes

### DIFF
--- a/intercept/OS/OS_linux_common.cpp
+++ b/intercept/OS/OS_linux_common.cpp
@@ -42,7 +42,6 @@ Services_Common::Services_Common()
 
 Services_Common::~Services_Common()
 {
-    pthread_mutex_destroy( &m_CriticalSection );
 }
 
 bool Services_Common::GetControl(

--- a/intercept/OS/OS_linux_common.h
+++ b/intercept/OS/OS_linux_common.h
@@ -74,9 +74,6 @@ public:
 
     bool    Init();
 
-    void    EnterCriticalSection();
-    void    LeaveCriticalSection();
-
     uint64_t    GetProcessID() const;
     uint64_t    GetThreadID() const;
 
@@ -117,7 +114,6 @@ public:
 
 private:
     Timer           m_Timer;
-    pthread_mutex_t m_CriticalSection;
 
     bool    GetControlFromFile(
                 const std::string& fileName,
@@ -130,24 +126,7 @@ private:
 
 inline bool Services_Common::Init()
 {
-    if( pthread_mutex_init(
-            &m_CriticalSection,
-            NULL ) )
-    {
-        return false;
-    }
-
     return true;
-}
-
-inline void Services_Common::EnterCriticalSection()
-{
-    pthread_mutex_lock( &m_CriticalSection );
-}
-
-inline void Services_Common::LeaveCriticalSection()
-{
-    pthread_mutex_unlock( &m_CriticalSection );
 }
 
 inline uint64_t Services_Common::GetProcessID() const

--- a/intercept/OS/OS_mac_common.cpp
+++ b/intercept/OS/OS_mac_common.cpp
@@ -37,7 +37,6 @@ Services_Common::Services_Common()
 
 Services_Common::~Services_Common()
 {
-    pthread_mutex_destroy( &m_CriticalSection );
 }
 
 bool Services_Common::GetControl(

--- a/intercept/OS/OS_mac_common.h
+++ b/intercept/OS/OS_mac_common.h
@@ -70,9 +70,6 @@ public:
 
     bool    Init();
 
-    void    EnterCriticalSection();
-    void    LeaveCriticalSection();
-
     uint64_t    GetProcessID() const;
     uint64_t    GetThreadID() const;
 
@@ -112,8 +109,6 @@ public:
                 const std::string& fileName ) const;
 
 private:
-    pthread_mutex_t m_CriticalSection;
-
     bool    GetControlFromFile(
                 const std::string& fileName,
                 const std::string& controlName,
@@ -125,24 +120,7 @@ private:
 
 inline bool Services_Common::Init()
 {
-    if( pthread_mutex_init(
-            &m_CriticalSection,
-            NULL ) )
-    {
-        return false;
-    }
-
     return true;
-}
-
-inline void Services_Common::EnterCriticalSection()
-{
-    pthread_mutex_lock( &m_CriticalSection );
-}
-
-inline void Services_Common::LeaveCriticalSection()
-{
-    pthread_mutex_unlock( &m_CriticalSection );
 }
 
 inline uint64_t Services_Common::GetProcessID() const

--- a/intercept/OS/OS_windows_common.cpp
+++ b/intercept/OS/OS_windows_common.cpp
@@ -36,7 +36,6 @@ Services_Common::Services_Common()
 
 Services_Common::~Services_Common()
 {
-    DeleteCriticalSection( &m_CriticalSection );
 }
 
 }

--- a/intercept/OS/OS_windows_common.h
+++ b/intercept/OS/OS_windows_common.h
@@ -65,9 +65,6 @@ public:
 
     bool    Init();
 
-    void    EnterCriticalSection();
-    void    LeaveCriticalSection();
-
     uint64_t    GetProcessID() const;
     uint64_t    GetThreadID() const;
 
@@ -108,7 +105,6 @@ public:
 
 private:
     Timer               m_Timer;
-    CRITICAL_SECTION    m_CriticalSection;
 
     DISALLOW_COPY_AND_ASSIGN( Services_Common );
 };
@@ -120,24 +116,7 @@ inline bool Services_Common::Init()
         return false;
     }
 
-    if( ::InitializeCriticalSectionAndSpinCount(
-            &m_CriticalSection,
-            0x400 ) == FALSE )
-    {
-        return false;
-    }
-
     return true;
-}
-
-inline void Services_Common::EnterCriticalSection()
-{
-    ::EnterCriticalSection( &m_CriticalSection );
-}
-
-inline void Services_Common::LeaveCriticalSection()
-{
-    ::LeaveCriticalSection( &m_CriticalSection );
 }
 
 inline uint64_t Services_Common::GetProcessID() const

--- a/intercept/mdapi/intercept_mdapi.cpp
+++ b/intercept/mdapi/intercept_mdapi.cpp
@@ -137,7 +137,7 @@ cl_command_queue CLIntercept::createMDAPICommandQueue(
 
     if( dispatch().clCreatePerfCountersCommandQueueINTEL && m_pMDHelper )
     {
-        m_OS.EnterCriticalSection();
+        std::lock_guard<std::mutex> lock(m_Mutex);
 
         if( m_pMDHelper->ActivateMetricSet() )
         {
@@ -160,8 +160,6 @@ cl_command_queue CLIntercept::createMDAPICommandQueue(
         {
             log( "Metric Discovery: Couldn't activate metric set!\n" );
         }
-
-        m_OS.LeaveCriticalSection();
     }
 
     return retVal;

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -25,6 +25,7 @@
 #include <list>
 #include <vector>
 #include <map>
+#include <mutex>
 #include <set>
 #include <sstream>
 #include <queue>
@@ -726,6 +727,8 @@ private:
 
     void    writeReport(
                 std::ostream& os );
+
+    std::mutex      m_Mutex;
 
     OS::Services    m_OS;
     CLdispatch      m_Dispatch;
@@ -2074,15 +2077,13 @@ inline std::string CLIntercept::getShortKernelNameWithHash(
 //
 inline void CLIntercept::saveProgramNumber( const cl_program program )
 {
-    m_OS.EnterCriticalSection();
+    std::lock_guard<std::mutex> lock(m_Mutex);
 
     SProgramInfo&   programInfo = m_ProgramInfoMap[ program ];
     programInfo.ProgramNumber = m_ProgramNumber;
     programInfo.CompileCount = 0;
 
     m_ProgramNumber++;
-
-    m_OS.LeaveCriticalSection();
 }
 
 inline unsigned int CLIntercept::getProgramNumber() const


### PR DESCRIPTION
## Description of Changes

Instead of implementing OS-specific abstractions for critical sections, switch to standard std::mutexes and lock_guards.

## Testing Done

I've been running these changes for the past week or so, alongside the CMake 3.1 changes.