### PR TITLE
added driver version override

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -697,6 +697,10 @@ If set to a non-negative value, the clGetDeviceInfo() query for CL\_DEVICE\_PREF
 
 If set to a non-negative value, the clGetDeviceInfo() query for CL\_DEVICE\_PREFERRED\_VECTOR\_WIDTH\_DOUBLE will return this value instead of the true device preferred vector width.
 
+##### `DriverVersion` (string)
+
+If set to a non-empty string, the clGetDeviceInfo() query for CL\_DRIVER\_VERSION will return this value instead of the true driver version.
+
 ### Precompiled Kernel and Builtin Kernel Override Controls
 
 ##### `ForceByteBufferOverrides` (bool)

--- a/intercept/src/controls.h
+++ b/intercept/src/controls.h
@@ -186,6 +186,7 @@ CLI_CONTROL( cl_uint,       DevicePreferredVectorWidthLong,         UINT_MAX, "I
 CLI_CONTROL( cl_uint,       DevicePreferredVectorWidthHalf,         UINT_MAX, "If set to a non-negative value, the clGetDeviceInfo() query for CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF will return this value instead of the true device preferred vector width." )
 CLI_CONTROL( cl_uint,       DevicePreferredVectorWidthFloat,        UINT_MAX, "If set to a non-negative value, the clGetDeviceInfo() query for CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT will return this value instead of the true device preferred vector width." )
 CLI_CONTROL( cl_uint,       DevicePreferredVectorWidthDouble,       UINT_MAX, "If set to a non-negative value, the clGetDeviceInfo() query for CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE will return this value instead of the true device preferred vector width." )
+CLI_CONTROL( std::string,   DriverVersion,                          "",    "If set to a non-empty string, the clGetDeviceInfo() query for CL_DRIVER_VERSION will return this value instead of the true driver version." )
 
 CLI_CONTROL_SEPARATOR( Precompiled Kernel and Builtin Kernel Override Controls: )
 CLI_CONTROL( bool,          ForceByteBufferOverrides,               false, "If set to a nonzero value, each of the buffer functions that are overridden (via one or more of the keys below) will use a byte-wise operation to read/write/copy the buffer (default behavior is to try to copy multiple bytes at a time, if possible).  Note: Requires OpenCL 1.1 or the \"byte addressable store\" extension." )

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -8788,6 +8788,18 @@ bool CLIntercept::overrideGetDeviceInfo(
             deviceBuiltInKernels = NULL;
         }
         break;
+    case CL_DRIVER_VERSION:
+        if( m_Config.DriverVersion != "" )
+        {
+            char*   ptr = (char*)param_value;
+            errorCode = writeStringToMemory(
+                param_value_size,
+                m_Config.DriverVersion,
+                param_value_size_ret,
+                ptr );
+            override = true;
+        }
+        break;
     default:
         break;
     }


### PR DESCRIPTION
## Description of Changes

Adds a control to override the driver version string returned by `CL_DRIVER_VERSION`.

## Testing Done

Set the control and observed the set value was returned by `CL_DRIVER_VERSION`.
