### PR TITLE
change control name from DllName to OpenCLFileName

### DIFF
--- a/cliconfig/envVars.h
+++ b/cliconfig/envVars.h
@@ -100,6 +100,7 @@ struct VarDescription
 static const VarDescription cVars[] =
 {
     { CONTROL_TYPE_BOOL, "BreakOnLoad", "", 0, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will break into the debugger when the DLL is loaded." },
+    { CONTROL_TYPE_STRING, "OpenCLFileName", "", 0, "Used to control the DLL or Shared Library that the Intercept Layer for OpenCL Applications loads to make real OpenCL calls. If present, only this file name is loaded. If omitted, the Intercept Layer for OpenCL Applications will search a default set of real OpenCL file names." },
 #include "src\controls.h"
 };
 

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -88,13 +88,34 @@ will record any controls that are set to non-default values.
 
 ### Setup and Loading Controls
 
-##### `DllName` (string)
+##### `OpenCLFileName` (string)
 
-Used to control the DLL or Shared Library that the Intercept Layer for OpenCL Applications loads to make real OpenCL calls.  If present, only this DLL name is loaded.  If omitted, the Intercept Layer for OpenCL Applications tries to load the real OpenCL DLL from file names in this order:
+Used to control the DLL or Shared Library that the Intercept Layer for OpenCL Applications loads to make real OpenCL calls.
+This can be a relative file name or a full absolute file name, but an absolute file name is recommended.
+If present, only this file name is loaded.
+If omitted, the Intercept Layer for OpenCL Applications tries to load the real OpenCL from file names in this order:
 
-- real_OpenCL.dll (anywhere in the system path)
-- %WINDIR%\SysWOW64\OpenCL.dll (32-bit DLLs only)
-- %WINDIR%\System32\OpenCL.dll
+For Windows:
+
+- `real_OpenCL.dll` (anywhere in the system path)
+- `%WINDIR%\SysWOW64\OpenCL.dll` (32-bit DLLs only)
+- `%WINDIR%\System32\OpenCL.dll`
+
+For Linux:
+
+- `./real_libOpenCL.so`
+- `/usr/lib/x86_64-linux-gnu/libOpenCL.so`
+- `/opt/intel/opencl/lib64/libOpenCL.so`
+
+For Android:
+
+- `/system/vendor/lib/real_libOpenCL.so`
+- `real_libOpenCL.so`
+
+This control is not used for OSX.
+
+This control used to be called `DllName`.
+The old name may still be used for backwards compatibility, but switching to the new name is recommended.
 
 ##### `BreakOnLoad` (bool)
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -69,11 +69,11 @@ Note: If the real ICD loader library is in a system directory, you may need to p
 4. Create a config file or setup environment variables to tell the Intercept Layer for OpenCL Applications where to find the real ICD loader.
 For example, you could create a `clintercept.conf` file with content:
 
-       DllName=path/to/your/real_libOpenCL.so
+       OpenCLFileName=path/to/your/real_libOpenCL.so
 
     Or, you could set an environment variable:
 
-       export CLI_DllName=path/to/your/real_libOpenCL.so
+       export CLI_OpenCLFileName=path/to/your/real_libOpenCL.so
 
     See the [controls documentation](controls.md) for more detail.
 
@@ -95,7 +95,7 @@ using only environment variables.  If the application specifies an rpath or
 otherwise circumvents the OS's method of identifying an appropriate
 libOpenCL.so, this method won't work.  Example:
 
-    LD_LIBRARY_PATH=/path/to/build/output CLI_DllName=/path/to/real/libOpenCL.so \
+    LD_LIBRARY_PATH=/path/to/build/output CLI_OpenCLFileName=/path/to/real/libOpenCL.so \
     CLI_DumpProgramSource=1 ./oclapplication
 
 ## Mac OSX

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -710,7 +710,7 @@ private:
     void    logDeviceInfo( cl_device_id device );
 
 #if defined(_WIN32) || defined(__linux__)
-    bool    initDispatch( const std::string& dllName );
+    bool    initDispatch( const std::string& libName );
 #elif defined(__APPLE__)
     bool    initDispatch( void );
 #else

--- a/scripts/generate_controls_doc.py
+++ b/scripts/generate_controls_doc.py
@@ -114,13 +114,34 @@ will record any controls that are set to non-default values.
 
 ### Setup and Loading Controls
 
-##### `DllName` (string)
+##### `OpenCLFileName` (string)
 
-Used to control the DLL or Shared Library that the Intercept Layer for OpenCL Applications loads to make real OpenCL calls.  If present, only this DLL name is loaded.  If omitted, the Intercept Layer for OpenCL Applications tries to load the real OpenCL DLL from file names in this order:
+Used to control the DLL or Shared Library that the Intercept Layer for OpenCL Applications loads to make real OpenCL calls.
+This can be a relative file name or a full absolute file name, but an absolute file name is recommended.
+If present, only this file name is loaded.
+If omitted, the Intercept Layer for OpenCL Applications tries to load the real OpenCL from file names in this order:
 
-- real_OpenCL.dll (anywhere in the system path)
-- %WINDIR%\SysWOW64\OpenCL.dll (32-bit DLLs only)
-- %WINDIR%\System32\OpenCL.dll
+For Windows:
+
+- `real_OpenCL.dll` (anywhere in the system path)
+- `%WINDIR%\SysWOW64\OpenCL.dll` (32-bit DLLs only)
+- `%WINDIR%\System32\OpenCL.dll`
+
+For Linux:
+
+- `./real_libOpenCL.so`
+- `/usr/lib/x86_64-linux-gnu/libOpenCL.so`
+- `/opt/intel/opencl/lib64/libOpenCL.so`
+
+For Android:
+
+- `/system/vendor/lib/real_libOpenCL.so`
+- `real_libOpenCL.so`
+
+This control is not used for OSX.
+
+This control used to be called `DllName`.
+The old name may still be used for backwards compatibility, but switching to the new name is recommended.
 
 ##### `BreakOnLoad` (bool)
 


### PR DESCRIPTION
## Description of Changes

Switched the name of the previous `DllName` control to `OpenCLFileName`.

On any non-Windows OS naming this control DllName doesn't make much sense.  DllName will still work, for backwards compatibility, but users are encouraged to switch to the new name instead.  If both the old DllName and the new OpenCLFileName control are set, the new control will "win".

## Testing Done

Tested default behavior (no controls set), old behavior (DllName set), and new behavior (OpenCLFileName set) on Windows and Linux.