### PR TITLE
include the number of kernel args with KernelInfoLogging

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -2482,6 +2482,14 @@ void CLIntercept::logKernelInfo(
                     CL_DEVICE_NAME,
                     deviceName );
 
+                cl_uint args = 0;
+                errorCode |= dispatch().clGetKernelInfo(
+                    kernel,
+                    CL_KERNEL_NUM_ARGS,
+                    sizeof(args),
+                    &args,
+                    NULL );
+
                 size_t  pwgsm = 0;
                 errorCode |= dispatch().clGetKernelWorkGroupInfo(
                     kernel,
@@ -2526,6 +2534,10 @@ void CLIntercept::logKernelInfo(
                 {
                     logf( "    For device: %s\n",
                         deviceName );
+                    if( config().KernelInfoLogging )
+                    {
+                        logf( "        Num Args: %u\n", args);
+                    }
                     if( config().KernelInfoLogging ||
                         config().PreferredWorkGroupSizeMultipleLogging )
                     {


### PR DESCRIPTION
## Description of Changes

Include the number of kernel args as part of KernelInfoLogging.  This can be helpful information when a kernel is generated from some other language (such as SYCL), vs. authored in OpenCL C directly.

## Testing Done

Ran a test app and observed that the number of kernel args was included in the log.
