### PR TITLE
log non-default control values

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -304,6 +304,17 @@ bool GetControl<std::string>(
     return success;
 }
 
+template<class T>
+static std::string GetNonDefaultString(
+    const char* name,
+    const T& value )
+{
+    std::ostringstream ss;
+    ss << std::boolalpha;
+    ss << "Control " << name << " is set to non-default value: " << value << "\n";
+    return ss.str();
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 //
 bool CLIntercept::init()
@@ -536,7 +547,10 @@ bool CLIntercept::init()
 #error Unknown OS!
 #endif
 
-#define CLI_CONTROL( _type, _name, _init, _desc ) if ( m_Config . _name != _init ) { log( #_name " is set to a non-default value!\n" ); }
+#define CLI_CONTROL( _type, _name, _init, _desc )                   \
+    if ( m_Config . _name != _init ) {                              \
+        log( GetNonDefaultString( #_name, m_Config . _name ) );     \
+    }
 #include "controls.h"
 #undef CLI_CONTROL
 


### PR DESCRIPTION
## Description of Changes

Previously, the Intercept Layer logged when a control was set to a non-default value, but it didn't log what the non-default value actually was.  After this change, the Intercept Layer will log both that a control is set to a non-default value, and what the value is.

Before:

```
HostPerformanceTiming is set to a non-default value!
DevicePerformanceTiming is set to a non-default value!
```

After:

```
Control HostPerformanceTiming is set to non-default value: true
Control DevicePerformanceTiming is set to non-default value: true
```

## Testing Done

Set integer, boolean, and string controls to non-default values and verified that the values of the controls were correctly included in the log.
