### PR TITLE
fixes for a few crashes with invalid parameters

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -5571,19 +5571,26 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clGetExtensionFunctionAddress)(
     if( pIntercept &&
         pIntercept->dispatch().clGetExtensionFunctionAddress )
     {
-        CALL_LOGGING_ENTER( "func_name = %s", func_name );
+        CALL_LOGGING_ENTER( "func_name = %s", func_name ? func_name : "(NULL)" );
         CPU_PERFORMANCE_TIMING_START();
 
-        // First, check to see if this is an extension we know about.
-        void*   retVal = pIntercept->getExtensionFunctionAddress(
-            NULL,
-            func_name );
-
-        // If it's not, call into the dispatch table as usual.
-        if( retVal == NULL )
+        void*   retVal = NULL;
+        if( func_name != NULL )
         {
-            retVal = pIntercept->dispatch().clGetExtensionFunctionAddress(
-                func_name );
+            // First, check to see if this is an extension we know about.
+            if( retVal == NULL )
+            {
+                retVal = pIntercept->getExtensionFunctionAddress(
+                    NULL,
+                    func_name );
+            }
+
+            // If it's not, call into the dispatch table as usual.
+            if( retVal == NULL )
+            {
+                retVal = pIntercept->dispatch().clGetExtensionFunctionAddress(
+                    func_name );
+            }
         }
 
         CPU_PERFORMANCE_TIMING_END();
@@ -5620,20 +5627,27 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clGetExtensionFunctionAddressForPlatform)(
         }
         CALL_LOGGING_ENTER( "platform = [ %s ], func_name = %s",
             platformInfo.c_str(),
-            func_name );
+            func_name ? func_name : "(NULL)" );
         CPU_PERFORMANCE_TIMING_START();
 
-        // First, check to see if this is an extension we know about.
-        void*   retVal = pIntercept->getExtensionFunctionAddress(
-            platform,
-            func_name );
-
-        // If it's not, call into the dispatch table as usual.
-        if( retVal == NULL )
+        void*   retVal = NULL;
+        if( func_name != NULL )
         {
-            retVal = pIntercept->dispatch().clGetExtensionFunctionAddressForPlatform(
-                platform,
-                func_name );
+            // First, check to see if this is an extension we know about.
+            if( retVal == NULL )
+            {
+                pIntercept->getExtensionFunctionAddress(
+                    platform,
+                    func_name );
+            }
+
+            // If it's not, call into the dispatch table as usual.
+            if( retVal == NULL )
+            {
+                retVal = pIntercept->dispatch().clGetExtensionFunctionAddressForPlatform(
+                    platform,
+                    func_name );
+            }
         }
 
         CPU_PERFORMANCE_TIMING_END();

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -2032,12 +2032,19 @@ void CLIntercept::getCreateSubBufferArgsString(
     switch( createType )
     {
     case CL_BUFFER_CREATE_TYPE_REGION:
+        ss << "region = ";
+        if( createInfo != NULL )
         {
             cl_buffer_region*   pRegion = (cl_buffer_region*)createInfo;
-            ss << "origin = "
+            ss << "{ origin = "
                 << pRegion->origin
-                << " size = "
-                << pRegion->size;
+                << ", size = "
+                << pRegion->size
+                << " }";
+        }
+        else
+        {
+            ss << "(NULL)";
         }
         break;
     default:
@@ -2767,7 +2774,10 @@ void CLIntercept::combineProgramStrings(
         if( ( lengths == NULL ) ||
             ( lengths[i] == 0 ) )
         {
-            length = strlen( strings[i] );
+            if( strings[i] != NULL )
+            {
+                length = strlen( strings[i] );
+            }
         }
         else
         {
@@ -2793,19 +2803,25 @@ void CLIntercept::combineProgramStrings(
             if( ( lengths == NULL ) ||
                 ( lengths[i] == 0 ) )
             {
-                length = strlen( strings[i] );
+                if( strings[i] != NULL )
+                {
+                    length = strlen( strings[i] );
+                }
             }
             else
             {
                 length = lengths[i];
             }
-            CLI_MEMCPY(
-                pDst,
-                remaining,
-                strings[i],
-                length );
-            pDst += length;
-            remaining -= length;
+            if( length )
+            {
+                CLI_MEMCPY(
+                    pDst,
+                    remaining,
+                    strings[i],
+                    length );
+                pDst += length;
+                remaining -= length;
+            }
         }
 
         // Replace any NULL chars between kernels with spaces.


### PR DESCRIPTION
fixes #89

## Description of Changes

Fixes a few cases where the Intercept Layer would crash when passed invalid input.  Although these are conditions that should result in OpenCL errors, the Intercept Layer shouldn't crash.  A few of these cases require CallLogging and / or DumpProgramSource to be enabled:

* Passing a NULL string to clGetExtensionFunctionAddress or clGetExtensionFunctionAddressForPlatform.  Note that some ICD loaders crash on this behavior as well, though this has been fixed in later versions.
* Passing NULL as the buffer_create_info parameter to clCreateSubBuffer.
* Passing NULL as one of the strings to clCreateProgramWithSource.

## Testing Done

Tested the cases described above.  Observed crashes without these changes, and no crashes afterwards.
