### PR TITLE
add missing chrome tracing critical section

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -11536,7 +11536,7 @@ void CLIntercept::chromeCallLoggingExit(
     clock::time_point tickStart,
     clock::time_point tickEnd )
 {
-    // Critical section?
+    std::lock_guard<std::mutex> lock(m_Mutex);
 
     std::string str;
     str += functionName;


### PR DESCRIPTION
## Description of Changes

Added a missing critical section in ChromeCallLogging.  This is a likely fix for #147.

## Testing Done

Ran a few apps with both ChromeCallLogging and ChromeTracing enabled and didn't see any errors.  Admittedly this not targeted multi-threaded testing.