### PR TITLE
Add dependency on OpenCL target for tools

### DIFF
--- a/cliconfig/CMakeLists.txt
+++ b/cliconfig/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(CLIConfig WIN32
     ${CLICONFIG_ICON_FILES}
     ${CLICONFIG_SOURCE_FILES}
 )
+add_dependencies(CLIConfig OpenCL)
 target_compile_definitions(CLIConfig PRIVATE _AFXDLL)
 target_compile_definitions(CLIConfig PRIVATE UNICODE _UNICODE)
 target_include_directories(CLIConfig PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../intercept)

--- a/cliloader/CMakeLists.txt
+++ b/cliloader/CMakeLists.txt
@@ -34,6 +34,7 @@ source_group( Source FILES
 add_executable(cliloader
     ${CLILOADER_SOURCE_FILES}
 )
+add_dependencies(cliloader OpenCL)
 target_include_directories(cliloader PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}
 )

--- a/cliprof/CMakeLists.txt
+++ b/cliprof/CMakeLists.txt
@@ -34,6 +34,7 @@ source_group( Source FILES
 add_executable(cliprof
     ${CLIPROF_SOURCE_FILES}
 )
+add_dependencies(cliprof OpenCL)
 target_include_directories(cliprof PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}
 )


### PR DESCRIPTION
Fixes #111

## Description of Changes

Intercept Layer tools now depend on intercept library itself. It prevents user confusion in case when they only build a single target (like cliprof).

## Testing Done

`cmake --build . --target cliprof` also emits intercept/libOpenCL.so
