### PR TITLE
Incorporate Max Subgroup Size Query for Kernel Info Tracking

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -4657,16 +4657,21 @@ void CLIntercept::addTimingEvent(
 
                 if( dispatch().clGetKernelSubGroupInfoKHR == NULL )
                 {
-                    cl_platform_id  platform = NULL;
-                    dispatch().clGetDeviceInfo(
-                        device,
-                        CL_DEVICE_PLATFORM,
-                        sizeof(platform),
-                        &platform,
-                        NULL );
-                    getExtensionFunctionAddress(
-                        platform,
-                        "clGetKernelSubGroupInfoKHR" );
+                    if( checkDeviceForExtension(
+                            device,
+                            "cl_khr_subgroups") )
+                    {
+                        cl_platform_id  platform = NULL;
+                        dispatch().clGetDeviceInfo(
+                            device,
+                            CL_DEVICE_PLATFORM,
+                            sizeof(platform),
+                            &platform,
+                            NULL );
+                        getExtensionFunctionAddress(
+                            platform,
+                            "clGetKernelSubGroupInfoKHR" );
+                    }
                 }
                 if( dispatch().clGetKernelSubGroupInfoKHR && maxsgs == 0 )
                 {


### PR DESCRIPTION
## Description of Changes

Kernel Info Tracking currently uses the "preferred work group size multiple" as a proxy for the "SIMD width" of the kernel.  This has empirically worked fairly well, but on some devices the "max subgroup size" provides a better estimate of the kernel's SIMD width.  This change incorporates that max subgroup size using the following algorithm:

1. If the passed-in local work size is NULL, query the maximum local work size for the kernel.  This is needed since the max subgroup size query needs the local work size.  Eventually, this could switch to a "suggested local work size" query for devices that support it.

2. Query the maximum subgroup size for the kernel using the API from `cl_khr_subgroups`, if the device supports `cl_khr_subgroups`.

3. If this query did not succeed, query the maximum subgroup size for the kernel using the API from OpenCL 2.1, if the device supports OpenCL 2.1.

4. Query the preferred work group size multiple for the kernel.

5. Use the smaller of the maximum subgroup size and the preferred work group size multiple as the "SIMD width" for the kernel, ignoring either query value if they are zero or otherwise failed.

Eventually I would like to remove the notion of a "SIMD width" from Kernel Info Tracking and report the maximum subgroup size and preferred work group size query directly instead.

## Testing Done

Checked that reasonable values are returned both for devices that support subgroups and devices that do not.