### PR TITLE
add number of compute units and clock frequency to perf report

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -4477,14 +4477,32 @@ void CLIntercept::addTimingEvent(
     if( m_DeviceNameMap.find(device) == m_DeviceNameMap.end() )
     {
         char*   deviceName = NULL;
+        cl_uint deviceComputeUnits = 0;
+        cl_uint deviceMaxClockFrequency = 0;
 
         allocateAndGetDeviceInfoString(
             device,
             CL_DEVICE_NAME,
             deviceName );
+        dispatch().clGetDeviceInfo(
+            device,
+            CL_DEVICE_MAX_COMPUTE_UNITS,
+            sizeof(deviceComputeUnits),
+            &deviceComputeUnits,
+            NULL );
+        dispatch().clGetDeviceInfo(
+            device,
+            CL_DEVICE_MAX_CLOCK_FREQUENCY,
+            sizeof(deviceMaxClockFrequency),
+            &deviceMaxClockFrequency,
+            NULL );
         if( deviceName )
         {
-            m_DeviceNameMap[device] = deviceName;
+            std::ostringstream  ss;
+            ss << deviceName << " ("
+                << deviceComputeUnits << "CUs, "
+                << deviceMaxClockFrequency << "MHz)";
+            m_DeviceNameMap[device] = ss.str();
         }
 
         delete [] deviceName;


### PR DESCRIPTION
## Description of Changes

In many cases it is useful to know the number of "compute units" and maximum clock frequency in addition to the device name to know how to interpret the device performance timing report data.  The device name was already included in the performance timing report, so this change adds the number of compute units and this information to the device performance timing report.

## Testing Done

Ran a test with DevicePerformaceTiming enabled and viewed the number of compute units and clock frequency in the performance timing report.