### PR TITLE
dump program options when DumpInputProgramBinaries is set

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -4020,7 +4020,11 @@ void CLIntercept::dumpProgramOptions(
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
 
-    CLI_ASSERT( config().DumpProgramSource || config().DumpProgramBinaries || config().DumpProgramSPIRV );
+    CLI_ASSERT(
+        config().DumpProgramSource ||
+        config().DumpInputProgramBinaries ||
+        config().DumpProgramBinaries ||
+        config().DumpProgramSPIRV );
 
     const SProgramInfo& programInfo = m_ProgramInfoMap[ program ];
 

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -1709,6 +1709,7 @@ inline bool CLIntercept::checkAubCaptureEnqueueLimits() const
 #define DUMP_PROGRAM_OPTIONS( program, options )                            \
     if( ( modified == false ) &&                                            \
         ( pIntercept->config().DumpProgramSource ||                         \
+          pIntercept->config().DumpInputProgramBinaries ||                  \
           pIntercept->config().DumpProgramBinaries ||                       \
           pIntercept->config().DumpProgramSPIRV ) )                         \
     {                                                                       \


### PR DESCRIPTION
## Description of Changes

This is a minor fix to also dump program build options when `DumpInputProgramBinaries` is set.  Without this fix, program build options are dumped when programs are created from source and IL (SPIR-V), but not when programs are created from pre-created binaries.

## Testing Done

Ran a simple program that created a program from a binary.  Verified that program options were not dumped before the fix, but are correctly dumped afterwards.