### PR TITLE
fix a build break when ENABLE_ITT is set

### DIFF
--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -1028,7 +1028,7 @@ private:
 
         __itt_track*        itt_track;
         __itt_clock_domain* itt_clock_domain;
-        uint64_t            CPUReferenceTime;
+        clock::time_point   CPUReferenceTime;
         cl_ulong            CLReferenceTime;
     };
 


### PR DESCRIPTION
## Description of Changes

A few parts of the ITT code were not updated for the switch to `std::chrono` timers and hence the build was failing.  This change updates this code to fix the build when `ENABLE_ITT` is set.

I looked into adding a config with `ENABLE_ITT` to the Travis builds, but doing so would require some way of acquiring the ITT headers and libs, and I'm not sure how to do that just yet.

## Testing Done

Successfully built with `ENABLE_ITT` set.
