### PR TITLE
fix a few Linux directory issues after CMake 3.1 changes

### DIFF
--- a/cliloader/cliloader.cpp
+++ b/cliloader/cliloader.cpp
@@ -572,6 +572,13 @@ int main(int argc, char *argv[])
         std::string libPath = path + "/../" + CLILOADER_LIB_DIR;
         found = getEnvVars( libPath, ld_preload, ld_library_path );
     }
+    if( found == false )
+    {
+        // Next, check for an intercept directory.
+        // This is for running cliloader straight from a CMake directory.
+        std::string libPath = path + "/../intercept";
+        found = getEnvVars( libPath, ld_preload, ld_library_path );
+    }
     if( found )
     {
         DEBUG("New %s is %s\n", LD_PRELOAD_ENV, ld_preload.c_str());

--- a/cliprof/cliprof.cpp
+++ b/cliprof/cliprof.cpp
@@ -509,6 +509,13 @@ int main(int argc, char *argv[])
         std::string libPath = path + "/../" + CLIPROF_LIB_DIR;
         found = getEnvVars( libPath, ld_preload, ld_library_path );
     }
+    if( found == false )
+    {
+        // Next, check for an intercept directory.
+        // This is for running cliprof straight from a CMake directory.
+        std::string libPath = path + "/../intercept";
+        found = getEnvVars( libPath, ld_preload, ld_library_path );
+    }
     if( found )
     {
         DEBUG("New %s is %s\n", LD_PRELOAD_ENV, ld_preload.c_str());

--- a/intercept/OS/OS_linux.h
+++ b/intercept/OS/OS_linux.h
@@ -82,8 +82,8 @@ inline bool Services::GetCLInterceptName(
 }
 
 #if defined(USE_KERNEL_OVERRIDES)
-extern "C" char _binary_Kernels_precompiled_kernels_cl_start;
-extern "C" char _binary_Kernels_precompiled_kernels_cl_end;
+extern "C" char _binary_kernels_precompiled_kernels_cl_start;
+extern "C" char _binary_kernels_precompiled_kernels_cl_end;
 #endif
 
 inline bool Services::GetPrecompiledKernelString(
@@ -91,16 +91,16 @@ inline bool Services::GetPrecompiledKernelString(
     size_t& length ) const
 {
 #if defined(USE_KERNEL_OVERRIDES)
-    str = &_binary_Kernels_precompiled_kernels_cl_start;
-    length = &_binary_Kernels_precompiled_kernels_cl_end - &_binary_Kernels_precompiled_kernels_cl_start;
+    str = &_binary_kernels_precompiled_kernels_cl_start;
+    length = &_binary_kernels_precompiled_kernels_cl_end - &_binary_kernels_precompiled_kernels_cl_start;
 #endif
 
     return true;
 }
 
 #if defined(USE_KERNEL_OVERRIDES)
-extern "C" char _binary_Kernels_builtin_kernels_cl_start;
-extern "C" char _binary_Kernels_builtin_kernels_cl_end;
+extern "C" char _binary_kernels_builtin_kernels_cl_start;
+extern "C" char _binary_kernels_builtin_kernels_cl_end;
 #endif
 
 inline bool Services::GetBuiltinKernelString(
@@ -108,8 +108,8 @@ inline bool Services::GetBuiltinKernelString(
     size_t& length ) const
 {
 #if defined(USE_KERNEL_OVERRIDES)
-    str = &_binary_Kernels_builtin_kernels_cl_start;
-    length = &_binary_Kernels_builtin_kernels_cl_end - &_binary_Kernels_builtin_kernels_cl_start;
+    str = &_binary_kernels_builtin_kernels_cl_start;
+    length = &_binary_kernels_builtin_kernels_cl_end - &_binary_kernels_builtin_kernels_cl_start;
 #endif
 
     return true;

--- a/intercept/src/clIntercept.map
+++ b/intercept/src/clIntercept.map
@@ -22,10 +22,10 @@
 
 INTERNAL {
     global:
-        _binary_Kernels_builtin_kernels_cl_start;
-        _binary_Kernels_builtin_kernels_cl_end;
-        _binary_Kernels_precompiled_kernels_cl_start;
-        _binary_Kernels_precompiled_kernels_cl_end;
+        _binary_kernels_builtin_kernels_cl_start;
+        _binary_kernels_builtin_kernels_cl_end;
+        _binary_kernels_precompiled_kernels_cl_start;
+        _binary_kernels_precompiled_kernels_cl_end;
     local:
         *;
 };


### PR DESCRIPTION
## Description of Changes

Fixes a few Linux issues caused by moving files around as part of the CMake 3.1 changes.

## Testing Done

Tested cliprof and cliloader without running "make install" on Linux.
