### PR TITLE
switch from temp strings on the stack to a single large string buffer

### DIFF
--- a/intercept/src/common.h
+++ b/intercept/src/common.h
@@ -93,7 +93,7 @@
     #define CLI_C_ASSERT(e) typedef char __attribute__((unused)) __C_ASSERT__[(e)?1:-1]
 #endif
 
-#define CLI_MAX_STRING_SIZE 1024
+#define CLI_STRING_BUFFER_SIZE (16 * 1024)
 
 /*****************************************************************************\
 

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -124,44 +124,44 @@ public:
 
     void    getPlatformInfoString(
                 cl_platform_id platform,
-                std::string& str ) const;
+                std::string& str );
     void    getDeviceInfoString(
                 cl_uint num_devices,
                 const cl_device_id* devices,
-                std::string& str ) const;
+                std::string& str );
     void    getEventListString(
                 cl_uint num_events,
                 const cl_event* event_list,
-                std::string& str ) const;
+                std::string& str );
     void    getContextPropertiesString(
                 const cl_context_properties* properties,
-                std::string& str ) const;
+                std::string& str );
     void    getSamplerPropertiesString(
                 const cl_sampler_properties* properties,
-                std::string& str ) const;
+                std::string& str );
     void    getCommandQueuePropertiesString(
                 const cl_queue_properties* properties,
-                std::string& str ) const;
+                std::string& str );
     void    getCreateKernelsInProgramRetString(
                 cl_int retVal,
                 cl_kernel* kernels,
                 cl_uint* num_kernels_ret,
-                std::string& str ) const;
+                std::string& str );
     void    getKernelArgString(
                 cl_uint arg_index,
                 size_t arg_size,
                 const void* arg_value,
-                std::string& str ) const;
+                std::string& str );
     void    getEnqueueNDRangeKernelArgsString(
                 cl_uint work_dim,
                 const size_t* global_work_offset,
                 const size_t* global_work_size,
                 const size_t* local_work_size,
-                std::string& str ) const;
+                std::string& str );
     void    getCreateSubBufferArgsString(
                 cl_buffer_create_type createType,
                 const void *createInfo,
-                std::string& str ) const;
+                std::string& str );
 
     void    logCLInfo();
     void    logBuild(
@@ -741,6 +741,7 @@ private:
     std::ofstream   m_InterceptLog;
     std::ofstream   m_InterceptTrace;
 
+    char        m_StringBuffer[CLI_STRING_BUFFER_SIZE];
     bool        m_LoggedCLInfo;
 
     uint64_t    m_EnqueueCounter;


### PR DESCRIPTION
Fixes #92 

## Description of Changes

As discussed on #92, the "too long" message is because the temporary call logging string buffer is allocated on the stack vs. the heap, and therefore has limited size.  This change switches from a string buffer allocated on the stack to a string buffer allocated on the heap, as part of the CLIntercept context.  Because it is allocated on the heap it can be much larger (16KB vs. 1KB), so although a "too long" message is still possible, it's going to be a lot longer before it occurs.

## Testing Done

Tested with a simple app and CallLogging enabled.