### PR TITLE
add missing string include for vs2019

### DIFF
--- a/cliconfig/CLIConfig.h
+++ b/cliconfig/CLIConfig.h
@@ -28,6 +28,7 @@
 #include <afxcmn.h>
 #include <afxtempl.h>
 
+#include <string>
 #include <vector>
 
 #include "resource.h"


### PR DESCRIPTION
## Description of Changes

It looks like another header files from prior versions of Visual Studio was including <string>, but starting with VS 2019 the config app will not build without including <string> explicitly.

## Testing Done

Tested 64-bit builds on VS 2019.  Note, it doesn't appear that Visual Studio 2019 support is available via Appveyor just yet.