### PR TITLE
use the normalized time for ChromePerformanceTimingInStages

### DIFF
--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -750,7 +750,7 @@ private:
     typedef std::map< uint64_t, unsigned int>   CThreadNumberMap;
     CThreadNumberMap    m_ThreadNumberMap;
 
-    unsigned int m_EventsChromeTraced;
+    unsigned int    m_EventsChromeTraced;
 
     unsigned int    m_ProgramNumber;
 


### PR DESCRIPTION
## Description of Changes

Since there is no guarantee that the event profiling time stamps use the same time domain as other host timers, it is necessary to "normalize" the event profiling time stamps in some cases.  This is a slight change to the recently added ChromePerformaceTimingInStages feature to base the start times on the normalized time, not purely on the host timer start time.  This aligns the ChromePerfomanceTimingInStages logging with the previous ChromePerformanceTiming logging.

@alisanikiforova, can you please confirm that these changes work for you?

## Testing Done

Tested ChromePerformanceTiming and ChromePerformanceTimingInStages with a simple sample for an Intel CPU and a third-party GPU device.
