### PR TITLE
Emulate Unified Shared Memory with Shared Virtual Memory

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -415,6 +415,10 @@ If set to a nonzero value, the Intercept Layer for OpenCL Applications will dump
 
 If set to a nonzero value, the Intercept Layer for OpenCL Applications will emulate support for the cl\_khr\_extended\_versioning extension.
 
+##### `Emulate_cl_intel_unified_shared_memory` (bool)
+
+If set to a nonzero value, the Intercept Layer for OpenCL Applications will emulate support for the cl\_intel\_unified\_shared\_memory extension USM APIs using SVM APIs.  This can be useful to test USM applications on an implementation that supports SVM, but not USM.
+
 ### Controls for Automatically Creating SPIR-V Modules
 
 ##### `AutoCreateSPIRV` (bool)

--- a/intercept/CMakeLists.txt
+++ b/intercept/CMakeLists.txt
@@ -78,6 +78,8 @@ set(CLINTERCEPT_SOURCE_FILES
     src/controls.h
     src/dispatch.cpp
     src/dispatch.h
+    src/emulate.cpp
+    src/emulate.h
     src/enummap.cpp
     src/enummap.h
     src/instrumentation.h

--- a/intercept/src/controls.h
+++ b/intercept/src/controls.h
@@ -108,6 +108,7 @@ CLI_CONTROL( bool,          DumpKernelISABinaries,                  false, "If s
 
 CLI_CONTROL_SEPARATOR( Controls for Emulating Features: )
 CLI_CONTROL( bool,          Emulate_cl_khr_extended_versioning,     false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will emulate support for the cl_khr_extended_versioning extension." )
+CLI_CONTROL( bool,          Emulate_cl_intel_unified_shared_memory, false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will emulate support for the cl_intel_unified_shared_memory extension USM APIs using SVM APIs.  This can be useful to test USM applications on an implementation that supports SVM, but not USM." )
 
 CLI_CONTROL_SEPARATOR( Controls for Automatically Creating SPIR-V Modules: )
 CLI_CONTROL( bool,          AutoCreateSPIRV,                        false,       "If set to a nonzero value, the Intercept Layer for OpenCL Applications will automatically create SPIR-V modules by invoking CLANG each time a program is built.  The filename will have the form \"CLI_<Program Number>_<Unique Program Hash Code>_<Compile Count>_<Unique Build Options Hash Code>.spv\".  Because invoking CLANG requires a file containing the OpenCL C source, setting this option implicitly sets DumpProgramSource as well.  Additionally, this feature is not available for injected program source." )

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -5238,7 +5238,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueNDRangeKernel)(
 
             if( pIntercept->config().Emulate_cl_intel_unified_shared_memory )
             {
-                pIntercept->shimSetKernelIndirectUSMExecInfo(
+                pIntercept->setUSMKernelExecInfo(
                     command_queue,
                     kernel );
             }
@@ -6770,7 +6770,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetKernelExecInfo) (
 
         if( pIntercept->config().Emulate_cl_intel_unified_shared_memory )
         {
-            retVal = pIntercept->shimTrackKernelExecInfo(
+            retVal = pIntercept->trackUSMKernelExecInfo(
                 kernel,
                 param_name,
                 param_value_size,

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -5236,6 +5236,13 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueNDRangeKernel)(
             ITT_ADD_ARRAY_PARAM_AS_METADATA(work_dim, local_work_size);
             ITT_ADD_ARRAY_PARAM_AS_METADATA(num_events_in_wait_list, event_wait_list);
 
+            if( pIntercept->config().Emulate_cl_intel_unified_shared_memory )
+            {
+                pIntercept->shimSetKernelIndirectUSMExecInfo(
+                    command_queue,
+                    kernel );
+            }
+
             retVal = CL_INVALID_OPERATION;
 
             if( ( retVal != CL_SUCCESS ) &&
@@ -6759,11 +6766,25 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetKernelExecInfo) (
             param_name );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatch().clSetKernelExecInfo(
-            kernel,
-            param_name,
-            param_value_size,
-            param_value );
+        cl_int  retVal = CL_INVALID_OPERATION;
+
+        if( pIntercept->config().Emulate_cl_intel_unified_shared_memory )
+        {
+            retVal = pIntercept->shimTrackKernelExecInfo(
+                kernel,
+                param_name,
+                param_value_size,
+                param_value );
+        }
+
+        if( retVal != CL_SUCCESS )
+        {
+            retVal = pIntercept->dispatch().clSetKernelExecInfo(
+                kernel,
+                param_name,
+                param_value_size,
+                param_value );
+        }
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
@@ -9079,8 +9100,8 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseVA_APIMediaSurfacesINTEL(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-CL_API_ENTRY void* CL_API_CALL
-clHostMemAllocINTEL(
+// cl_intel_unified_shared_memory
+CL_API_ENTRY void* CL_API_CALL clHostMemAllocINTEL(
     cl_context context,
     const cl_mem_properties_intel* properties,
     size_t size,
@@ -9089,7 +9110,8 @@ clHostMemAllocINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept )
+    if( pIntercept &&
+        pIntercept->dispatch().clHostMemAllocINTEL )
     {
         // TODO: Make properties string.
         CALL_LOGGING_ENTER( "context = %p, properties = %p, size = %d, alignment = %d",
@@ -9100,23 +9122,12 @@ clHostMemAllocINTEL(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        void*   retVal = NULL;
-        if( pIntercept->dispatch().clHostMemAllocINTEL )
-        {
-            retVal = pIntercept->dispatch().clHostMemAllocINTEL(
-                context,
-                properties,
-                size,
-                alignment,
-                errcode_ret );
-        }
-        else
-        {
-            if( errcode_ret )
-            {
-                errcode_ret[0] = CL_INVALID_OPERATION;
-            }
-        }
+        void*   retVal = pIntercept->dispatch().clHostMemAllocINTEL(
+            context,
+            properties,
+            size,
+            alignment,
+            errcode_ret );
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
@@ -9130,8 +9141,8 @@ clHostMemAllocINTEL(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-CL_API_ENTRY void* CL_API_CALL
-clDeviceMemAllocINTEL(
+// cl_intel_unified_shared_memory
+CL_API_ENTRY void* CL_API_CALL clDeviceMemAllocINTEL(
     cl_context context,
     cl_device_id device,
     const cl_mem_properties_intel* properties,
@@ -9141,7 +9152,8 @@ clDeviceMemAllocINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept )
+    if( pIntercept &&
+        pIntercept->dispatch().clDeviceMemAllocINTEL )
     {
         std::string deviceInfo;
         if( pIntercept->config().CallLogging )
@@ -9161,24 +9173,13 @@ clDeviceMemAllocINTEL(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        void*   retVal = NULL;
-        if( pIntercept->dispatch().clDeviceMemAllocINTEL )
-        {
-            retVal = pIntercept->dispatch().clDeviceMemAllocINTEL(
-                context,
-                device,
-                properties,
-                size,
-                alignment,
-                errcode_ret );
-        }
-        else
-        {
-            if( errcode_ret )
-            {
-                errcode_ret[0] = CL_INVALID_OPERATION;
-            }
-        }
+        void*   retVal = pIntercept->dispatch().clDeviceMemAllocINTEL(
+            context,
+            device,
+            properties,
+            size,
+            alignment,
+            errcode_ret );
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
@@ -9192,8 +9193,8 @@ clDeviceMemAllocINTEL(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-CL_API_ENTRY void* CL_API_CALL
-clSharedMemAllocINTEL(
+// cl_intel_unified_shared_memory
+CL_API_ENTRY void* CL_API_CALL clSharedMemAllocINTEL(
     cl_context context,
     cl_device_id device,
     const cl_mem_properties_intel* properties,
@@ -9203,7 +9204,8 @@ clSharedMemAllocINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept )
+    if( pIntercept &&
+        pIntercept->dispatch().clSharedMemAllocINTEL )
     {
         std::string deviceInfo;
         if( pIntercept->config().CallLogging )
@@ -9223,24 +9225,13 @@ clSharedMemAllocINTEL(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        void*   retVal = NULL;
-        if( pIntercept->dispatch().clSharedMemAllocINTEL )
-        {
-            retVal = pIntercept->dispatch().clSharedMemAllocINTEL(
-                context,
-                device,
-                properties,
-                size,
-                alignment,
-                errcode_ret );
-        }
-        else
-        {
-            if( errcode_ret )
-            {
-                errcode_ret[0] = CL_INVALID_OPERATION;
-            }
-        }
+        void*   retVal = pIntercept->dispatch().clSharedMemAllocINTEL(
+            context,
+            device,
+            properties,
+            size,
+            alignment,
+            errcode_ret );
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
@@ -9254,27 +9245,24 @@ clSharedMemAllocINTEL(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-CL_API_ENTRY cl_int CL_API_CALL
-clMemFreeINTEL(
+// cl_intel_unified_shared_memory
+CL_API_ENTRY cl_int CL_API_CALL clMemFreeINTEL(
     cl_context context,
     void* ptr)
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept )
+    if( pIntercept &&
+        pIntercept->dispatch().clMemFreeINTEL )
     {
         CALL_LOGGING_ENTER( "context = %p, ptr = %p",
             context,
             ptr );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = CL_INVALID_OPERATION;
-        if( pIntercept->dispatch().clMemFreeINTEL )
-        {
-            retVal = pIntercept->dispatch().clMemFreeINTEL(
-                context,
-                ptr );
-        }
+        cl_int  retVal = pIntercept->dispatch().clMemFreeINTEL(
+            context,
+            ptr );
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
@@ -9288,6 +9276,7 @@ clMemFreeINTEL(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+// cl_intel_unified_shared_memory
 CL_API_ENTRY cl_int CL_API_CALL
 clMemBlockingFreeINTEL(
     cl_context context,
@@ -9295,20 +9284,17 @@ clMemBlockingFreeINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept )
+    if( pIntercept &&
+        pIntercept->dispatch().clMemBlockingFreeINTEL )
     {
         CALL_LOGGING_ENTER( "context = %p, ptr = %p",
             context,
             ptr );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = CL_INVALID_OPERATION;
-        if( pIntercept->dispatch().clMemBlockingFreeINTEL )
-        {
-            retVal = pIntercept->dispatch().clMemBlockingFreeINTEL(
-                context,
-                ptr );
-        }
+        cl_int  retVal = pIntercept->dispatch().clMemBlockingFreeINTEL(
+            context,
+            ptr );
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
@@ -9322,6 +9308,7 @@ clMemBlockingFreeINTEL(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+// cl_intel_unified_shared_memory
 CL_API_ENTRY cl_int CL_API_CALL clGetMemAllocInfoINTEL(
     cl_context context,
     const void* ptr,
@@ -9332,7 +9319,8 @@ CL_API_ENTRY cl_int CL_API_CALL clGetMemAllocInfoINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept )
+    if( pIntercept &&
+        pIntercept->dispatch().clGetMemAllocInfoINTEL )
     {
         CALL_LOGGING_ENTER( "context = %p, ptr = %p, param_name = %s (%08X)",
             context,
@@ -9341,17 +9329,13 @@ CL_API_ENTRY cl_int CL_API_CALL clGetMemAllocInfoINTEL(
             param_name );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = CL_INVALID_OPERATION;
-        if( pIntercept->dispatch().clGetMemAllocInfoINTEL )
-        {
-            retVal = pIntercept->dispatch().clGetMemAllocInfoINTEL(
-                context,
-                ptr,
-                param_name,
-                param_value_size,
-                param_value,
-                param_value_size_ret );
-        }
+        cl_int  retVal = pIntercept->dispatch().clGetMemAllocInfoINTEL(
+            context,
+            ptr,
+            param_name,
+            param_value_size,
+            param_value,
+            param_value_size_ret );
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
@@ -9365,6 +9349,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetMemAllocInfoINTEL(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+// cl_intel_unified_shared_memory
 CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgMemPointerINTEL(
     cl_kernel kernel,
     cl_uint arg_index,
@@ -9372,7 +9357,8 @@ CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgMemPointerINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept )
+    if( pIntercept &&
+        pIntercept->dispatch().clSetKernelArgMemPointerINTEL )
     {
         CALL_LOGGING_ENTER_KERNEL(
             kernel,
@@ -9383,14 +9369,10 @@ CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgMemPointerINTEL(
         CHECK_KERNEL_ARG_USM_POINTER( kernel, arg_value );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = CL_INVALID_OPERATION;
-        if( pIntercept->dispatch().clSetKernelArgMemPointerINTEL )
-        {
-            retVal = pIntercept->dispatch().clSetKernelArgMemPointerINTEL(
-                kernel,
-                arg_index,
-                arg_value );
-        }
+        cl_int  retVal = pIntercept->dispatch().clSetKernelArgMemPointerINTEL(
+            kernel,
+            arg_index,
+            arg_value );
 
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
@@ -9404,6 +9386,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgMemPointerINTEL(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+// cl_intel_unified_shared_memory
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemsetINTEL(   // Deprecated
     cl_command_queue queue,
     void* dst_ptr,
@@ -9415,7 +9398,8 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemsetINTEL(   // Deprecated
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept )
+    if( pIntercept &&
+        pIntercept->dispatch().clEnqueueMemsetINTEL )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -9432,21 +9416,14 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemsetINTEL(   // Deprecated
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            if( pIntercept->dispatch().clEnqueueMemsetINTEL )
-            {
-                retVal = pIntercept->dispatch().clEnqueueMemsetINTEL(
-                    queue,
-                    dst_ptr,
-                    value,
-                    size,
-                    num_events_in_wait_list,
-                    event_wait_list,
-                    event );
-            }
-            else
-            {
-                retVal = CL_INVALID_OPERATION;
-            }
+            retVal = pIntercept->dispatch().clEnqueueMemsetINTEL(
+                queue,
+                dst_ptr,
+                value,
+                size,
+                num_events_in_wait_list,
+                event_wait_list,
+                event );
 
             CPU_PERFORMANCE_TIMING_END();
             DEVICE_PERFORMANCE_TIMING_END( queue, event );
@@ -9466,6 +9443,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemsetINTEL(   // Deprecated
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+// cl_intel_unified_shared_memory
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemFillINTEL(
     cl_command_queue queue,
     void* dst_ptr,
@@ -9478,7 +9456,8 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemFillINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept )
+    if( pIntercept &&
+        pIntercept->dispatch().clEnqueueMemFillINTEL )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -9495,22 +9474,15 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemFillINTEL(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            if( pIntercept->dispatch().clEnqueueMemFillINTEL )
-            {
-                retVal = pIntercept->dispatch().clEnqueueMemFillINTEL(
-                    queue,
-                    dst_ptr,
-                    pattern,
-                    pattern_size,
-                    size,
-                    num_events_in_wait_list,
-                    event_wait_list,
-                    event );
-            }
-            else
-            {
-                retVal = CL_INVALID_OPERATION;
-            }
+            retVal = pIntercept->dispatch().clEnqueueMemFillINTEL(
+                queue,
+                dst_ptr,
+                pattern,
+                pattern_size,
+                size,
+                num_events_in_wait_list,
+                event_wait_list,
+                event );
 
             CPU_PERFORMANCE_TIMING_END();
             DEVICE_PERFORMANCE_TIMING_END( queue, event );
@@ -9530,6 +9502,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemFillINTEL(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+// cl_intel_unified_shared_memory
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemcpyINTEL(
     cl_command_queue queue,
     cl_bool blocking,
@@ -9542,7 +9515,8 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemcpyINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept )
+    if( pIntercept &&
+        pIntercept->dispatch().clEnqueueMemcpyINTEL )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -9560,22 +9534,15 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemcpyINTEL(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            if( pIntercept->dispatch().clEnqueueMemcpyINTEL )
-            {
-                retVal = pIntercept->dispatch().clEnqueueMemcpyINTEL(
-                    queue,
-                    blocking,
-                    dst_ptr,
-                    src_ptr,
-                    size,
-                    num_events_in_wait_list,
-                    event_wait_list,
-                    event );
-            }
-            else
-            {
-                retVal = CL_INVALID_OPERATION;
-            }
+            retVal = pIntercept->dispatch().clEnqueueMemcpyINTEL(
+                queue,
+                blocking,
+                dst_ptr,
+                src_ptr,
+                size,
+                num_events_in_wait_list,
+                event_wait_list,
+                event );
 
             CPU_PERFORMANCE_TIMING_END();
             DEVICE_PERFORMANCE_TIMING_END( queue, event );
@@ -9595,6 +9562,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemcpyINTEL(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+// cl_intel_unified_shared_memory
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueMigrateMemINTEL(
     cl_command_queue queue,
     const void* ptr,
@@ -9606,7 +9574,8 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMigrateMemINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept )
+    if( pIntercept &&
+        pIntercept->dispatch().clEnqueueMigrateMemINTEL )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -9624,21 +9593,14 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMigrateMemINTEL(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            if( pIntercept->dispatch().clEnqueueMigrateMemINTEL )
-            {
-                retVal = pIntercept->dispatch().clEnqueueMigrateMemINTEL(
-                    queue,
-                    ptr,
-                    size,
-                    flags,
-                    num_events_in_wait_list,
-                    event_wait_list,
-                    event );
-            }
-            else
-            {
-                retVal = CL_INVALID_OPERATION;
-            }
+            retVal = pIntercept->dispatch().clEnqueueMigrateMemINTEL(
+                queue,
+                ptr,
+                size,
+                flags,
+                num_events_in_wait_list,
+                event_wait_list,
+                event );
 
             CPU_PERFORMANCE_TIMING_END();
             DEVICE_PERFORMANCE_TIMING_END( queue, event );
@@ -9658,6 +9620,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMigrateMemINTEL(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+// cl_intel_unified_shared_memory
 CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemAdviseINTEL(
     cl_command_queue queue,
     const void* ptr,
@@ -9669,7 +9632,8 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemAdviseINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept )
+    if( pIntercept &&
+        pIntercept->dispatch().clEnqueueMemAdviseINTEL )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -9687,21 +9651,14 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemAdviseINTEL(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            if( pIntercept->dispatch().clEnqueueMemAdviseINTEL )
-            {
-                retVal = pIntercept->dispatch().clEnqueueMemAdviseINTEL(
-                    queue,
-                    ptr,
-                    size,
-                    advice,
-                    num_events_in_wait_list,
-                    event_wait_list,
-                    event );
-            }
-            else
-            {
-                retVal = CL_INVALID_OPERATION;
-            }
+            retVal = pIntercept->dispatch().clEnqueueMemAdviseINTEL(
+                queue,
+                ptr,
+                size,
+                advice,
+                num_events_in_wait_list,
+                event_wait_list,
+                event );
 
             CPU_PERFORMANCE_TIMING_END();
             DEVICE_PERFORMANCE_TIMING_END( queue, event );

--- a/intercept/src/emulate.cpp
+++ b/intercept/src/emulate.cpp
@@ -38,7 +38,7 @@ void* CLI_API_CALL clHostMemAllocINTEL_EMU(
 
     if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory )
     {
-        return pIntercept->shimHostMemAlloc(
+        return pIntercept->emulatedHostMemAlloc(
             context,
             properties,
             size,
@@ -64,7 +64,7 @@ void* CLI_API_CALL clDeviceMemAllocINTEL_EMU(
 
     if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory )
     {
-        return pIntercept->shimDeviceMemAlloc(
+        return pIntercept->emulatedDeviceMemAlloc(
             context,
             device,
             properties,
@@ -91,7 +91,7 @@ void* CLI_API_CALL clSharedMemAllocINTEL_EMU(
 
     if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory )
     {
-        return pIntercept->shimSharedMemAlloc(
+        return pIntercept->emulatedSharedMemAlloc(
             context,
             device,
             properties,
@@ -114,7 +114,7 @@ cl_int CLI_API_CALL clMemFreeINTEL_EMU(
 
     if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory )
     {
-        return pIntercept->shimMemFree(
+        return pIntercept->emulatedMemFree(
             context,
             ptr );
     }
@@ -134,7 +134,7 @@ cl_int CLI_API_CALL clMemBlockingFreeINTEL_EMU(
     if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory )
     {
         // TODO: Track queues and block all.
-        return pIntercept->shimMemFree(
+        return pIntercept->emulatedMemFree(
             context,
             ptr );
     }
@@ -157,7 +157,7 @@ cl_int CLI_API_CALL clGetMemAllocInfoINTEL_EMU(
 
     if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory )
     {
-        return pIntercept->shimGetMemAllocInfoINTEL(
+        return pIntercept->emulatedGetMemAllocInfoINTEL(
             context,
             ptr,
             param_name,

--- a/intercept/src/emulate.cpp
+++ b/intercept/src/emulate.cpp
@@ -1,0 +1,355 @@
+/*
+// Copyright (c) 2018-2020 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+*/
+
+#include <string>
+
+#include "intercept.h"
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// cl_intel_unified_shared_memory
+void* CLI_API_CALL clHostMemAllocINTEL_EMU(
+    cl_context context,
+    const cl_mem_properties_intel* properties,
+    size_t size,
+    cl_uint alignment,
+    cl_int* errcode_ret)
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory )
+    {
+        return pIntercept->shimHostMemAlloc(
+            context,
+            properties,
+            size,
+            alignment,
+            errcode_ret );
+    }
+
+    return NULL;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// cl_intel_unified_shared_memory
+void* CLI_API_CALL clDeviceMemAllocINTEL_EMU(
+    cl_context context,
+    cl_device_id device,
+    const cl_mem_properties_intel* properties,
+    size_t size,
+    cl_uint alignment,
+    cl_int* errcode_ret)
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory )
+    {
+        return pIntercept->shimDeviceMemAlloc(
+            context,
+            device,
+            properties,
+            size,
+            alignment,
+            errcode_ret );
+    }
+
+    return NULL;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// cl_intel_unified_shared_memory
+void* CLI_API_CALL clSharedMemAllocINTEL_EMU(
+    cl_context context,
+    cl_device_id device,
+    const cl_mem_properties_intel* properties,
+    size_t size,
+    cl_uint alignment,
+    cl_int* errcode_ret)
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory )
+    {
+        return pIntercept->shimSharedMemAlloc(
+            context,
+            device,
+            properties,
+            size,
+            alignment,
+            errcode_ret );
+    }
+
+    return NULL;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// cl_intel_unified_shared_memory
+cl_int CLI_API_CALL clMemFreeINTEL_EMU(
+    cl_context context,
+    void* ptr)
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory )
+    {
+        return pIntercept->shimMemFree(
+            context,
+            ptr );
+    }
+
+    return CL_INVALID_OPERATION;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// cl_intel_unified_shared_memory
+cl_int CLI_API_CALL clMemBlockingFreeINTEL_EMU(
+    cl_context context,
+    void* ptr)
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory )
+    {
+        // TODO: Track queues and block all.
+        return pIntercept->shimMemFree(
+            context,
+            ptr );
+    }
+
+    return CL_INVALID_OPERATION;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// cl_intel_unified_shared_memory
+cl_int CLI_API_CALL clGetMemAllocInfoINTEL_EMU(
+    cl_context context,
+    const void* ptr,
+    cl_mem_info_intel param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory )
+    {
+        return pIntercept->shimGetMemAllocInfoINTEL(
+            context,
+            ptr,
+            param_name,
+            param_value_size,
+            param_value,
+            param_value_size_ret );
+    }
+
+    return CL_INVALID_OPERATION;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// cl_intel_unified_shared_memory
+cl_int CLI_API_CALL clSetKernelArgMemPointerINTEL_EMU(
+    cl_kernel kernel,
+    cl_uint arg_index,
+    const void* arg_value)
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory &&
+        pIntercept->dispatch().clSetKernelArgSVMPointer )
+    {
+        return pIntercept->dispatch().clSetKernelArgSVMPointer(
+            kernel,
+            arg_index,
+            arg_value );
+    }
+
+    return CL_INVALID_OPERATION;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// cl_intel_unified_shared_memory
+cl_int CLI_API_CALL clEnqueueMemsetINTEL_EMU(   // Deprecated
+    cl_command_queue queue,
+    void* dst_ptr,
+    cl_int value,
+    size_t size,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory &&
+        pIntercept->dispatch().clEnqueueSVMMemFill )
+    {
+        const cl_uchar  pattern = (cl_uchar)value;
+        return pIntercept->dispatch().clEnqueueSVMMemFill(
+            queue,
+            dst_ptr,
+            &pattern,
+            sizeof(pattern),
+            size,
+            num_events_in_wait_list,
+            event_wait_list,
+            event );
+    }
+
+    return CL_INVALID_OPERATION;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// cl_intel_unified_shared_memory
+cl_int CLI_API_CALL clEnqueueMemFillINTEL_EMU(
+    cl_command_queue queue,
+    void* dst_ptr,
+    const void* pattern,
+    size_t pattern_size,
+    size_t size,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory &&
+        pIntercept->dispatch().clEnqueueSVMMemFill )
+    {
+        return pIntercept->dispatch().clEnqueueSVMMemFill(
+            queue,
+            dst_ptr,
+            &pattern,
+            sizeof(pattern),
+            size,
+            num_events_in_wait_list,
+            event_wait_list,
+            event );
+    }
+
+    return CL_INVALID_OPERATION;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// cl_intel_unified_shared_memory
+cl_int CLI_API_CALL clEnqueueMemcpyINTEL_EMU(
+    cl_command_queue queue,
+    cl_bool blocking,
+    void* dst_ptr,
+    const void* src_ptr,
+    size_t size,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory &&
+        pIntercept->dispatch().clEnqueueSVMMemcpy )
+    {
+        return pIntercept->dispatch().clEnqueueSVMMemcpy(
+            queue,
+            blocking,
+            dst_ptr,
+            src_ptr,
+            size,
+            num_events_in_wait_list,
+            event_wait_list,
+            event );
+    }
+
+    return CL_INVALID_OPERATION;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// cl_intel_unified_shared_memory
+cl_int CLI_API_CALL clEnqueueMigrateMemINTEL_EMU(
+    cl_command_queue queue,
+    const void* ptr,
+    size_t size,
+    cl_mem_migration_flags flags,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory )
+    {
+        // We could check for OpenCL 2.1 and call the SVM migrate
+        // functions, but for now we'll just enqueue a marker.
+#if 0
+        return pIntercept->dispatch().clEnqueueSVMMigrateMem(
+            queue,
+            1,
+            &ptr,
+            &size,
+            flags,
+            num_events_in_wait_list,
+            event_wait_list,
+            event );
+#else
+        return pIntercept->dispatch().clEnqueueMarkerWithWaitList(
+            queue,
+            num_events_in_wait_list,
+            event_wait_list,
+            event );
+#endif
+    }
+
+    return CL_INVALID_OPERATION;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// cl_intel_unified_shared_memory
+cl_int CLI_API_CALL clEnqueueMemAdviseINTEL_EMU(
+    cl_command_queue queue,
+    const void* ptr,
+    size_t size,
+    cl_mem_advice_intel advice,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event)
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory )
+    {
+        // TODO: What should we do here?
+        return pIntercept->dispatch().clEnqueueMarkerWithWaitList(
+            queue,
+            num_events_in_wait_list,
+            event_wait_list,
+            event );
+    }
+
+    return CL_INVALID_OPERATION;
+}

--- a/intercept/src/emulate.h
+++ b/intercept/src/emulate.h
@@ -1,0 +1,116 @@
+/*
+// Copyright (c) 2018-2020 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+*/
+
+#include "intercept.h"
+
+// cl_intel_unified_shared_memory
+
+void* CLI_API_CALL clHostMemAllocINTEL_EMU(
+    cl_context context,
+    const cl_mem_properties_intel* properties,
+    size_t size,
+    cl_uint alignment,
+    cl_int* errcode_ret);
+
+void* CLI_API_CALL clDeviceMemAllocINTEL_EMU(
+    cl_context context,
+    cl_device_id device,
+    const cl_mem_properties_intel* properties,
+    size_t size,
+    cl_uint alignment,
+    cl_int* errcode_ret);
+
+void* CLI_API_CALL clSharedMemAllocINTEL_EMU(
+    cl_context context,
+    cl_device_id device,
+    const cl_mem_properties_intel* properties,
+    size_t size,
+    cl_uint alignment,
+    cl_int* errcode_ret);
+
+cl_int CLI_API_CALL clMemFreeINTEL_EMU(
+    cl_context context,
+    void* ptr);
+
+cl_int CLI_API_CALL clMemBlockingFreeINTEL_EMU(
+    cl_context context,
+    void* ptr);
+
+cl_int CLI_API_CALL clGetMemAllocInfoINTEL_EMU(
+    cl_context context,
+    const void* ptr,
+    cl_mem_info_intel param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret);
+
+cl_int CLI_API_CALL clSetKernelArgMemPointerINTEL_EMU(
+    cl_kernel kernel,
+    cl_uint arg_index,
+    const void* arg_value);
+
+cl_int CLI_API_CALL clEnqueueMemsetINTEL_EMU(   // Deprecated
+    cl_command_queue queue,
+    void* dst_ptr,
+    cl_int value,
+    size_t size,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event);
+
+cl_int CLI_API_CALL clEnqueueMemFillINTEL_EMU(
+    cl_command_queue queue,
+    void* dst_ptr,
+    const void* pattern,
+    size_t pattern_size,
+    size_t size,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event);
+
+cl_int CLI_API_CALL clEnqueueMemcpyINTEL_EMU(
+    cl_command_queue queue,
+    cl_bool blocking,
+    void* dst_ptr,
+    const void* src_ptr,
+    size_t size,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event);
+
+cl_int CLI_API_CALL clEnqueueMigrateMemINTEL_EMU(
+    cl_command_queue queue,
+    const void* ptr,
+    size_t size,
+    cl_mem_migration_flags flags,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event);
+
+cl_int CLI_API_CALL clEnqueueMemAdviseINTEL_EMU(
+    cl_command_queue queue,
+    const void* ptr,
+    size_t size,
+    cl_mem_advice_intel advice,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event);

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -12629,9 +12629,6 @@ cl_int CLIntercept::setUSMKernelExecInfo(
 
         const SUSMContextInfo& usmContextInfo = m_USMContextInfoMap[context];
 
-        // If we supported multiple devices, we'd get the device from
-        // the queue and map it to the device's allocation vector here.
-
         std::lock_guard<std::mutex> lock(m_Mutex);
 
         bool    hasSVMPtrs =

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -10708,7 +10708,7 @@ void CLIntercept::SIMDSurveyNDRangeKernel(
     {                                                                       \
         if( dispatch() . funcname == NULL )                                 \
         {                                                                   \
-            void *func = funcname##_EMU;                                    \
+            void *func = (void*)funcname##_EMU;                             \
             void** pfunc = (void**)( &m_Dispatch . funcname );              \
             *pfunc = func;                                                  \
         }                                                                   \

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -12711,12 +12711,11 @@ cl_int CLIntercept::setUSMKernelExecInfo(
             size_t  count =
                 usmKernelInfo.SVMPtrs.size() +
                 usmKernelInfo.USMPtrs.size() +
-                setHostAllocs ? usmContextInfo.HostAllocVector.size() : 0 +
-                setDeviceAllocs ? usmContextInfo.DeviceAllocVector.size() : 0 +
-                setSharedAllocs ? usmContextInfo.SharedAllocVector.size() : 0;
+                ( setHostAllocs ? usmContextInfo.HostAllocVector.size() : 0 ) +
+                ( setDeviceAllocs ? usmContextInfo.DeviceAllocVector.size() : 0 ) +
+                ( setSharedAllocs ? usmContextInfo.SharedAllocVector.size() : 0 );
 
-            std::vector<const void*>  combined;
-            combined.reserve( count );
+            std::vector<const void*>  combined( count );
 
             combined.insert(
                 combined.end(),

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -8453,7 +8453,7 @@ bool CLIntercept::overrideGetDeviceInfo(
             override = true;
         }
         else if( m_Config.Emulate_cl_khr_extended_versioning ||
-		         m_Config.Emulate_cl_intel_unified_shared_memory )
+                 m_Config.Emulate_cl_intel_unified_shared_memory )
         {
             std::string newExtensions;
             if( m_Config.Emulate_cl_khr_extended_versioning &&
@@ -8721,8 +8721,17 @@ bool CLIntercept::overrideGetDeviceInfo(
     case CL_DEVICE_EXTENSIONS_WITH_VERSION_KHR:
         if( m_Config.Emulate_cl_khr_extended_versioning )
         {
-            std::string deviceExtensions =
-                "cl_khr_extended_versioning ";
+            std::string deviceExtensions;
+            if( m_Config.Emulate_cl_khr_extended_versioning &&
+                !checkDeviceForExtension( device, "cl_khr_extended_versioning") )
+            {
+                deviceExtensions += "cl_khr_extended_versioning ";
+            }
+            if( m_Config.Emulate_cl_intel_unified_shared_memory &&
+                !checkDeviceForExtension( device, "cl_intel_unified_shared_memory") )
+            {
+                deviceExtensions += "cl_intel_unified_shared_memory ";
+            }
 
             char*   tempDeviceExtensions = NULL;
 
@@ -12135,7 +12144,7 @@ bool CLIntercept::checkAubCaptureKernelSignature(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-static bool shimValidateMemProperties(
+static bool validateUSMMemProperties(
     const cl_mem_properties_intel* properties )
 {
     if( properties )
@@ -12171,14 +12180,14 @@ static bool shimValidateMemProperties(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-void* CLIntercept::shimHostMemAlloc(
+void* CLIntercept::emulatedHostMemAlloc(
     cl_context context,
     const cl_mem_properties_intel* properties,
     size_t size,
     cl_uint alignment,
     cl_int* errcode_ret)
 {
-    if( !shimValidateMemProperties(properties) )
+    if( !validateUSMMemProperties(properties) )
     {
         if( errcode_ret )
         {
@@ -12234,7 +12243,7 @@ void* CLIntercept::shimHostMemAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-void* CLIntercept::shimDeviceMemAlloc(
+void* CLIntercept::emulatedDeviceMemAlloc(
     cl_context context,
     cl_device_id device,
     const cl_mem_properties_intel* properties,
@@ -12242,7 +12251,7 @@ void* CLIntercept::shimDeviceMemAlloc(
     cl_uint alignment,
     cl_int* errcode_ret)
 {
-    if( !shimValidateMemProperties(properties) )
+    if( !validateUSMMemProperties(properties) )
     {
         if( errcode_ret )
         {
@@ -12287,7 +12296,7 @@ void* CLIntercept::shimDeviceMemAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-void* CLIntercept::shimSharedMemAlloc(
+void* CLIntercept::emulatedSharedMemAlloc(
     cl_context context,
     cl_device_id device,
     const cl_mem_properties_intel* properties,
@@ -12295,7 +12304,7 @@ void* CLIntercept::shimSharedMemAlloc(
     cl_uint alignment,
     cl_int* errcode_ret)
 {
-    if( !shimValidateMemProperties(properties) )
+    if( !validateUSMMemProperties(properties) )
     {
         if( errcode_ret )
         {
@@ -12352,7 +12361,7 @@ void* CLIntercept::shimSharedMemAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-cl_int CLIntercept::shimMemFree(
+cl_int CLIntercept::emulatedMemFree(
     cl_context context,
     const void* ptr )
 {
@@ -12408,7 +12417,7 @@ cl_int CLIntercept::shimMemFree(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-cl_int CLIntercept::shimGetMemAllocInfoINTEL(
+cl_int CLIntercept::emulatedGetMemAllocInfoINTEL(
     cl_context context,
     const void* ptr,
     cl_mem_info_intel param_name,
@@ -12511,7 +12520,7 @@ cl_int CLIntercept::shimGetMemAllocInfoINTEL(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-cl_int CLIntercept::shimTrackKernelExecInfo(
+cl_int CLIntercept::trackUSMKernelExecInfo(
     cl_kernel kernel,
     cl_kernel_exec_info param_name,
     size_t param_value_size,
@@ -12591,7 +12600,7 @@ cl_int CLIntercept::shimTrackKernelExecInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-cl_int CLIntercept::shimSetKernelIndirectUSMExecInfo(
+cl_int CLIntercept::setUSMKernelExecInfo(
     cl_command_queue commandQueue,
     cl_kernel kernel )
 {

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -701,33 +701,31 @@ public:
                 cl_event event,
                 clock::time_point queuedTime );
 
-    // USM Shim:
-    void*   shimHostMemAlloc(
+    // USM Emulation:
+    void*   emulatedHostMemAlloc(
                 cl_context context,
                 const cl_mem_properties_intel* properties,
                 size_t size,
                 cl_uint alignment,
                 cl_int* errcode_ret);
-    void*   shimDeviceMemAlloc(
-                cl_context context,
-                cl_device_id device,
-                const cl_mem_properties_intel* properties,
-                size_t size,
-                cl_uint alignment,
-                cl_int* errcode_ret);
-    void*   shimSharedMemAlloc(
+    void*   emulatedDeviceMemAlloc(
                 cl_context context,
                 cl_device_id device,
                 const cl_mem_properties_intel* properties,
                 size_t size,
                 cl_uint alignment,
                 cl_int* errcode_ret);
-
-    cl_int  shimMemFree(
+    void*   emulatedSharedMemAlloc(
+                cl_context context,
+                cl_device_id device,
+                const cl_mem_properties_intel* properties,
+                size_t size,
+                cl_uint alignment,
+                cl_int* errcode_ret);
+    cl_int  emulatedMemFree(
                 cl_context context,
                 const void* ptr );
-
-    cl_int  shimGetMemAllocInfoINTEL(
+    cl_int  emulatedGetMemAllocInfoINTEL(
                 cl_context context,
                 const void* ptr,
                 cl_mem_info_intel param_name,
@@ -735,13 +733,12 @@ public:
                 void* param_value,
                 size_t* param_value_size_ret);
 
-    cl_int  shimTrackKernelExecInfo(
+    cl_int  trackUSMKernelExecInfo(
                 cl_kernel kernel,
                 cl_kernel_exec_info param_name,
                 size_t param_value_size,
                 const void* param_value);
-
-    cl_int  shimSetKernelIndirectUSMExecInfo(
+    cl_int  setUSMKernelExecInfo(
                 cl_command_queue queue,
                 cl_kernel kernel );
 
@@ -1081,7 +1078,7 @@ private:
     CITTQueueInfoMap    m_ITTQueueInfoMap;
 #endif
 
-    // USM Shim:
+    // USM Emulation:
     struct SUSMAllocInfo
     {
         SUSMAllocInfo() :

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -1104,9 +1104,10 @@ private:
         CUSMAllocMap    AllocMap;
 
         CUSMAllocVector HostAllocVector;
-        // TODO: Support multiple devices by mapping device-> vector?
         CUSMAllocVector DeviceAllocVector;
         CUSMAllocVector SharedAllocVector;
+        // Note: We could differentiate between device allocs for
+        // specific devices, but we do not do this currently.
     };
 
     typedef std::map< cl_context, SUSMContextInfo > CUSMContextInfoMap;

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -701,6 +701,50 @@ public:
                 cl_event event,
                 clock::time_point queuedTime );
 
+    // USM Shim:
+    void*   shimHostMemAlloc(
+                cl_context context,
+                const cl_mem_properties_intel* properties,
+                size_t size,
+                cl_uint alignment,
+                cl_int* errcode_ret);
+    void*   shimDeviceMemAlloc(
+                cl_context context,
+                cl_device_id device,
+                const cl_mem_properties_intel* properties,
+                size_t size,
+                cl_uint alignment,
+                cl_int* errcode_ret);
+    void*   shimSharedMemAlloc(
+                cl_context context,
+                cl_device_id device,
+                const cl_mem_properties_intel* properties,
+                size_t size,
+                cl_uint alignment,
+                cl_int* errcode_ret);
+
+    cl_int  shimMemFree(
+                cl_context context,
+                const void* ptr );
+
+    cl_int  shimGetMemAllocInfoINTEL(
+                cl_context context,
+                const void* ptr,
+                cl_mem_info_intel param_name,
+                size_t param_value_size,
+                void* param_value,
+                size_t* param_value_size_ret);
+
+    cl_int  shimTrackKernelExecInfo(
+                cl_kernel kernel,
+                cl_kernel_exec_info param_name,
+                size_t param_value_size,
+                const void* param_value);
+
+    cl_int  shimSetKernelIndirectUSMExecInfo(
+                cl_command_queue queue,
+                cl_kernel kernel );
+
 private:
     static const char* sc_URL;
     static const char* sc_DumpDirectoryName;
@@ -1036,6 +1080,59 @@ private:
     typedef std::map< cl_command_queue, SITTQueueInfo > CITTQueueInfoMap;
     CITTQueueInfoMap    m_ITTQueueInfoMap;
 #endif
+
+    // USM Shim:
+    struct SUSMAllocInfo
+    {
+        SUSMAllocInfo() :
+            Type( CL_MEM_TYPE_UNKNOWN_INTEL ),
+            Device( NULL ),
+            BaseAddress( NULL ),
+            Size( 0 ),
+            Alignment( 0 ) {}
+
+        cl_unified_shared_memory_type_intel Type;
+        cl_device_id    Device;
+
+        const void*     BaseAddress;
+        size_t          Size;
+        size_t          Alignment;
+    };
+
+    typedef std::map< const void*, SUSMAllocInfo >  CUSMAllocMap;
+    typedef std::vector<const void*>    CUSMAllocVector;
+
+    struct SUSMContextInfo
+    {
+        CUSMAllocMap    AllocMap;
+
+        CUSMAllocVector HostAllocVector;
+        // TODO: Support multiple devices by mapping device-> vector?
+        CUSMAllocVector DeviceAllocVector;
+        CUSMAllocVector SharedAllocVector;
+    };
+
+    // TODO: Support multiple contexts by mapping context -> USMContextInfo?
+    SUSMContextInfo m_USMContextInfo;
+
+    struct SUSMKernelInfo
+    {
+        SUSMKernelInfo() :
+            IndirectHostAccess( false ),
+            IndirectDeviceAccess( false ),
+            IndirectSharedAccess( false ) {}
+
+        bool    IndirectHostAccess;
+        bool    IndirectDeviceAccess;
+        bool    IndirectSharedAccess;
+
+        std::vector<void*>  SVMPtrs;
+        std::vector<void*>  USMPtrs;
+    };
+
+    typedef std::map< cl_kernel, SUSMKernelInfo >   CUSMKernelInfoMap;
+
+    CUSMKernelInfoMap   m_USMKernelInfoMap;
 
     DISALLOW_COPY_AND_ASSIGN( CLIntercept );
 };
@@ -2195,10 +2292,10 @@ inline cl_device_type CLIntercept::filterDeviceType( cl_device_type device_type 
     return device_type;
 }
 
-///////////////////////////////////////////////////////////////////////////////
-//
 #if defined(USE_ITT)
 
+///////////////////////////////////////////////////////////////////////////////
+//
 inline __itt_domain* CLIntercept::ittDomain() const
 {
     return m_ITTDomain;

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -1109,8 +1109,8 @@ private:
         CUSMAllocVector SharedAllocVector;
     };
 
-    // TODO: Support multiple contexts by mapping context -> USMContextInfo?
-    SUSMContextInfo m_USMContextInfo;
+    typedef std::map< cl_context, SUSMContextInfo > CUSMContextInfoMap;
+    CUSMContextInfoMap  m_USMContextInfoMap;
 
     struct SUSMKernelInfo
     {
@@ -1128,7 +1128,6 @@ private:
     };
 
     typedef std::map< cl_kernel, SUSMKernelInfo >   CUSMKernelInfoMap;
-
     CUSMKernelInfoMap   m_USMKernelInfoMap;
 
     DISALLOW_COPY_AND_ASSIGN( CLIntercept );


### PR DESCRIPTION
## Description of Changes

This change adds emulation of Unified Shared Memory (USM) for devices that support Shared Virtual Memory (SVM).  The Unified Shared Memory capabilities are dependent on the Shared Virtual Memory capabilities of the device, but even devices that only support coarse grain Shared Virtual Memory can still support basic "device" Unified Shared Memory.  The emulation works even on devices that support Shared Virtual Memory unofficially, without reporting support for OpenCL 2.0.

Most of the changes involve tracking Unified Shared Memory allocations for querying purposes and for indirect usage of Unified Shared Memory.  Most of the remaining changes are simply routing Unified Shared Memory calls to SVM equivalents.

The Unified Shared Memory extension is still a "preview" specification and may be found here:

* https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc

## Testing Done

Tested [USM samples](https://github.com/bashbaug/SimpleOpenCLSamples/tree/master/samples/usm) on devices that do not natively support USM.