### PR TITLE
MDAPI Event Based Sampling for Linux

### DIFF
--- a/docs/mdapi.md
+++ b/docs/mdapi.md
@@ -29,8 +29,7 @@ MDAPI performance counters for each event.
 MDAPI event-based sampling has been supported for some time and is the most robust
 mechanism to collect MDAPI performance metrics, however it has some limitations:
 
-* MDAPI event-based sampling is currently only available on Windows.
-* MDAPI event-based sampling on Linux is tracked here: [intel/compute-runtime #182](https://github.com/intel/compute-runtime/issues/182).
+* MDAPI event-based sampling is only available on Windows and newer Linux drivers.
 * MDAPI event-based sampling is unlikely to be supported on OSX.
 * The API to create an OpenCL command queue that supports MDAPI event-based
 sampling currently does not support newer OpenCL command queue properties such
@@ -88,9 +87,9 @@ it usually resides under `/System/Library/Extensions/AppleIntel<CPU NAME>Graphic
 where `<CPU NAME>` is a short name of your CPU generation. For example, on Kaby
 Lake machines `<CPU NAME>` is `KBL`. You can also add path to `libigdmd.dylib`
 library to `DYLD_LIBRARY_PATH` environment library, so that it can be found system-wide.
-* MDAPI time-based sampling currently requires elevated privileges
+* Collecting MDAPI metrics currently requires elevated privileges
 because metrics are collected system-wide.
-* On Linux, MDAPI time-based sampling may be enabled for non-root users
+* On Linux, MDAPI metrics may be enabled for non-root users
 by setting `/proc/sys/dev/i915/perf_stream_paranoid` to `0`:
 
     ```sh

--- a/intercept/mdapi/MetricsDiscoveryHelper.cpp
+++ b/intercept/mdapi/MetricsDiscoveryHelper.cpp
@@ -32,7 +32,7 @@
 
 // Enables logs:
 //#ifdef _DEBUG
-//#define MD_DEBUG
+#define MD_DEBUG
 //#endif
 
 #if defined(_WIN32)
@@ -139,7 +139,7 @@ MDHelper* MDHelper::CreateEBS(
     const std::string& metricsFileName,
     const bool includeMaxValues )
 {
-    MDHelper*   pMDHelper = new MDHelper(API_TYPE_OCL);
+    MDHelper*   pMDHelper = new MDHelper(API_TYPE_OCL|API_TYPE_OGL4_X);
     if( pMDHelper )
     {
         if( pMDHelper->InitMetricsDiscovery(

--- a/intercept/mdapi/MetricsDiscoveryHelper.cpp
+++ b/intercept/mdapi/MetricsDiscoveryHelper.cpp
@@ -32,7 +32,7 @@
 
 // Enables logs:
 //#ifdef _DEBUG
-#define MD_DEBUG
+//#define MD_DEBUG
 //#endif
 
 #if defined(_WIN32)
@@ -139,7 +139,13 @@ MDHelper* MDHelper::CreateEBS(
     const std::string& metricsFileName,
     const bool includeMaxValues )
 {
+#if defined(__linux__)
+    // This is a temporary workaround until the Linux MDAPI is updated
+    // to expose metrics for OpenCL.
     MDHelper*   pMDHelper = new MDHelper(API_TYPE_OCL|API_TYPE_OGL4_X);
+#else
+    MDHelper*   pMDHelper = new MDHelper(API_TYPE_OCL);
+#endif
     if( pMDHelper )
     {
         if( pMDHelper->InitMetricsDiscovery(


### PR DESCRIPTION
## Description of Changes

Since support MDAPI event based sampling was added to the Intel Linux GPU OpenCL driver [recently](https://github.com/intel/compute-runtime/releases/tag/20.14.16441) we can now do event profiling on both Windows and Linux!  This PR updates the docs to describe that both Windows and Linux support event-based sampling, and adds a small workaround to check for both OpenCL and OpenGL counters until the MDAPI library itself is updated.

## Testing Done

Verified that event-based sampling works on Linux via `cliloader --mdapi-ebs`.