### PR TITLE
Add Support for Multi-Platform Apps with Extensions

### DIFF
--- a/intercept/mdapi/intercept_mdapi.cpp
+++ b/intercept/mdapi/intercept_mdapi.cpp
@@ -151,18 +151,17 @@ cl_command_queue CLIntercept::createMDAPICommandQueue(
     // devices then we will need a different mechanism to get a
     // device-specific function pointer.
 
-    cl_platform_id  platform = NULL;
-    dispatch().clGetDeviceInfo(
-        device,
-        CL_DEVICE_PLATFORM,
-        sizeof(platform),
-        &platform,
-        NULL );
-    getExtensionFunctionAddress(
-        platform,
-        "clCreatePerfCountersCommandQueueINTEL" );
+    cl_platform_id  platform = getPlatform(device);
+    auto dispatchX = this->dispatchX(platform);
 
-    if( dispatchX().clCreatePerfCountersCommandQueueINTEL && m_pMDHelper )
+    if( dispatchX.clCreatePerfCountersCommandQueueINTEL == NULL )
+    {
+        getExtensionFunctionAddress(
+            platform,
+            "clCreatePerfCountersCommandQueueINTEL" );
+    }
+
+    if( dispatchX.clCreatePerfCountersCommandQueueINTEL && m_pMDHelper )
     {
         std::lock_guard<std::mutex> lock(m_Mutex);
 
@@ -170,7 +169,7 @@ cl_command_queue CLIntercept::createMDAPICommandQueue(
         {
             cl_uint configuration = m_pMDHelper->GetMetricsConfiguration();
 
-            retVal = dispatchX().clCreatePerfCountersCommandQueueINTEL(
+            retVal = dispatchX.clCreatePerfCountersCommandQueueINTEL(
                 context,
                 device,
                 properties,

--- a/intercept/mdapi/intercept_mdapi.cpp
+++ b/intercept/mdapi/intercept_mdapi.cpp
@@ -162,7 +162,7 @@ cl_command_queue CLIntercept::createMDAPICommandQueue(
         platform,
         "clCreatePerfCountersCommandQueueINTEL" );
 
-    if( dispatch().clCreatePerfCountersCommandQueueINTEL && m_pMDHelper )
+    if( dispatchX().clCreatePerfCountersCommandQueueINTEL && m_pMDHelper )
     {
         std::lock_guard<std::mutex> lock(m_Mutex);
 
@@ -170,7 +170,7 @@ cl_command_queue CLIntercept::createMDAPICommandQueue(
         {
             cl_uint configuration = m_pMDHelper->GetMetricsConfiguration();
 
-            retVal = dispatch().clCreatePerfCountersCommandQueueINTEL(
+            retVal = dispatchX().clCreatePerfCountersCommandQueueINTEL(
                 context,
                 device,
                 properties,

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -5187,7 +5187,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLBuffer)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateFromGLBuffer )
+    if( pIntercept && pIntercept->dispatchX().clCreateFromGLBuffer )
     {
         CALL_LOGGING_ENTER(
             "context = %p, "
@@ -5198,7 +5198,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLBuffer)(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatch().clCreateFromGLBuffer(
+        cl_mem  retVal = pIntercept->dispatchX().clCreateFromGLBuffer(
             context,
             flags,
             bufobj,
@@ -5229,7 +5229,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateFromGLTexture )
+    if( pIntercept && pIntercept->dispatchX().clCreateFromGLTexture )
     {
         CALL_LOGGING_ENTER(
             "context = %p, "
@@ -5248,7 +5248,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture)(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatch().clCreateFromGLTexture(
+        cl_mem  retVal = pIntercept->dispatchX().clCreateFromGLTexture(
             context,
             flags,
             target,
@@ -5283,7 +5283,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture2D)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateFromGLTexture2D )
+    if( pIntercept && pIntercept->dispatchX().clCreateFromGLTexture2D )
     {
         CALL_LOGGING_ENTER(
             "context = %p, "
@@ -5302,7 +5302,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture2D)(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatch().clCreateFromGLTexture2D(
+        cl_mem  retVal = pIntercept->dispatchX().clCreateFromGLTexture2D(
             context,
             flags,
             target,
@@ -5337,7 +5337,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture3D)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateFromGLTexture3D )
+    if( pIntercept && pIntercept->dispatchX().clCreateFromGLTexture3D )
     {
         CALL_LOGGING_ENTER(
             "context = %p, "
@@ -5356,7 +5356,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture3D)(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatch().clCreateFromGLTexture3D(
+        cl_mem  retVal = pIntercept->dispatchX().clCreateFromGLTexture3D(
             context,
             flags,
             target,
@@ -5389,7 +5389,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLRenderbuffer)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateFromGLRenderbuffer )
+    if( pIntercept && pIntercept->dispatchX().clCreateFromGLRenderbuffer )
     {
         CALL_LOGGING_ENTER(
             "context = %p, "
@@ -5400,7 +5400,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLRenderbuffer)(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatch().clCreateFromGLRenderbuffer(
+        cl_mem  retVal = pIntercept->dispatchX().clCreateFromGLRenderbuffer(
             context,
             flags,
             renderbuffer,
@@ -5427,12 +5427,12 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetGLObjectInfo)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clGetGLObjectInfo )
+    if( pIntercept && pIntercept->dispatchX().clGetGLObjectInfo )
     {
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatch().clGetGLObjectInfo(
+        cl_int  retVal = pIntercept->dispatchX().clGetGLObjectInfo(
             memobj,
             gl_object_type,
             gl_object_name);
@@ -5458,12 +5458,12 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetGLTextureInfo)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clGetGLTextureInfo )
+    if( pIntercept && pIntercept->dispatchX().clGetGLTextureInfo )
     {
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatch().clGetGLTextureInfo(
+        cl_int  retVal = pIntercept->dispatchX().clGetGLTextureInfo(
             memobj,
             param_name,
             param_value_size,
@@ -5492,7 +5492,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueAcquireGLObjects)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clEnqueueAcquireGLObjects )
+    if( pIntercept && pIntercept->dispatchX().clEnqueueAcquireGLObjects )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -5506,7 +5506,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueAcquireGLObjects)(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = pIntercept->dispatch().clEnqueueAcquireGLObjects(
+            retVal = pIntercept->dispatchX().clEnqueueAcquireGLObjects(
                 command_queue,
                 num_objects,
                 mem_objects,
@@ -5542,7 +5542,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReleaseGLObjects)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clEnqueueReleaseGLObjects )
+    if( pIntercept && pIntercept->dispatchX().clEnqueueReleaseGLObjects )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -5556,7 +5556,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReleaseGLObjects)(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = pIntercept->dispatch().clEnqueueReleaseGLObjects(
+            retVal = pIntercept->dispatchX().clEnqueueReleaseGLObjects(
                 command_queue,
                 num_objects,
                 mem_objects,
@@ -6189,7 +6189,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithPropertiesKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateCommandQueueWithPropertiesKHR )
+    if( pIntercept && pIntercept->dispatchX().clCreateCommandQueueWithPropertiesKHR )
     {
         cl_queue_properties*    newProperties = NULL;
         cl_command_queue    retVal = NULL;
@@ -6238,7 +6238,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithPropertiesKHR(
 
         if( ( retVal == NULL ) && newProperties )
         {
-            retVal = pIntercept->dispatch().clCreateCommandQueueWithPropertiesKHR(
+            retVal = pIntercept->dispatchX().clCreateCommandQueueWithPropertiesKHR(
                 context,
                 device,
                 newProperties,
@@ -6246,7 +6246,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithPropertiesKHR(
         }
         if( retVal == NULL )
         {
-            retVal = pIntercept->dispatch().clCreateCommandQueueWithPropertiesKHR(
+            retVal = pIntercept->dispatchX().clCreateCommandQueueWithPropertiesKHR(
                 context,
                 device,
                 properties,
@@ -6453,7 +6453,7 @@ CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithILKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateProgramWithILKHR )
+    if( pIntercept && pIntercept->dispatchX().clCreateProgramWithILKHR )
     {
         char*       injectedSPIRV = NULL;
         uint64_t    hash = 0;
@@ -6467,7 +6467,7 @@ CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithILKHR(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_program  retVal = pIntercept->dispatch().clCreateProgramWithILKHR(
+        cl_program  retVal = pIntercept->dispatchX().clCreateProgramWithILKHR(
             context,
             il,
             length,
@@ -6575,14 +6575,14 @@ CL_API_ENTRY cl_int CL_API_CALL clGetKernelSubGroupInfoKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clGetKernelSubGroupInfoKHR )
+    if( pIntercept && pIntercept->dispatchX().clGetKernelSubGroupInfoKHR )
     {
         cl_int  retVal = CL_SUCCESS;
 
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
-        retVal = pIntercept->dispatch().clGetKernelSubGroupInfoKHR(
+        retVal = pIntercept->dispatchX().clGetKernelSubGroupInfoKHR(
             kernel,
             device,
             param_name,
@@ -6668,12 +6668,12 @@ CL_API_ENTRY cl_int CL_API_CALL clGetGLContextInfoKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clGetGLContextInfoKHR )
+    if( pIntercept && pIntercept->dispatchX().clGetGLContextInfoKHR )
     {
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatch().clGetGLContextInfoKHR(
+        cl_int  retVal = pIntercept->dispatchX().clGetGLContextInfoKHR(
             properties,
             param_name,
             param_value_size,
@@ -6700,14 +6700,14 @@ CL_API_ENTRY cl_event CL_API_CALL clCreateEventFromGLsyncKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateEventFromGLsyncKHR )
+    if( pIntercept && pIntercept->dispatchX().clCreateEventFromGLsyncKHR )
     {
         CALL_LOGGING_ENTER( "context = %p",
             context );
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_event    retVal = pIntercept->dispatch().clCreateEventFromGLsyncKHR(
+        cl_event    retVal = pIntercept->dispatchX().clCreateEventFromGLsyncKHR(
             context,
             sync,
             errcode_ret);
@@ -6739,12 +6739,12 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D10KHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clGetDeviceIDsFromD3D10KHR )
+    if( pIntercept && pIntercept->dispatchX().clGetDeviceIDsFromD3D10KHR )
     {
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatch().clGetDeviceIDsFromD3D10KHR(
+        cl_int  retVal = pIntercept->dispatchX().clGetDeviceIDsFromD3D10KHR(
             platform,
             d3d_device_source,
             d3d_object,
@@ -6774,7 +6774,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10BufferKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateFromD3D10BufferKHR )
+    if( pIntercept && pIntercept->dispatchX().clCreateFromD3D10BufferKHR )
     {
         CALL_LOGGING_ENTER(
             "context = %p, "
@@ -6785,7 +6785,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10BufferKHR(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatch().clCreateFromD3D10BufferKHR(
+        cl_mem  retVal = pIntercept->dispatchX().clCreateFromD3D10BufferKHR(
             context,
             flags,
             resource,
@@ -6815,7 +6815,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture2DKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateFromD3D10Texture2DKHR )
+    if( pIntercept && pIntercept->dispatchX().clCreateFromD3D10Texture2DKHR )
     {
         CALL_LOGGING_ENTER(
             "context = %p, "
@@ -6826,7 +6826,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture2DKHR(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatch().clCreateFromD3D10Texture2DKHR(
+        cl_mem  retVal = pIntercept->dispatchX().clCreateFromD3D10Texture2DKHR(
             context,
             flags,
             resource,
@@ -6857,7 +6857,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture3DKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateFromD3D10Texture3DKHR )
+    if( pIntercept && pIntercept->dispatchX().clCreateFromD3D10Texture3DKHR )
     {
         CALL_LOGGING_ENTER(
             "context = %p, "
@@ -6868,7 +6868,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture3DKHR(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatch().clCreateFromD3D10Texture3DKHR(
+        cl_mem  retVal = pIntercept->dispatchX().clCreateFromD3D10Texture3DKHR(
             context,
             flags,
             resource,
@@ -6900,7 +6900,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D10ObjectsKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clEnqueueAcquireD3D10ObjectsKHR )
+    if( pIntercept && pIntercept->dispatchX().clEnqueueAcquireD3D10ObjectsKHR )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -6913,7 +6913,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D10ObjectsKHR(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = pIntercept->dispatch().clEnqueueAcquireD3D10ObjectsKHR(
+            retVal = pIntercept->dispatchX().clEnqueueAcquireD3D10ObjectsKHR(
                 command_queue,
                 num_objects,
                 mem_objects,
@@ -6950,7 +6950,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D10ObjectsKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clEnqueueReleaseD3D10ObjectsKHR )
+    if( pIntercept && pIntercept->dispatchX().clEnqueueReleaseD3D10ObjectsKHR )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -6963,7 +6963,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D10ObjectsKHR(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = pIntercept->dispatch().clEnqueueReleaseD3D10ObjectsKHR(
+            retVal = pIntercept->dispatchX().clEnqueueReleaseD3D10ObjectsKHR(
                 command_queue,
                 num_objects,
                 mem_objects,
@@ -7003,12 +7003,12 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D11KHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clGetDeviceIDsFromD3D11KHR )
+    if( pIntercept && pIntercept->dispatchX().clGetDeviceIDsFromD3D11KHR )
     {
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatch().clGetDeviceIDsFromD3D11KHR(
+        cl_int  retVal = pIntercept->dispatchX().clGetDeviceIDsFromD3D11KHR(
             platform,
             d3d_device_source,
             d3d_object,
@@ -7038,7 +7038,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11BufferKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateFromD3D11BufferKHR )
+    if( pIntercept && pIntercept->dispatchX().clCreateFromD3D11BufferKHR )
     {
         CALL_LOGGING_ENTER(
             "context = %p, "
@@ -7049,7 +7049,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11BufferKHR(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatch().clCreateFromD3D11BufferKHR(
+        cl_mem  retVal = pIntercept->dispatchX().clCreateFromD3D11BufferKHR(
             context,
             flags,
             resource,
@@ -7079,7 +7079,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture2DKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateFromD3D11Texture2DKHR )
+    if( pIntercept && pIntercept->dispatchX().clCreateFromD3D11Texture2DKHR )
     {
         CALL_LOGGING_ENTER(
             "context = %p, "
@@ -7090,7 +7090,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture2DKHR(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatch().clCreateFromD3D11Texture2DKHR(
+        cl_mem  retVal = pIntercept->dispatchX().clCreateFromD3D11Texture2DKHR(
             context,
             flags,
             resource,
@@ -7121,7 +7121,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture3DKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateFromD3D11Texture3DKHR )
+    if( pIntercept && pIntercept->dispatchX().clCreateFromD3D11Texture3DKHR )
     {
         CALL_LOGGING_ENTER(
             "context = %p, "
@@ -7132,7 +7132,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture3DKHR(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatch().clCreateFromD3D11Texture3DKHR(
+        cl_mem  retVal = pIntercept->dispatchX().clCreateFromD3D11Texture3DKHR(
             context,
             flags,
             resource,
@@ -7164,7 +7164,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D11ObjectsKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clEnqueueAcquireD3D11ObjectsKHR )
+    if( pIntercept && pIntercept->dispatchX().clEnqueueAcquireD3D11ObjectsKHR )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -7177,7 +7177,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D11ObjectsKHR(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = pIntercept->dispatch().clEnqueueAcquireD3D11ObjectsKHR(
+            retVal = pIntercept->dispatchX().clEnqueueAcquireD3D11ObjectsKHR(
                 command_queue,
                 num_objects,
                 mem_objects,
@@ -7214,7 +7214,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D11ObjectsKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clEnqueueReleaseD3D11ObjectsKHR )
+    if( pIntercept && pIntercept->dispatchX().clEnqueueReleaseD3D11ObjectsKHR )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -7227,7 +7227,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D11ObjectsKHR(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = pIntercept->dispatch().clEnqueueReleaseD3D11ObjectsKHR(
+            retVal = pIntercept->dispatchX().clEnqueueReleaseD3D11ObjectsKHR(
                 command_queue,
                 num_objects,
                 mem_objects,
@@ -7268,12 +7268,12 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromDX9MediaAdapterKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clGetDeviceIDsFromDX9MediaAdapterKHR )
+    if( pIntercept && pIntercept->dispatchX().clGetDeviceIDsFromDX9MediaAdapterKHR )
     {
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatch().clGetDeviceIDsFromDX9MediaAdapterKHR(
+        cl_int  retVal = pIntercept->dispatchX().clGetDeviceIDsFromDX9MediaAdapterKHR(
             platform,
             num_media_adapters,
             media_adapters_type,
@@ -7306,7 +7306,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateFromDX9MediaSurfaceKHR )
+    if( pIntercept && pIntercept->dispatchX().clCreateFromDX9MediaSurfaceKHR )
     {
         CALL_LOGGING_ENTER(
             "context = %p, "
@@ -7317,7 +7317,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceKHR(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatch().clCreateFromDX9MediaSurfaceKHR(
+        cl_mem  retVal = pIntercept->dispatchX().clCreateFromDX9MediaSurfaceKHR(
             context,
             flags,
             adapter_type,
@@ -7350,7 +7350,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireDX9MediaSurfacesKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clEnqueueAcquireDX9MediaSurfacesKHR )
+    if( pIntercept && pIntercept->dispatchX().clEnqueueAcquireDX9MediaSurfacesKHR )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -7363,7 +7363,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireDX9MediaSurfacesKHR(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = pIntercept->dispatch().clEnqueueAcquireDX9MediaSurfacesKHR(
+            retVal = pIntercept->dispatchX().clEnqueueAcquireDX9MediaSurfacesKHR(
                 command_queue,
                 num_objects,
                 mem_objects,
@@ -7400,7 +7400,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseDX9MediaSurfacesKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clEnqueueReleaseDX9MediaSurfacesKHR )
+    if( pIntercept && pIntercept->dispatchX().clEnqueueReleaseDX9MediaSurfacesKHR )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -7413,7 +7413,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseDX9MediaSurfacesKHR(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = pIntercept->dispatch().clEnqueueReleaseDX9MediaSurfacesKHR(
+            retVal = pIntercept->dispatchX().clEnqueueReleaseDX9MediaSurfacesKHR(
                 command_queue,
                 num_objects,
                 mem_objects,
@@ -7455,12 +7455,12 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromDX9INTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clGetDeviceIDsFromDX9INTEL )
+    if( pIntercept && pIntercept->dispatchX().clGetDeviceIDsFromDX9INTEL )
     {
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatch().clGetDeviceIDsFromDX9INTEL(
+        cl_int  retVal = pIntercept->dispatchX().clGetDeviceIDsFromDX9INTEL(
             platform,
             d3d_device_source,
             dx9_object,
@@ -7492,7 +7492,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateFromDX9MediaSurfaceINTEL )
+    if( pIntercept && pIntercept->dispatchX().clCreateFromDX9MediaSurfaceINTEL )
     {
         CALL_LOGGING_ENTER(
             "context = %p, "
@@ -7503,7 +7503,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceINTEL(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatch().clCreateFromDX9MediaSurfaceINTEL(
+        cl_mem  retVal = pIntercept->dispatchX().clCreateFromDX9MediaSurfaceINTEL(
             context,
             flags,
             resource,
@@ -7536,7 +7536,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireDX9ObjectsINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clEnqueueAcquireDX9ObjectsINTEL )
+    if( pIntercept && pIntercept->dispatchX().clEnqueueAcquireDX9ObjectsINTEL )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -7549,7 +7549,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireDX9ObjectsINTEL(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = pIntercept->dispatch().clEnqueueAcquireDX9ObjectsINTEL(
+            retVal = pIntercept->dispatchX().clEnqueueAcquireDX9ObjectsINTEL(
                 command_queue,
                 num_objects,
                 mem_objects,
@@ -7586,7 +7586,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseDX9ObjectsINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clEnqueueReleaseDX9ObjectsINTEL )
+    if( pIntercept && pIntercept->dispatchX().clEnqueueReleaseDX9ObjectsINTEL )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -7599,7 +7599,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseDX9ObjectsINTEL(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = pIntercept->dispatch().clEnqueueReleaseDX9ObjectsINTEL(
+            retVal = pIntercept->dispatchX().clEnqueueReleaseDX9ObjectsINTEL(
                 command_queue,
                 num_objects,
                 mem_objects,
@@ -7638,7 +7638,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreatePerfCountersCommandQueueINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreatePerfCountersCommandQueueINTEL )
+    if( pIntercept && pIntercept->dispatchX().clCreatePerfCountersCommandQueueINTEL )
     {
         // We don't have to do this, since profiling must be enabled
         // for a perf counters command queue, but it doesn't hurt to
@@ -7657,7 +7657,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreatePerfCountersCommandQueueINTEL(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_command_queue    retVal = pIntercept->dispatch().clCreatePerfCountersCommandQueueINTEL(
+        cl_command_queue    retVal = pIntercept->dispatchX().clCreatePerfCountersCommandQueueINTEL(
             context,
             device,
             properties,
@@ -7688,12 +7688,12 @@ CL_API_ENTRY cl_int CL_API_CALL clSetPerformanceConfigurationINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clSetPerformanceConfigurationINTEL )
+    if( pIntercept && pIntercept->dispatchX().clSetPerformanceConfigurationINTEL )
     {
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int retVal = pIntercept->dispatch().clSetPerformanceConfigurationINTEL(
+        cl_int retVal = pIntercept->dispatchX().clSetPerformanceConfigurationINTEL(
             device,
             count,
             offsets,
@@ -7721,7 +7721,7 @@ CL_API_ENTRY cl_accelerator_intel CL_API_CALL clCreateAcceleratorINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateAcceleratorINTEL )
+    if( pIntercept && pIntercept->dispatchX().clCreateAcceleratorINTEL )
     {
         if( ( accelerator_type == CL_ACCELERATOR_TYPE_MOTION_ESTIMATION_INTEL ) &&
             ( descriptor_size >= sizeof( cl_motion_estimation_desc_intel ) ) )
@@ -7744,7 +7744,7 @@ CL_API_ENTRY cl_accelerator_intel CL_API_CALL clCreateAcceleratorINTEL(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_accelerator_intel retVal = pIntercept->dispatch().clCreateAcceleratorINTEL(
+        cl_accelerator_intel retVal = pIntercept->dispatchX().clCreateAcceleratorINTEL(
             context,
             accelerator_type,
             descriptor_size,
@@ -7774,14 +7774,14 @@ CL_API_ENTRY cl_int CL_API_CALL clGetAcceleratorInfoINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clGetAcceleratorInfoINTEL )
+    if( pIntercept && pIntercept->dispatchX().clGetAcceleratorInfoINTEL )
     {
         CALL_LOGGING_ENTER( "param_name = %s (%X)",
             pIntercept->enumName().name( param_name ).c_str(),
             param_name );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatch().clGetAcceleratorInfoINTEL(
+        cl_int  retVal = pIntercept->dispatchX().clGetAcceleratorInfoINTEL(
             accelerator,
             param_name,
             param_value_size,
@@ -7806,13 +7806,13 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainAcceleratorINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clRetainAcceleratorINTEL )
+    if( pIntercept && pIntercept->dispatchX().clRetainAcceleratorINTEL )
     {
         cl_uint ref_count = 0;
         if( pIntercept->callLogging() )
         {
             ref_count = 0;
-            pIntercept->dispatch().clGetAcceleratorInfoINTEL(
+            pIntercept->dispatchX().clGetAcceleratorInfoINTEL(
                 accelerator,
                 CL_ACCELERATOR_REFERENCE_COUNT_INTEL,
                 sizeof( ref_count ),
@@ -7824,7 +7824,7 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainAcceleratorINTEL(
             accelerator );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatch().clRetainAcceleratorINTEL(
+        cl_int  retVal = pIntercept->dispatchX().clRetainAcceleratorINTEL(
             accelerator );
 
         CPU_PERFORMANCE_TIMING_END();
@@ -7832,7 +7832,7 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainAcceleratorINTEL(
         if( pIntercept->callLogging() )
         {
             ref_count = 0;
-            pIntercept->dispatch().clGetAcceleratorInfoINTEL(
+            pIntercept->dispatchX().clGetAcceleratorInfoINTEL(
                 accelerator,
                 CL_ACCELERATOR_REFERENCE_COUNT_INTEL,
                 sizeof( ref_count ),
@@ -7855,13 +7855,13 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseAcceleratorINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clReleaseAcceleratorINTEL )
+    if( pIntercept && pIntercept->dispatchX().clReleaseAcceleratorINTEL )
     {
         cl_uint ref_count = 0;
         if( pIntercept->callLogging() )
         {
             ref_count = 0;
-            pIntercept->dispatch().clGetAcceleratorInfoINTEL(
+            pIntercept->dispatchX().clGetAcceleratorInfoINTEL(
                 accelerator,
                 CL_ACCELERATOR_REFERENCE_COUNT_INTEL,
                 sizeof( ref_count ),
@@ -7873,7 +7873,7 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseAcceleratorINTEL(
             accelerator );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatch().clReleaseAcceleratorINTEL(
+        cl_int  retVal = pIntercept->dispatchX().clReleaseAcceleratorINTEL(
             accelerator );
 
         CPU_PERFORMANCE_TIMING_END();
@@ -7906,12 +7906,12 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromVA_APIMediaAdapterINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clGetDeviceIDsFromVA_APIMediaAdapterINTEL )
+    if( pIntercept && pIntercept->dispatchX().clGetDeviceIDsFromVA_APIMediaAdapterINTEL )
     {
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatch().clGetDeviceIDsFromVA_APIMediaAdapterINTEL(
+        cl_int  retVal = pIntercept->dispatchX().clGetDeviceIDsFromVA_APIMediaAdapterINTEL(
             platform,
             media_adapter_type,
             media_adapter,
@@ -7942,7 +7942,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromVA_APIMediaSurfaceINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clCreateFromVA_APIMediaSurfaceINTEL )
+    if( pIntercept && pIntercept->dispatchX().clCreateFromVA_APIMediaSurfaceINTEL )
     {
         CALL_LOGGING_ENTER(
             "context = %p, "
@@ -7953,7 +7953,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromVA_APIMediaSurfaceINTEL(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatch().clCreateFromVA_APIMediaSurfaceINTEL(
+        cl_mem  retVal = pIntercept->dispatchX().clCreateFromVA_APIMediaSurfaceINTEL(
             context,
             flags,
             surface,
@@ -7985,7 +7985,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireVA_APIMediaSurfacesINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clEnqueueAcquireVA_APIMediaSurfacesINTEL )
+    if( pIntercept && pIntercept->dispatchX().clEnqueueAcquireVA_APIMediaSurfacesINTEL )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -7998,7 +7998,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireVA_APIMediaSurfacesINTEL(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = pIntercept->dispatch().clEnqueueAcquireVA_APIMediaSurfacesINTEL(
+            retVal = pIntercept->dispatchX().clEnqueueAcquireVA_APIMediaSurfacesINTEL(
                 command_queue,
                 num_objects,
                 mem_objects,
@@ -8035,7 +8035,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseVA_APIMediaSurfacesINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clEnqueueReleaseVA_APIMediaSurfacesINTEL )
+    if( pIntercept && pIntercept->dispatchX().clEnqueueReleaseVA_APIMediaSurfacesINTEL )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -8048,7 +8048,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseVA_APIMediaSurfacesINTEL(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = pIntercept->dispatch().clEnqueueReleaseVA_APIMediaSurfacesINTEL(
+            retVal = pIntercept->dispatchX().clEnqueueReleaseVA_APIMediaSurfacesINTEL(
                 command_queue,
                 num_objects,
                 mem_objects,
@@ -8086,7 +8086,7 @@ CL_API_ENTRY void* CL_API_CALL clHostMemAllocINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clHostMemAllocINTEL )
+    if( pIntercept && pIntercept->dispatchX().clHostMemAllocINTEL )
     {
         // TODO: Make properties string.
         CALL_LOGGING_ENTER( "context = %p, properties = %p, size = %d, alignment = %d",
@@ -8097,7 +8097,7 @@ CL_API_ENTRY void* CL_API_CALL clHostMemAllocINTEL(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        void*   retVal = pIntercept->dispatch().clHostMemAllocINTEL(
+        void*   retVal = pIntercept->dispatchX().clHostMemAllocINTEL(
             context,
             properties,
             size,
@@ -8127,7 +8127,7 @@ CL_API_ENTRY void* CL_API_CALL clDeviceMemAllocINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clDeviceMemAllocINTEL )
+    if( pIntercept && pIntercept->dispatchX().clDeviceMemAllocINTEL )
     {
         std::string deviceInfo;
         if( pIntercept->config().CallLogging )
@@ -8147,7 +8147,7 @@ CL_API_ENTRY void* CL_API_CALL clDeviceMemAllocINTEL(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        void*   retVal = pIntercept->dispatch().clDeviceMemAllocINTEL(
+        void*   retVal = pIntercept->dispatchX().clDeviceMemAllocINTEL(
             context,
             device,
             properties,
@@ -8178,7 +8178,7 @@ CL_API_ENTRY void* CL_API_CALL clSharedMemAllocINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clSharedMemAllocINTEL )
+    if( pIntercept && pIntercept->dispatchX().clSharedMemAllocINTEL )
     {
         std::string deviceInfo;
         if( pIntercept->config().CallLogging )
@@ -8198,7 +8198,7 @@ CL_API_ENTRY void* CL_API_CALL clSharedMemAllocINTEL(
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
-        void*   retVal = pIntercept->dispatch().clSharedMemAllocINTEL(
+        void*   retVal = pIntercept->dispatchX().clSharedMemAllocINTEL(
             context,
             device,
             properties,
@@ -8225,14 +8225,14 @@ CL_API_ENTRY cl_int CL_API_CALL clMemFreeINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clMemFreeINTEL )
+    if( pIntercept && pIntercept->dispatchX().clMemFreeINTEL )
     {
         CALL_LOGGING_ENTER( "context = %p, ptr = %p",
             context,
             ptr );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatch().clMemFreeINTEL(
+        cl_int  retVal = pIntercept->dispatchX().clMemFreeINTEL(
             context,
             ptr );
 
@@ -8256,14 +8256,14 @@ clMemBlockingFreeINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clMemBlockingFreeINTEL )
+    if( pIntercept && pIntercept->dispatchX().clMemBlockingFreeINTEL )
     {
         CALL_LOGGING_ENTER( "context = %p, ptr = %p",
             context,
             ptr );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatch().clMemBlockingFreeINTEL(
+        cl_int  retVal = pIntercept->dispatchX().clMemBlockingFreeINTEL(
             context,
             ptr );
 
@@ -8290,7 +8290,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetMemAllocInfoINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clGetMemAllocInfoINTEL )
+    if( pIntercept && pIntercept->dispatchX().clGetMemAllocInfoINTEL )
     {
         CALL_LOGGING_ENTER( "context = %p, ptr = %p, param_name = %s (%08X)",
             context,
@@ -8299,7 +8299,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetMemAllocInfoINTEL(
             param_name );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatch().clGetMemAllocInfoINTEL(
+        cl_int  retVal = pIntercept->dispatchX().clGetMemAllocInfoINTEL(
             context,
             ptr,
             param_name,
@@ -8327,7 +8327,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgMemPointerINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clSetKernelArgMemPointerINTEL )
+    if( pIntercept && pIntercept->dispatchX().clSetKernelArgMemPointerINTEL )
     {
         CALL_LOGGING_ENTER_KERNEL(
             kernel,
@@ -8338,7 +8338,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgMemPointerINTEL(
         CHECK_KERNEL_ARG_USM_POINTER( kernel, arg_value );
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatch().clSetKernelArgMemPointerINTEL(
+        cl_int  retVal = pIntercept->dispatchX().clSetKernelArgMemPointerINTEL(
             kernel,
             arg_index,
             arg_value );
@@ -8367,7 +8367,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemsetINTEL(   // Deprecated
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clEnqueueMemsetINTEL )
+    if( pIntercept && pIntercept->dispatchX().clEnqueueMemsetINTEL )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -8384,7 +8384,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemsetINTEL(   // Deprecated
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = pIntercept->dispatch().clEnqueueMemsetINTEL(
+            retVal = pIntercept->dispatchX().clEnqueueMemsetINTEL(
                 queue,
                 dst_ptr,
                 value,
@@ -8424,7 +8424,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemFillINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clEnqueueMemFillINTEL )
+    if( pIntercept && pIntercept->dispatchX().clEnqueueMemFillINTEL )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -8441,7 +8441,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemFillINTEL(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = pIntercept->dispatch().clEnqueueMemFillINTEL(
+            retVal = pIntercept->dispatchX().clEnqueueMemFillINTEL(
                 queue,
                 dst_ptr,
                 pattern,
@@ -8482,7 +8482,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemcpyINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clEnqueueMemcpyINTEL )
+    if( pIntercept && pIntercept->dispatchX().clEnqueueMemcpyINTEL )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -8500,7 +8500,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemcpyINTEL(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = pIntercept->dispatch().clEnqueueMemcpyINTEL(
+            retVal = pIntercept->dispatchX().clEnqueueMemcpyINTEL(
                 queue,
                 blocking,
                 dst_ptr,
@@ -8540,7 +8540,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMigrateMemINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clEnqueueMigrateMemINTEL )
+    if( pIntercept && pIntercept->dispatchX().clEnqueueMigrateMemINTEL )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -8558,7 +8558,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMigrateMemINTEL(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = pIntercept->dispatch().clEnqueueMigrateMemINTEL(
+            retVal = pIntercept->dispatchX().clEnqueueMigrateMemINTEL(
                 queue,
                 ptr,
                 size,
@@ -8597,7 +8597,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemAdviseINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatch().clEnqueueMemAdviseINTEL )
+    if( pIntercept && pIntercept->dispatchX().clEnqueueMemAdviseINTEL )
     {
         cl_int  retVal = CL_SUCCESS;
 
@@ -8615,7 +8615,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemAdviseINTEL(
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = pIntercept->dispatch().clEnqueueMemAdviseINTEL(
+            retVal = pIntercept->dispatchX().clEnqueueMemAdviseINTEL(
                 queue,
                 ptr,
                 size,

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -5187,30 +5187,34 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLBuffer)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateFromGLBuffer )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER(
-            "context = %p, "
-            "flags = %s (%llX)",
-            context,
-            pIntercept->enumName().name_mem_flags( flags ).c_str(),
-            flags );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateFromGLBuffer )
+        {
+            CALL_LOGGING_ENTER(
+                "context = %p, "
+                "flags = %s (%llX)",
+                context,
+                pIntercept->enumName().name_mem_flags( flags ).c_str(),
+                flags );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatchX().clCreateFromGLBuffer(
-            context,
-            flags,
-            bufobj,
-            errcode_ret);
+            cl_mem  retVal = dispatchX.clCreateFromGLBuffer(
+                context,
+                flags,
+                bufobj,
+                errcode_ret);
 
-        CPU_PERFORMANCE_TIMING_END();
-        ADD_BUFFER( retVal );
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            ADD_BUFFER( retVal );
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -5229,43 +5233,47 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateFromGLTexture )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER(
-            "context = %p, "
-            "flags = %s (%llX), "
-            "texture_target = %s (%d), "
-            "miplevel = %d, "
-            "texture = %d",
-            context,
-            pIntercept->enumName().name_mem_flags( flags ).c_str(),
-            flags,
-            pIntercept->enumName().name_gl( target ).c_str(),
-            target,
-            miplevel,
-            texture );
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateFromGLTexture )
+        {
+            CALL_LOGGING_ENTER(
+                "context = %p, "
+                "flags = %s (%llX), "
+                "texture_target = %s (%d), "
+                "miplevel = %d, "
+                "texture = %d",
+                context,
+                pIntercept->enumName().name_mem_flags( flags ).c_str(),
+                flags,
+                pIntercept->enumName().name_gl( target ).c_str(),
+                target,
+                miplevel,
+                texture );
 
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatchX().clCreateFromGLTexture(
-            context,
-            flags,
-            target,
-            miplevel,
-            texture,
-            errcode_ret);
+            cl_mem  retVal = dispatchX.clCreateFromGLTexture(
+                context,
+                flags,
+                target,
+                miplevel,
+                texture,
+                errcode_ret);
 
-        CPU_PERFORMANCE_TIMING_END();
-        ADD_IMAGE( retVal );
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            ADD_IMAGE( retVal );
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
 
-        pIntercept->logCL_GLTextureDetails( retVal, target, miplevel, texture );
+            pIntercept->logCL_GLTextureDetails( retVal, target, miplevel, texture );
 
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -5283,43 +5291,47 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture2D)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateFromGLTexture2D )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER(
-            "context = %p, "
-            "flags = %s (%llX), "
-            "texture_target = %s (%d), "
-            "miplevel = %d, "
-            "texture = %d",
-            context,
-            pIntercept->enumName().name_mem_flags( flags ).c_str(),
-            flags,
-            pIntercept->enumName().name_gl( target ).c_str(),
-            target,
-            miplevel,
-            texture );
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateFromGLTexture2D )
+        {
+            CALL_LOGGING_ENTER(
+                "context = %p, "
+                "flags = %s (%llX), "
+                "texture_target = %s (%d), "
+                "miplevel = %d, "
+                "texture = %d",
+                context,
+                pIntercept->enumName().name_mem_flags( flags ).c_str(),
+                flags,
+                pIntercept->enumName().name_gl( target ).c_str(),
+                target,
+                miplevel,
+                texture );
 
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatchX().clCreateFromGLTexture2D(
-            context,
-            flags,
-            target,
-            miplevel,
-            texture,
-            errcode_ret);
+            cl_mem  retVal = dispatchX.clCreateFromGLTexture2D(
+                context,
+                flags,
+                target,
+                miplevel,
+                texture,
+                errcode_ret);
 
-        CPU_PERFORMANCE_TIMING_END();
-        ADD_IMAGE( retVal );
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            ADD_IMAGE( retVal );
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
 
-        pIntercept->logCL_GLTextureDetails( retVal, target, miplevel, texture );
+            pIntercept->logCL_GLTextureDetails( retVal, target, miplevel, texture );
 
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -5337,43 +5349,47 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture3D)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateFromGLTexture3D )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER(
-            "context = %p, "
-            "flags = %s (%llX), "
-            "texture_target = %s (%d), "
-            "miplevel = %d, "
-            "texture = %d",
-            context,
-            pIntercept->enumName().name_mem_flags( flags ).c_str(),
-            flags,
-            pIntercept->enumName().name_gl( target ).c_str(),
-            target,
-            miplevel,
-            texture );
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateFromGLTexture3D )
+        {
+            CALL_LOGGING_ENTER(
+                "context = %p, "
+                "flags = %s (%llX), "
+                "texture_target = %s (%d), "
+                "miplevel = %d, "
+                "texture = %d",
+                context,
+                pIntercept->enumName().name_mem_flags( flags ).c_str(),
+                flags,
+                pIntercept->enumName().name_gl( target ).c_str(),
+                target,
+                miplevel,
+                texture );
 
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatchX().clCreateFromGLTexture3D(
-            context,
-            flags,
-            target,
-            miplevel,
-            texture,
-            errcode_ret);
+            cl_mem  retVal = dispatchX.clCreateFromGLTexture3D(
+                context,
+                flags,
+                target,
+                miplevel,
+                texture,
+                errcode_ret);
 
-        CPU_PERFORMANCE_TIMING_END();
-        ADD_IMAGE( retVal );
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            ADD_IMAGE( retVal );
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
 
-        pIntercept->logCL_GLTextureDetails( retVal, target, miplevel, texture );
+            pIntercept->logCL_GLTextureDetails( retVal, target, miplevel, texture );
 
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -5389,30 +5405,34 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLRenderbuffer)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateFromGLRenderbuffer )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER(
-            "context = %p, "
-            "flags = %s (%llX)",
-            context,
-            pIntercept->enumName().name_mem_flags( flags ).c_str(),
-            flags );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateFromGLRenderbuffer )
+        {
+            CALL_LOGGING_ENTER(
+                "context = %p, "
+                "flags = %s (%llX)",
+                context,
+                pIntercept->enumName().name_mem_flags( flags ).c_str(),
+                flags );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatchX().clCreateFromGLRenderbuffer(
-            context,
-            flags,
-            renderbuffer,
-            errcode_ret);
+            cl_mem  retVal = dispatchX.clCreateFromGLRenderbuffer(
+                context,
+                flags,
+                renderbuffer,
+                errcode_ret);
 
-        CPU_PERFORMANCE_TIMING_END();
-        ADD_IMAGE( retVal );
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            ADD_IMAGE( retVal );
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -5427,21 +5447,25 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetGLObjectInfo)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clGetGLObjectInfo )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER();
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(memobj);
+        if( dispatchX.clGetGLObjectInfo )
+        {
+            CALL_LOGGING_ENTER();
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatchX().clGetGLObjectInfo(
-            memobj,
-            gl_object_type,
-            gl_object_name);
+            cl_int  retVal = dispatchX.clGetGLObjectInfo(
+                memobj,
+                gl_object_type,
+                gl_object_name);
 
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT( retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -5458,23 +5482,27 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetGLTextureInfo)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clGetGLTextureInfo )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER();
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(memobj);
+        if( dispatchX.clGetGLTextureInfo )
+        {
+            CALL_LOGGING_ENTER();
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatchX().clGetGLTextureInfo(
-            memobj,
-            param_name,
-            param_value_size,
-            param_value,
-            param_value_size_ret);
+            cl_int  retVal = dispatchX.clGetGLTextureInfo(
+                memobj,
+                param_name,
+                param_value_size,
+                param_value,
+                param_value_size_ret);
 
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT( retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -5492,39 +5520,43 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueAcquireGLObjects)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clEnqueueAcquireGLObjects )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
-
-        CHECK_AUBCAPTURE_START( command_queue );
-
-        if( pIntercept->nullEnqueue() == false )
+        auto dispatchX = pIntercept->dispatchX(command_queue);
+        if( dispatchX.clEnqueueAcquireGLObjects )
         {
-            CALL_LOGGING_ENTER( "queue = %p",
-                command_queue );
-            CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
-            CPU_PERFORMANCE_TIMING_START();
+            cl_int  retVal = CL_SUCCESS;
 
-            retVal = pIntercept->dispatchX().clEnqueueAcquireGLObjects(
-                command_queue,
-                num_objects,
-                mem_objects,
-                num_events_in_wait_list,
-                event_wait_list,
-                event);
+            CHECK_AUBCAPTURE_START( command_queue );
 
-            CPU_PERFORMANCE_TIMING_END();
-            DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
-            CHECK_ERROR( retVal );
-            ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( retVal, event );
+            if( pIntercept->nullEnqueue() == false )
+            {
+                CALL_LOGGING_ENTER( "queue = %p",
+                    command_queue );
+                CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                DEVICE_PERFORMANCE_TIMING_START( event );
+                CPU_PERFORMANCE_TIMING_START();
+
+                retVal = dispatchX.clEnqueueAcquireGLObjects(
+                    command_queue,
+                    num_objects,
+                    mem_objects,
+                    num_events_in_wait_list,
+                    event_wait_list,
+                    event);
+
+                CPU_PERFORMANCE_TIMING_END();
+                DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
+                CHECK_ERROR( retVal );
+                ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
+                CALL_LOGGING_EXIT_EVENT( retVal, event );
+            }
+
+            FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
+            CHECK_AUBCAPTURE_STOP( command_queue );
+
+            return retVal;
         }
-
-        FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
-        CHECK_AUBCAPTURE_STOP( command_queue );
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -5542,41 +5574,45 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReleaseGLObjects)(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clEnqueueReleaseGLObjects )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
-
-        CHECK_AUBCAPTURE_START( command_queue );
-
-        if( pIntercept->nullEnqueue() == false )
+        auto dispatchX = pIntercept->dispatchX(command_queue);
+        if( dispatchX.clEnqueueReleaseGLObjects )
         {
-            CALL_LOGGING_ENTER( "queue = %p",
-                command_queue );
-            CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
-            CPU_PERFORMANCE_TIMING_START();
+            cl_int  retVal = CL_SUCCESS;
 
-            retVal = pIntercept->dispatchX().clEnqueueReleaseGLObjects(
-                command_queue,
-                num_objects,
-                mem_objects,
-                num_events_in_wait_list,
-                event_wait_list,
-                event);
+            CHECK_AUBCAPTURE_START( command_queue );
 
-            CPU_PERFORMANCE_TIMING_END();
-            DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
-            CHECK_ERROR( retVal );
-            ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( retVal, event );
+            if( pIntercept->nullEnqueue() == false )
+            {
+                CALL_LOGGING_ENTER( "queue = %p",
+                    command_queue );
+                CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                DEVICE_PERFORMANCE_TIMING_START( event );
+                CPU_PERFORMANCE_TIMING_START();
+
+                retVal = dispatchX.clEnqueueReleaseGLObjects(
+                    command_queue,
+                    num_objects,
+                    mem_objects,
+                    num_events_in_wait_list,
+                    event_wait_list,
+                    event);
+
+                CPU_PERFORMANCE_TIMING_END();
+                DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
+                CHECK_ERROR( retVal );
+                ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
+                CALL_LOGGING_EXIT_EVENT( retVal, event );
+            }
+
+            FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
+            CHECK_AUBCAPTURE_STOP( command_queue );
+
+            DEVICE_PERFORMANCE_TIMING_CHECK();
+
+            return retVal;
         }
-
-        FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
-        CHECK_AUBCAPTURE_STOP( command_queue );
-
-        DEVICE_PERFORMANCE_TIMING_CHECK();
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -6189,37 +6225,59 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithPropertiesKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateCommandQueueWithPropertiesKHR )
+    if( pIntercept )
     {
-        cl_queue_properties*    newProperties = NULL;
-        cl_command_queue    retVal = NULL;
-
-        std::string deviceInfo;
-        std::string commandQueueProperties;
-        if( pIntercept->callLogging() )
+        auto dispatchX = pIntercept->dispatchX(device);
+        if( dispatchX.clCreateCommandQueueWithPropertiesKHR )
         {
-            pIntercept->getDeviceInfoString(
-                1,
-                &device,
-                deviceInfo );
-            pIntercept->getCommandQueuePropertiesString(
-                properties,
-                commandQueueProperties );
-        }
-        CALL_LOGGING_ENTER( "context = %p, device = [ %s ], properties = [ %s ]",
-            context,
-            deviceInfo.c_str(),
-            commandQueueProperties.c_str() );
-        CREATE_COMMAND_QUEUE_OVERRIDE_INIT( device, properties, newProperties );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+            cl_queue_properties*    newProperties = NULL;
+            cl_command_queue    retVal = NULL;
+
+            std::string deviceInfo;
+            std::string commandQueueProperties;
+            if( pIntercept->callLogging() )
+            {
+                pIntercept->getDeviceInfoString(
+                    1,
+                    &device,
+                    deviceInfo );
+                pIntercept->getCommandQueuePropertiesString(
+                    properties,
+                    commandQueueProperties );
+            }
+            CALL_LOGGING_ENTER( "context = %p, device = [ %s ], properties = [ %s ]",
+                context,
+                deviceInfo.c_str(),
+                commandQueueProperties.c_str() );
+            CREATE_COMMAND_QUEUE_OVERRIDE_INIT( device, properties, newProperties );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
 #if defined(USE_MDAPI)
-        if( pIntercept->config().DevicePerfCounterEventBasedSampling )
-        {
+            if( pIntercept->config().DevicePerfCounterEventBasedSampling )
+            {
+                if( ( retVal == NULL ) && newProperties )
+                {
+                    retVal = pIntercept->createMDAPICommandQueue(
+                        context,
+                        device,
+                        newProperties,
+                        errcode_ret );
+                }
+                if( retVal == NULL )
+                {
+                    retVal = pIntercept->createMDAPICommandQueue(
+                        context,
+                        device,
+                        properties,
+                        errcode_ret );
+                }
+            }
+#endif
+
             if( ( retVal == NULL ) && newProperties )
             {
-                retVal = pIntercept->createMDAPICommandQueue(
+                retVal = dispatchX.clCreateCommandQueueWithPropertiesKHR(
                     context,
                     device,
                     newProperties,
@@ -6227,39 +6285,21 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithPropertiesKHR(
             }
             if( retVal == NULL )
             {
-                retVal = pIntercept->createMDAPICommandQueue(
+                retVal = dispatchX.clCreateCommandQueueWithPropertiesKHR(
                     context,
                     device,
                     properties,
                     errcode_ret );
             }
-        }
-#endif
 
-        if( ( retVal == NULL ) && newProperties )
-        {
-            retVal = pIntercept->dispatchX().clCreateCommandQueueWithPropertiesKHR(
-                context,
-                device,
-                newProperties,
-                errcode_ret );
-        }
-        if( retVal == NULL )
-        {
-            retVal = pIntercept->dispatchX().clCreateCommandQueueWithPropertiesKHR(
-                context,
-                device,
-                properties,
-                errcode_ret );
-        }
+            CPU_PERFORMANCE_TIMING_END();
+            CREATE_COMMAND_QUEUE_OVERRIDE_CLEANUP( newProperties );
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        CPU_PERFORMANCE_TIMING_END();
-        CREATE_COMMAND_QUEUE_OVERRIDE_CLEANUP( newProperties );
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
-
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -6453,36 +6493,40 @@ CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithILKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateProgramWithILKHR )
+    if( pIntercept )
     {
-        char*       injectedSPIRV = NULL;
-        uint64_t    hash = 0;
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateProgramWithILKHR )
+        {
+            char*       injectedSPIRV = NULL;
+            uint64_t    hash = 0;
 
-        COMPUTE_SPIRV_HASH( length, il, hash );
-        INJECT_PROGRAM_SPIRV( length, il, injectedSPIRV, hash );
+            COMPUTE_SPIRV_HASH( length, il, hash );
+            INJECT_PROGRAM_SPIRV( length, il, injectedSPIRV, hash );
 
-        CALL_LOGGING_ENTER( "context = %p, length = %u",
-            context,
-            length );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+            CALL_LOGGING_ENTER( "context = %p, length = %u",
+                context,
+                length );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_program  retVal = pIntercept->dispatchX().clCreateProgramWithILKHR(
-            context,
-            il,
-            length,
-            errcode_ret );
+            cl_program  retVal = dispatchX.clCreateProgramWithILKHR(
+                context,
+                il,
+                length,
+                errcode_ret );
 
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        DUMP_PROGRAM_SPIRV( retVal, length, il, hash );
-        SAVE_PROGRAM_HASH( retVal, hash );
-        DELETE_INJECTED_SPIRV( injectedSPIRV );
+            DUMP_PROGRAM_SPIRV( retVal, length, il, hash );
+            SAVE_PROGRAM_HASH( retVal, hash );
+            DELETE_INJECTED_SPIRV( injectedSPIRV );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -6575,28 +6619,32 @@ CL_API_ENTRY cl_int CL_API_CALL clGetKernelSubGroupInfoKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clGetKernelSubGroupInfoKHR )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
+        auto dispatchX = pIntercept->dispatchX(kernel);
+        if( dispatchX.clGetKernelSubGroupInfoKHR )
+        {
+            cl_int  retVal = CL_SUCCESS;
 
-        CALL_LOGGING_ENTER();
-        CPU_PERFORMANCE_TIMING_START();
+            CALL_LOGGING_ENTER();
+            CPU_PERFORMANCE_TIMING_START();
 
-        retVal = pIntercept->dispatchX().clGetKernelSubGroupInfoKHR(
-            kernel,
-            device,
-            param_name,
-            input_value_size,
-            input_value,
-            param_value_size,
-            param_value,
-            param_value_size_ret );
+            retVal = dispatchX.clGetKernelSubGroupInfoKHR(
+                kernel,
+                device,
+                param_name,
+                input_value_size,
+                input_value,
+                param_value_size,
+                param_value,
+                param_value_size_ret );
 
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT( retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -6668,12 +6716,19 @@ CL_API_ENTRY cl_int CL_API_CALL clGetGLContextInfoKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clGetGLContextInfoKHR )
+    // clGetGLContextInfoKHR is a special-case.
+    // It's an extension function and is part of cl_khr_gl_sharing, but it
+    // doesn't necessarily pass a dispatchable object as its first argument,
+    // and is implemented in the ICD loader and called into via the core API
+    // dispatch table.  This means that we can install it into our core API
+    // dispatch table as well, and don't need to look it up per-platform.
+
+    if( pIntercept && pIntercept->dispatch().clGetGLContextInfoKHR )
     {
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatchX().clGetGLContextInfoKHR(
+        cl_int  retVal = pIntercept->dispatch().clGetGLContextInfoKHR(
             properties,
             param_name,
             param_value_size,
@@ -6700,24 +6755,28 @@ CL_API_ENTRY cl_event CL_API_CALL clCreateEventFromGLsyncKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateEventFromGLsyncKHR )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER( "context = %p",
-            context );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateEventFromGLsyncKHR )
+        {
+            CALL_LOGGING_ENTER( "context = %p",
+                context );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_event    retVal = pIntercept->dispatchX().clCreateEventFromGLsyncKHR(
-            context,
-            sync,
-            errcode_ret);
+            cl_event    retVal = dispatchX.clCreateEventFromGLsyncKHR(
+                context,
+                sync,
+                errcode_ret);
 
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -6739,25 +6798,29 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D10KHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clGetDeviceIDsFromD3D10KHR )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER();
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(platform);
+        if( dispatchX.clGetDeviceIDsFromD3D10KHR )
+        {
+            CALL_LOGGING_ENTER();
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatchX().clGetDeviceIDsFromD3D10KHR(
-            platform,
-            d3d_device_source,
-            d3d_object,
-            d3d_device_set,
-            num_entries,
-            devices,
-            num_devices);
+            cl_int  retVal = dispatchX.clGetDeviceIDsFromD3D10KHR(
+                platform,
+                d3d_device_source,
+                d3d_object,
+                d3d_device_set,
+                num_entries,
+                devices,
+                num_devices);
 
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT( retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -6774,30 +6837,34 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10BufferKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateFromD3D10BufferKHR )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER(
-            "context = %p, "
-            "flags = %s (%llX)",
-            context,
-            pIntercept->enumName().name_mem_flags( flags ).c_str(),
-            flags );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateFromD3D10BufferKHR )
+        {
+            CALL_LOGGING_ENTER(
+                "context = %p, "
+                "flags = %s (%llX)",
+                context,
+                pIntercept->enumName().name_mem_flags( flags ).c_str(),
+                flags );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatchX().clCreateFromD3D10BufferKHR(
-            context,
-            flags,
-            resource,
-            errcode_ret);
+            cl_mem  retVal = dispatchX.clCreateFromD3D10BufferKHR(
+                context,
+                flags,
+                resource,
+                errcode_ret);
 
-        CPU_PERFORMANCE_TIMING_END();
-        ADD_BUFFER( retVal );
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            ADD_BUFFER( retVal );
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -6815,31 +6882,35 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture2DKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateFromD3D10Texture2DKHR )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER(
-            "context = %p, "
-            "flags = %s (%llX)",
-            context,
-            pIntercept->enumName().name_mem_flags( flags ).c_str(),
-            flags );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateFromD3D10Texture2DKHR )
+        {
+            CALL_LOGGING_ENTER(
+                "context = %p, "
+                "flags = %s (%llX)",
+                context,
+                pIntercept->enumName().name_mem_flags( flags ).c_str(),
+                flags );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatchX().clCreateFromD3D10Texture2DKHR(
-            context,
-            flags,
-            resource,
-            subresource,
-            errcode_ret);
+            cl_mem  retVal = dispatchX.clCreateFromD3D10Texture2DKHR(
+                context,
+                flags,
+                resource,
+                subresource,
+                errcode_ret);
 
-        CPU_PERFORMANCE_TIMING_END();
-        ADD_IMAGE( retVal );
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            ADD_IMAGE( retVal );
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -6857,31 +6928,35 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture3DKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateFromD3D10Texture3DKHR )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER(
-            "context = %p, "
-            "flags = %s (%llX)",
-            context,
-            pIntercept->enumName().name_mem_flags( flags ).c_str(),
-            flags );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateFromD3D10Texture3DKHR )
+        {
+            CALL_LOGGING_ENTER(
+                "context = %p, "
+                "flags = %s (%llX)",
+                context,
+                pIntercept->enumName().name_mem_flags( flags ).c_str(),
+                flags );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatchX().clCreateFromD3D10Texture3DKHR(
-            context,
-            flags,
-            resource,
-            subresource,
-            errcode_ret);
+            cl_mem  retVal = dispatchX.clCreateFromD3D10Texture3DKHR(
+                context,
+                flags,
+                resource,
+                subresource,
+                errcode_ret);
 
-        CPU_PERFORMANCE_TIMING_END();
-        ADD_IMAGE( retVal );
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            ADD_IMAGE( retVal );
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -6900,38 +6975,42 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D10ObjectsKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clEnqueueAcquireD3D10ObjectsKHR )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
-
-        CHECK_AUBCAPTURE_START( command_queue );
-
-        if( pIntercept->nullEnqueue() == false )
+        auto dispatchX = pIntercept->dispatchX(command_queue);
+        if( dispatchX.clEnqueueAcquireD3D10ObjectsKHR )
         {
-            CALL_LOGGING_ENTER();
-            CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
-            CPU_PERFORMANCE_TIMING_START();
+            cl_int  retVal = CL_SUCCESS;
 
-            retVal = pIntercept->dispatchX().clEnqueueAcquireD3D10ObjectsKHR(
-                command_queue,
-                num_objects,
-                mem_objects,
-                num_events_in_wait_list,
-                event_wait_list,
-                event);
+            CHECK_AUBCAPTURE_START( command_queue );
 
-            CPU_PERFORMANCE_TIMING_END();
-            DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
-            CHECK_ERROR( retVal );
-            ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( retVal, event );
+            if( pIntercept->nullEnqueue() == false )
+            {
+                CALL_LOGGING_ENTER();
+                CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                DEVICE_PERFORMANCE_TIMING_START( event );
+                CPU_PERFORMANCE_TIMING_START();
+
+                retVal = dispatchX.clEnqueueAcquireD3D10ObjectsKHR(
+                    command_queue,
+                    num_objects,
+                    mem_objects,
+                    num_events_in_wait_list,
+                    event_wait_list,
+                    event);
+
+                CPU_PERFORMANCE_TIMING_END();
+                DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
+                CHECK_ERROR( retVal );
+                ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
+                CALL_LOGGING_EXIT_EVENT( retVal, event );
+            }
+
+            FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
+            CHECK_AUBCAPTURE_STOP( command_queue );
+
+            return retVal;
         }
-
-        FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
-        CHECK_AUBCAPTURE_STOP( command_queue );
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -6950,40 +7029,44 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D10ObjectsKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clEnqueueReleaseD3D10ObjectsKHR )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
-
-        CHECK_AUBCAPTURE_START( command_queue );
-
-        if( pIntercept->nullEnqueue() == false )
+        auto dispatchX = pIntercept->dispatchX(command_queue);
+        if( dispatchX.clEnqueueReleaseD3D10ObjectsKHR )
         {
-            CALL_LOGGING_ENTER();
-            CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
-            CPU_PERFORMANCE_TIMING_START();
+            cl_int  retVal = CL_SUCCESS;
 
-            retVal = pIntercept->dispatchX().clEnqueueReleaseD3D10ObjectsKHR(
-                command_queue,
-                num_objects,
-                mem_objects,
-                num_events_in_wait_list,
-                event_wait_list,
-                event);
+            CHECK_AUBCAPTURE_START( command_queue );
 
-            CPU_PERFORMANCE_TIMING_END();
-            DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
-            CHECK_ERROR( retVal );
-            ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( retVal, event );
+            if( pIntercept->nullEnqueue() == false )
+            {
+                CALL_LOGGING_ENTER();
+                CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                DEVICE_PERFORMANCE_TIMING_START( event );
+                CPU_PERFORMANCE_TIMING_START();
+
+                retVal = dispatchX.clEnqueueReleaseD3D10ObjectsKHR(
+                    command_queue,
+                    num_objects,
+                    mem_objects,
+                    num_events_in_wait_list,
+                    event_wait_list,
+                    event);
+
+                CPU_PERFORMANCE_TIMING_END();
+                DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
+                CHECK_ERROR( retVal );
+                ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
+                CALL_LOGGING_EXIT_EVENT( retVal, event );
+            }
+
+            FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
+            CHECK_AUBCAPTURE_STOP( command_queue );
+
+            DEVICE_PERFORMANCE_TIMING_CHECK();
+
+            return retVal;
         }
-
-        FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
-        CHECK_AUBCAPTURE_STOP( command_queue );
-
-        DEVICE_PERFORMANCE_TIMING_CHECK();
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -7003,25 +7086,29 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D11KHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clGetDeviceIDsFromD3D11KHR )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER();
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(platform);
+        if( dispatchX.clGetDeviceIDsFromD3D11KHR )
+        {
+            CALL_LOGGING_ENTER();
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatchX().clGetDeviceIDsFromD3D11KHR(
-            platform,
-            d3d_device_source,
-            d3d_object,
-            d3d_device_set,
-            num_entries,
-            devices,
-            num_devices);
+            cl_int  retVal = dispatchX.clGetDeviceIDsFromD3D11KHR(
+                platform,
+                d3d_device_source,
+                d3d_object,
+                d3d_device_set,
+                num_entries,
+                devices,
+                num_devices);
 
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT( retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -7038,30 +7125,34 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11BufferKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateFromD3D11BufferKHR )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER(
-            "context = %p, "
-            "flags = %s (%llX)",
-            context,
-            pIntercept->enumName().name_mem_flags( flags ).c_str(),
-            flags );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateFromD3D11BufferKHR )
+        {
+            CALL_LOGGING_ENTER(
+                "context = %p, "
+                "flags = %s (%llX)",
+                context,
+                pIntercept->enumName().name_mem_flags( flags ).c_str(),
+                flags );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatchX().clCreateFromD3D11BufferKHR(
-            context,
-            flags,
-            resource,
-            errcode_ret);
+            cl_mem  retVal = dispatchX.clCreateFromD3D11BufferKHR(
+                context,
+                flags,
+                resource,
+                errcode_ret);
 
-        CPU_PERFORMANCE_TIMING_END();
-        ADD_BUFFER( retVal );
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            ADD_BUFFER( retVal );
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -7079,31 +7170,35 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture2DKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateFromD3D11Texture2DKHR )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER(
-            "context = %p, "
-            "flags = %s (%llX)",
-            context,
-            pIntercept->enumName().name_mem_flags( flags ).c_str(),
-            flags );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateFromD3D11Texture2DKHR )
+        {
+            CALL_LOGGING_ENTER(
+                "context = %p, "
+                "flags = %s (%llX)",
+                context,
+                pIntercept->enumName().name_mem_flags( flags ).c_str(),
+                flags );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatchX().clCreateFromD3D11Texture2DKHR(
-            context,
-            flags,
-            resource,
-            subresource,
-            errcode_ret);
+            cl_mem  retVal = dispatchX.clCreateFromD3D11Texture2DKHR(
+                context,
+                flags,
+                resource,
+                subresource,
+                errcode_ret);
 
-        CPU_PERFORMANCE_TIMING_END();
-        ADD_IMAGE( retVal );
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            ADD_IMAGE( retVal );
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -7121,31 +7216,35 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture3DKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateFromD3D11Texture3DKHR )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER(
-            "context = %p, "
-            "flags = %s (%llX)",
-            context,
-            pIntercept->enumName().name_mem_flags( flags ).c_str(),
-            flags );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateFromD3D11Texture3DKHR )
+        {
+            CALL_LOGGING_ENTER(
+                "context = %p, "
+                "flags = %s (%llX)",
+                context,
+                pIntercept->enumName().name_mem_flags( flags ).c_str(),
+                flags );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatchX().clCreateFromD3D11Texture3DKHR(
-            context,
-            flags,
-            resource,
-            subresource,
-            errcode_ret);
+            cl_mem  retVal = dispatchX.clCreateFromD3D11Texture3DKHR(
+                context,
+                flags,
+                resource,
+                subresource,
+                errcode_ret);
 
-        CPU_PERFORMANCE_TIMING_END();
-        ADD_IMAGE( retVal );
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            ADD_IMAGE( retVal );
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -7164,38 +7263,42 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D11ObjectsKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clEnqueueAcquireD3D11ObjectsKHR )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
-
-        CHECK_AUBCAPTURE_START( command_queue );
-
-        if( pIntercept->nullEnqueue() == false )
+        auto dispatchX = pIntercept->dispatchX(command_queue);
+        if( dispatchX.clEnqueueAcquireD3D11ObjectsKHR )
         {
-            CALL_LOGGING_ENTER();
-            CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
-            CPU_PERFORMANCE_TIMING_START();
+            cl_int  retVal = CL_SUCCESS;
 
-            retVal = pIntercept->dispatchX().clEnqueueAcquireD3D11ObjectsKHR(
-                command_queue,
-                num_objects,
-                mem_objects,
-                num_events_in_wait_list,
-                event_wait_list,
-                event);
+            CHECK_AUBCAPTURE_START( command_queue );
 
-            CPU_PERFORMANCE_TIMING_END();
-            DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
-            CHECK_ERROR( retVal );
-            ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( retVal, event );
+            if( pIntercept->nullEnqueue() == false )
+            {
+                CALL_LOGGING_ENTER();
+                CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                DEVICE_PERFORMANCE_TIMING_START( event );
+                CPU_PERFORMANCE_TIMING_START();
+
+                retVal = dispatchX.clEnqueueAcquireD3D11ObjectsKHR(
+                    command_queue,
+                    num_objects,
+                    mem_objects,
+                    num_events_in_wait_list,
+                    event_wait_list,
+                    event);
+
+                CPU_PERFORMANCE_TIMING_END();
+                DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
+                CHECK_ERROR( retVal );
+                ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
+                CALL_LOGGING_EXIT_EVENT( retVal, event );
+            }
+
+            FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
+            CHECK_AUBCAPTURE_STOP( command_queue );
+
+            return retVal;
         }
-
-        FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
-        CHECK_AUBCAPTURE_STOP( command_queue );
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -7214,40 +7317,44 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D11ObjectsKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clEnqueueReleaseD3D11ObjectsKHR )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
-
-        CHECK_AUBCAPTURE_START( command_queue );
-
-        if( pIntercept->nullEnqueue() == false )
+        auto dispatchX = pIntercept->dispatchX(command_queue);
+        if( dispatchX.clEnqueueReleaseD3D11ObjectsKHR )
         {
-            CALL_LOGGING_ENTER();
-            CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
-            CPU_PERFORMANCE_TIMING_START();
+            cl_int  retVal = CL_SUCCESS;
 
-            retVal = pIntercept->dispatchX().clEnqueueReleaseD3D11ObjectsKHR(
-                command_queue,
-                num_objects,
-                mem_objects,
-                num_events_in_wait_list,
-                event_wait_list,
-                event);
+            CHECK_AUBCAPTURE_START( command_queue );
 
-            CPU_PERFORMANCE_TIMING_END();
-            DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
-            CHECK_ERROR( retVal );
-            ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( retVal, event );
+            if( pIntercept->nullEnqueue() == false )
+            {
+                CALL_LOGGING_ENTER();
+                CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                DEVICE_PERFORMANCE_TIMING_START( event );
+                CPU_PERFORMANCE_TIMING_START();
+
+                retVal = dispatchX.clEnqueueReleaseD3D11ObjectsKHR(
+                    command_queue,
+                    num_objects,
+                    mem_objects,
+                    num_events_in_wait_list,
+                    event_wait_list,
+                    event);
+
+                CPU_PERFORMANCE_TIMING_END();
+                DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
+                CHECK_ERROR( retVal );
+                ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
+                CALL_LOGGING_EXIT_EVENT( retVal, event );
+            }
+
+            FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
+            CHECK_AUBCAPTURE_STOP( command_queue );
+
+            DEVICE_PERFORMANCE_TIMING_CHECK();
+
+            return retVal;
         }
-
-        FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
-        CHECK_AUBCAPTURE_STOP( command_queue );
-
-        DEVICE_PERFORMANCE_TIMING_CHECK();
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -7268,26 +7375,30 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromDX9MediaAdapterKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clGetDeviceIDsFromDX9MediaAdapterKHR )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER();
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(platform);
+        if( dispatchX.clGetDeviceIDsFromDX9MediaAdapterKHR )
+        {
+            CALL_LOGGING_ENTER();
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatchX().clGetDeviceIDsFromDX9MediaAdapterKHR(
-            platform,
-            num_media_adapters,
-            media_adapters_type,
-            media_adapters,
-            media_adapter_set,
-            num_entries,
-            devices,
-            num_devices);
+            cl_int  retVal = dispatchX.clGetDeviceIDsFromDX9MediaAdapterKHR(
+                platform,
+                num_media_adapters,
+                media_adapters_type,
+                media_adapters,
+                media_adapter_set,
+                num_entries,
+                devices,
+                num_devices);
 
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT( retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -7306,32 +7417,36 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateFromDX9MediaSurfaceKHR )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER(
-            "context = %p, "
-            "flags = %s (%llX)",
-            context,
-            pIntercept->enumName().name_mem_flags( flags ).c_str(),
-            flags );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateFromDX9MediaSurfaceKHR )
+        {
+            CALL_LOGGING_ENTER(
+                "context = %p, "
+                "flags = %s (%llX)",
+                context,
+                pIntercept->enumName().name_mem_flags( flags ).c_str(),
+                flags );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatchX().clCreateFromDX9MediaSurfaceKHR(
-            context,
-            flags,
-            adapter_type,
-            surface_info,
-            plane,
-            errcode_ret);
+            cl_mem  retVal = dispatchX.clCreateFromDX9MediaSurfaceKHR(
+                context,
+                flags,
+                adapter_type,
+                surface_info,
+                plane,
+                errcode_ret);
 
-        CPU_PERFORMANCE_TIMING_END();
-        ADD_IMAGE( retVal );
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            ADD_IMAGE( retVal );
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -7350,38 +7465,42 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireDX9MediaSurfacesKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clEnqueueAcquireDX9MediaSurfacesKHR )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
-
-        CHECK_AUBCAPTURE_START( command_queue );
-
-        if( pIntercept->nullEnqueue() == false )
+        auto dispatchX = pIntercept->dispatchX(command_queue);
+        if( dispatchX.clEnqueueAcquireDX9MediaSurfacesKHR )
         {
-            CALL_LOGGING_ENTER();
-            CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
-            CPU_PERFORMANCE_TIMING_START();
+            cl_int  retVal = CL_SUCCESS;
 
-            retVal = pIntercept->dispatchX().clEnqueueAcquireDX9MediaSurfacesKHR(
-                command_queue,
-                num_objects,
-                mem_objects,
-                num_events_in_wait_list,
-                event_wait_list,
-                event);
+            CHECK_AUBCAPTURE_START( command_queue );
 
-            CPU_PERFORMANCE_TIMING_END();
-            DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
-            CHECK_ERROR( retVal );
-            ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( retVal, event );
+            if( pIntercept->nullEnqueue() == false )
+            {
+                CALL_LOGGING_ENTER();
+                CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                DEVICE_PERFORMANCE_TIMING_START( event );
+                CPU_PERFORMANCE_TIMING_START();
+
+                retVal = dispatchX.clEnqueueAcquireDX9MediaSurfacesKHR(
+                    command_queue,
+                    num_objects,
+                    mem_objects,
+                    num_events_in_wait_list,
+                    event_wait_list,
+                    event);
+
+                CPU_PERFORMANCE_TIMING_END();
+                DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
+                CHECK_ERROR( retVal );
+                ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
+                CALL_LOGGING_EXIT_EVENT( retVal, event );
+            }
+
+            FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
+            CHECK_AUBCAPTURE_STOP( command_queue );
+
+            return retVal;
         }
-
-        FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
-        CHECK_AUBCAPTURE_STOP( command_queue );
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -7400,40 +7519,44 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseDX9MediaSurfacesKHR(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clEnqueueReleaseDX9MediaSurfacesKHR )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
-
-        CHECK_AUBCAPTURE_START( command_queue );
-
-        if( pIntercept->nullEnqueue() == false )
+        auto dispatchX = pIntercept->dispatchX(command_queue);
+        if( dispatchX.clEnqueueReleaseDX9MediaSurfacesKHR )
         {
-            CALL_LOGGING_ENTER();
-            CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
-            CPU_PERFORMANCE_TIMING_START();
+            cl_int  retVal = CL_SUCCESS;
 
-            retVal = pIntercept->dispatchX().clEnqueueReleaseDX9MediaSurfacesKHR(
-                command_queue,
-                num_objects,
-                mem_objects,
-                num_events_in_wait_list,
-                event_wait_list,
-                event);
+            CHECK_AUBCAPTURE_START( command_queue );
 
-            CPU_PERFORMANCE_TIMING_END();
-            DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
-            CHECK_ERROR( retVal );
-            ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( retVal, event );
+            if( pIntercept->nullEnqueue() == false )
+            {
+                CALL_LOGGING_ENTER();
+                CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                DEVICE_PERFORMANCE_TIMING_START( event );
+                CPU_PERFORMANCE_TIMING_START();
+
+                retVal = dispatchX.clEnqueueReleaseDX9MediaSurfacesKHR(
+                    command_queue,
+                    num_objects,
+                    mem_objects,
+                    num_events_in_wait_list,
+                    event_wait_list,
+                    event);
+
+                CPU_PERFORMANCE_TIMING_END();
+                DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
+                CHECK_ERROR( retVal );
+                ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
+                CALL_LOGGING_EXIT_EVENT( retVal, event );
+            }
+
+            FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
+            CHECK_AUBCAPTURE_STOP( command_queue );
+
+            DEVICE_PERFORMANCE_TIMING_CHECK();
+
+            return retVal;
         }
-
-        FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
-        CHECK_AUBCAPTURE_STOP( command_queue );
-
-        DEVICE_PERFORMANCE_TIMING_CHECK();
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -7455,25 +7578,29 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromDX9INTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clGetDeviceIDsFromDX9INTEL )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER();
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(platform);
+        if( dispatchX.clGetDeviceIDsFromDX9INTEL )
+        {
+            CALL_LOGGING_ENTER();
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatchX().clGetDeviceIDsFromDX9INTEL(
-            platform,
-            d3d_device_source,
-            dx9_object,
-            d3d_device_set,
-            num_entries,
-            devices,
-            num_devices);
+            cl_int  retVal = dispatchX.clGetDeviceIDsFromDX9INTEL(
+                platform,
+                d3d_device_source,
+                dx9_object,
+                d3d_device_set,
+                num_entries,
+                devices,
+                num_devices);
 
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT( retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -7492,32 +7619,36 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateFromDX9MediaSurfaceINTEL )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER(
-            "context = %p, "
-            "flags = %s (%llX)",
-            context,
-            pIntercept->enumName().name_mem_flags( flags ).c_str(),
-            flags );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateFromDX9MediaSurfaceINTEL )
+        {
+            CALL_LOGGING_ENTER(
+                "context = %p, "
+                "flags = %s (%llX)",
+                context,
+                pIntercept->enumName().name_mem_flags( flags ).c_str(),
+                flags );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatchX().clCreateFromDX9MediaSurfaceINTEL(
-            context,
-            flags,
-            resource,
-            sharedHandle,
-            plane,
-            errcode_ret);
+            cl_mem  retVal = dispatchX.clCreateFromDX9MediaSurfaceINTEL(
+                context,
+                flags,
+                resource,
+                sharedHandle,
+                plane,
+                errcode_ret);
 
-        CPU_PERFORMANCE_TIMING_END();
-        ADD_IMAGE( retVal );
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            ADD_IMAGE( retVal );
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -7536,38 +7667,42 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireDX9ObjectsINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clEnqueueAcquireDX9ObjectsINTEL )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
-
-        CHECK_AUBCAPTURE_START( command_queue );
-
-        if( pIntercept->nullEnqueue() == false )
+        auto dispatchX = pIntercept->dispatchX(command_queue);
+        if( dispatchX.clEnqueueAcquireDX9ObjectsINTEL )
         {
-            CALL_LOGGING_ENTER();
-            CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
-            CPU_PERFORMANCE_TIMING_START();
+            cl_int  retVal = CL_SUCCESS;
 
-            retVal = pIntercept->dispatchX().clEnqueueAcquireDX9ObjectsINTEL(
-                command_queue,
-                num_objects,
-                mem_objects,
-                num_events_in_wait_list,
-                event_wait_list,
-                event);
+            CHECK_AUBCAPTURE_START( command_queue );
 
-            CPU_PERFORMANCE_TIMING_END();
-            DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
-            CHECK_ERROR( retVal );
-            ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( retVal, event );
+            if( pIntercept->nullEnqueue() == false )
+            {
+                CALL_LOGGING_ENTER();
+                CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                DEVICE_PERFORMANCE_TIMING_START( event );
+                CPU_PERFORMANCE_TIMING_START();
+
+                retVal = dispatchX.clEnqueueAcquireDX9ObjectsINTEL(
+                    command_queue,
+                    num_objects,
+                    mem_objects,
+                    num_events_in_wait_list,
+                    event_wait_list,
+                    event);
+
+                CPU_PERFORMANCE_TIMING_END();
+                DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
+                CHECK_ERROR( retVal );
+                ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
+                CALL_LOGGING_EXIT_EVENT( retVal, event );
+            }
+
+            FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
+            CHECK_AUBCAPTURE_STOP( command_queue );
+
+            return retVal;
         }
-
-        FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
-        CHECK_AUBCAPTURE_STOP( command_queue );
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -7586,40 +7721,44 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseDX9ObjectsINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clEnqueueReleaseDX9ObjectsINTEL )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
-
-        CHECK_AUBCAPTURE_START( command_queue );
-
-        if( pIntercept->nullEnqueue() == false )
+        auto dispatchX = pIntercept->dispatchX(command_queue);
+        if( dispatchX.clEnqueueReleaseDX9ObjectsINTEL )
         {
-            CALL_LOGGING_ENTER();
-            CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
-            CPU_PERFORMANCE_TIMING_START();
+            cl_int  retVal = CL_SUCCESS;
 
-            retVal = pIntercept->dispatchX().clEnqueueReleaseDX9ObjectsINTEL(
-                command_queue,
-                num_objects,
-                mem_objects,
-                num_events_in_wait_list,
-                event_wait_list,
-                event);
+            CHECK_AUBCAPTURE_START( command_queue );
 
-            CPU_PERFORMANCE_TIMING_END();
-            DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
-            CHECK_ERROR( retVal );
-            ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( retVal, event );
+            if( pIntercept->nullEnqueue() == false )
+            {
+                CALL_LOGGING_ENTER();
+                CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                DEVICE_PERFORMANCE_TIMING_START( event );
+                CPU_PERFORMANCE_TIMING_START();
+
+                retVal = dispatchX.clEnqueueReleaseDX9ObjectsINTEL(
+                    command_queue,
+                    num_objects,
+                    mem_objects,
+                    num_events_in_wait_list,
+                    event_wait_list,
+                    event);
+
+                CPU_PERFORMANCE_TIMING_END();
+                DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
+                CHECK_ERROR( retVal );
+                ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
+                CALL_LOGGING_EXIT_EVENT( retVal, event );
+            }
+
+            FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
+            CHECK_AUBCAPTURE_STOP( command_queue );
+
+            DEVICE_PERFORMANCE_TIMING_CHECK();
+
+            return retVal;
         }
-
-        FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
-        CHECK_AUBCAPTURE_STOP( command_queue );
-
-        DEVICE_PERFORMANCE_TIMING_CHECK();
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -7638,40 +7777,44 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreatePerfCountersCommandQueueINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreatePerfCountersCommandQueueINTEL )
+    if( pIntercept )
     {
-        // We don't have to do this, since profiling must be enabled
-        // for a perf counters command queue, but it doesn't hurt to
-        // add it, either.
-        if( pIntercept->config().DevicePerformanceTiming ||
-            pIntercept->config().ITTPerformanceTiming ||
-            pIntercept->config().ChromePerformanceTiming ||
-            pIntercept->config().SIMDSurvey ||
-            pIntercept->config().DevicePerfCounterEventBasedSampling )
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreatePerfCountersCommandQueueINTEL )
         {
-            properties |= (cl_command_queue_properties)CL_QUEUE_PROFILING_ENABLE;
+            // We don't have to do this, since profiling must be enabled
+            // for a perf counters command queue, but it doesn't hurt to
+            // add it, either.
+            if( pIntercept->config().DevicePerformanceTiming ||
+                pIntercept->config().ITTPerformanceTiming ||
+                pIntercept->config().ChromePerformanceTiming ||
+                pIntercept->config().SIMDSurvey ||
+                pIntercept->config().DevicePerfCounterEventBasedSampling )
+            {
+                properties |= (cl_command_queue_properties)CL_QUEUE_PROFILING_ENABLE;
+            }
+
+            CALL_LOGGING_ENTER( "context = %p",
+                context );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
+
+            cl_command_queue    retVal = dispatchX.clCreatePerfCountersCommandQueueINTEL(
+                context,
+                device,
+                properties,
+                configuration,
+                errcode_ret );
+
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            ITT_REGISTER_COMMAND_QUEUE( retVal, true );
+            CHROME_REGISTER_COMMAND_QUEUE( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+
+            return retVal;
         }
-
-        CALL_LOGGING_ENTER( "context = %p",
-            context );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
-
-        cl_command_queue    retVal = pIntercept->dispatchX().clCreatePerfCountersCommandQueueINTEL(
-            context,
-            device,
-            properties,
-            configuration,
-            errcode_ret );
-
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
-        ITT_REGISTER_COMMAND_QUEUE( retVal, true );
-        CHROME_REGISTER_COMMAND_QUEUE( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -7688,22 +7831,26 @@ CL_API_ENTRY cl_int CL_API_CALL clSetPerformanceConfigurationINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clSetPerformanceConfigurationINTEL )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER();
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(device);
+        if( dispatchX.clSetPerformanceConfigurationINTEL )
+        {
+            CALL_LOGGING_ENTER();
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_int retVal = pIntercept->dispatchX().clSetPerformanceConfigurationINTEL(
-            device,
-            count,
-            offsets,
-            values );
+            cl_int retVal = dispatchX.clSetPerformanceConfigurationINTEL(
+                device,
+                count,
+                offsets,
+                values );
 
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT( retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -7721,42 +7868,46 @@ CL_API_ENTRY cl_accelerator_intel CL_API_CALL clCreateAcceleratorINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateAcceleratorINTEL )
+    if( pIntercept )
     {
-        if( ( accelerator_type == CL_ACCELERATOR_TYPE_MOTION_ESTIMATION_INTEL ) &&
-            ( descriptor_size >= sizeof( cl_motion_estimation_desc_intel ) ) )
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateAcceleratorINTEL )
         {
-            cl_motion_estimation_desc_intel* desc =
-                (cl_motion_estimation_desc_intel*)descriptor;
-            CALL_LOGGING_ENTER( "context = %p, motion_estimation_desc[ mb_block_type = %d, subpixel_mode = %d, sad_adjust_mode = %d, search_path_type = %d ]",
+            if( ( accelerator_type == CL_ACCELERATOR_TYPE_MOTION_ESTIMATION_INTEL ) &&
+                ( descriptor_size >= sizeof( cl_motion_estimation_desc_intel ) ) )
+            {
+                cl_motion_estimation_desc_intel* desc =
+                    (cl_motion_estimation_desc_intel*)descriptor;
+                CALL_LOGGING_ENTER( "context = %p, motion_estimation_desc[ mb_block_type = %d, subpixel_mode = %d, sad_adjust_mode = %d, search_path_type = %d ]",
+                    context,
+                    desc->mb_block_type,
+                    desc->subpixel_mode,
+                    desc->sad_adjust_mode,
+                    desc->search_path_type );
+            }
+            else
+            {
+                CALL_LOGGING_ENTER( "context = %p, accelerator_type = %u",
+                    context,
+                    (cl_uint)accelerator_type );
+            }
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
+
+            cl_accelerator_intel retVal = dispatchX.clCreateAcceleratorINTEL(
                 context,
-                desc->mb_block_type,
-                desc->subpixel_mode,
-                desc->sad_adjust_mode,
-                desc->search_path_type );
+                accelerator_type,
+                descriptor_size,
+                descriptor,
+                errcode_ret);
+
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( errcode_ret[0] );
+            //ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+
+            return retVal;
         }
-        else
-        {
-            CALL_LOGGING_ENTER( "context = %p, accelerator_type = %u",
-                context,
-                (cl_uint)accelerator_type );
-        }
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
-
-        cl_accelerator_intel retVal = pIntercept->dispatchX().clCreateAcceleratorINTEL(
-            context,
-            accelerator_type,
-            descriptor_size,
-            descriptor,
-            errcode_ret);
-
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( errcode_ret[0] );
-        //ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -7774,25 +7925,29 @@ CL_API_ENTRY cl_int CL_API_CALL clGetAcceleratorInfoINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clGetAcceleratorInfoINTEL )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER( "param_name = %s (%X)",
-            pIntercept->enumName().name( param_name ).c_str(),
-            param_name );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(accelerator);
+        if( dispatchX.clGetAcceleratorInfoINTEL )
+        {
+            CALL_LOGGING_ENTER( "param_name = %s (%X)",
+                pIntercept->enumName().name( param_name ).c_str(),
+                param_name );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatchX().clGetAcceleratorInfoINTEL(
-            accelerator,
-            param_name,
-            param_value_size,
-            param_value,
-            param_value_size_ret );
+            cl_int  retVal = dispatchX.clGetAcceleratorInfoINTEL(
+                accelerator,
+                param_name,
+                param_value_size,
+                param_value,
+                param_value_size_ret );
 
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT( retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -7806,42 +7961,46 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainAcceleratorINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clRetainAcceleratorINTEL )
+    if( pIntercept )
     {
-        cl_uint ref_count = 0;
-        if( pIntercept->callLogging() )
+        auto dispatchX = pIntercept->dispatchX(accelerator);
+        if( dispatchX.clRetainAcceleratorINTEL )
         {
-            ref_count = 0;
-            pIntercept->dispatchX().clGetAcceleratorInfoINTEL(
-                accelerator,
-                CL_ACCELERATOR_REFERENCE_COUNT_INTEL,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
+            cl_uint ref_count = 0;
+            if( pIntercept->callLogging() )
+            {
+                ref_count = 0;
+                dispatchX.clGetAcceleratorInfoINTEL(
+                    accelerator,
+                    CL_ACCELERATOR_REFERENCE_COUNT_INTEL,
+                    sizeof( ref_count ),
+                    &ref_count,
+                    NULL );
+            }
+            CALL_LOGGING_ENTER( "[ ref count = %d ] accelerator = %p",
+                ref_count,
+                accelerator );
+            CPU_PERFORMANCE_TIMING_START();
+
+            cl_int  retVal = dispatchX.clRetainAcceleratorINTEL(
+                accelerator );
+
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            if( pIntercept->callLogging() )
+            {
+                ref_count = 0;
+                dispatchX.clGetAcceleratorInfoINTEL(
+                    accelerator,
+                    CL_ACCELERATOR_REFERENCE_COUNT_INTEL,
+                    sizeof( ref_count ),
+                    &ref_count,
+                    NULL );
+            }
+            CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
+
+            return retVal;
         }
-        CALL_LOGGING_ENTER( "[ ref count = %d ] accelerator = %p",
-            ref_count,
-            accelerator );
-        CPU_PERFORMANCE_TIMING_START();
-
-        cl_int  retVal = pIntercept->dispatchX().clRetainAcceleratorINTEL(
-            accelerator );
-
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( retVal );
-        if( pIntercept->callLogging() )
-        {
-            ref_count = 0;
-            pIntercept->dispatchX().clGetAcceleratorInfoINTEL(
-                accelerator,
-                CL_ACCELERATOR_REFERENCE_COUNT_INTEL,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
-        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -7855,38 +8014,42 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseAcceleratorINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clReleaseAcceleratorINTEL )
+    if( pIntercept )
     {
-        cl_uint ref_count = 0;
-        if( pIntercept->callLogging() )
+        auto dispatchX = pIntercept->dispatchX(accelerator);
+        if( dispatchX.clReleaseAcceleratorINTEL )
         {
-            ref_count = 0;
-            pIntercept->dispatchX().clGetAcceleratorInfoINTEL(
-                accelerator,
-                CL_ACCELERATOR_REFERENCE_COUNT_INTEL,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
+            cl_uint ref_count = 0;
+            if( pIntercept->callLogging() )
+            {
+                ref_count = 0;
+                dispatchX.clGetAcceleratorInfoINTEL(
+                    accelerator,
+                    CL_ACCELERATOR_REFERENCE_COUNT_INTEL,
+                    sizeof( ref_count ),
+                    &ref_count,
+                    NULL );
+            }
+            CALL_LOGGING_ENTER( "[ ref count = %d ] accelerator = %p",
+                ref_count,
+                accelerator );
+            CPU_PERFORMANCE_TIMING_START();
+
+            cl_int  retVal = dispatchX.clReleaseAcceleratorINTEL(
+                accelerator );
+
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            if( pIntercept->callLogging() && ref_count != 0 )
+            {
+                // This isn't strictly correct, but it's pretty close, and it
+                // avoids crashes in some cases for bad implementations.
+                --ref_count;
+            }
+            CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
+
+            return retVal;
         }
-        CALL_LOGGING_ENTER( "[ ref count = %d ] accelerator = %p",
-            ref_count,
-            accelerator );
-        CPU_PERFORMANCE_TIMING_START();
-
-        cl_int  retVal = pIntercept->dispatchX().clReleaseAcceleratorINTEL(
-            accelerator );
-
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( retVal );
-        if( pIntercept->callLogging() && ref_count != 0 )
-        {
-            // This isn't strictly correct, but it's pretty close, and it
-            // avoids crashes in some cases for bad implementations.
-            --ref_count;
-        }
-        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -7906,25 +8069,29 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromVA_APIMediaAdapterINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clGetDeviceIDsFromVA_APIMediaAdapterINTEL )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER();
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(platform);
+        if( dispatchX.clGetDeviceIDsFromVA_APIMediaAdapterINTEL )
+        {
+            CALL_LOGGING_ENTER();
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatchX().clGetDeviceIDsFromVA_APIMediaAdapterINTEL(
-            platform,
-            media_adapter_type,
-            media_adapter,
-            media_adapter_set,
-            num_entries,
-            devices,
-            num_devices);
+            cl_int  retVal = dispatchX.clGetDeviceIDsFromVA_APIMediaAdapterINTEL(
+                platform,
+                media_adapter_type,
+                media_adapter,
+                media_adapter_set,
+                num_entries,
+                devices,
+                num_devices);
 
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT( retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -7942,31 +8109,35 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromVA_APIMediaSurfaceINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clCreateFromVA_APIMediaSurfaceINTEL )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER(
-            "context = %p, "
-            "flags = %s (%llX)",
-            context,
-            pIntercept->enumName().name_mem_flags( flags ).c_str(),
-            flags );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateFromVA_APIMediaSurfaceINTEL )
+        {
+            CALL_LOGGING_ENTER(
+                "context = %p, "
+                "flags = %s (%llX)",
+                context,
+                pIntercept->enumName().name_mem_flags( flags ).c_str(),
+                flags );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_mem  retVal = pIntercept->dispatchX().clCreateFromVA_APIMediaSurfaceINTEL(
-            context,
-            flags,
-            surface,
-            plane,
-            errcode_ret);
+            cl_mem  retVal = dispatchX.clCreateFromVA_APIMediaSurfaceINTEL(
+                context,
+                flags,
+                surface,
+                plane,
+                errcode_ret);
 
-        CPU_PERFORMANCE_TIMING_END();
-        ADD_IMAGE( retVal );
-        CHECK_ERROR( errcode_ret[0] );
-        ADD_OBJECT_ALLOCATION( retVal );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            ADD_IMAGE( retVal );
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -7985,38 +8156,42 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireVA_APIMediaSurfacesINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clEnqueueAcquireVA_APIMediaSurfacesINTEL )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
-
-        CHECK_AUBCAPTURE_START( command_queue );
-
-        if( pIntercept->nullEnqueue() == false )
+        auto dispatchX = pIntercept->dispatchX(command_queue);
+        if( dispatchX.clEnqueueAcquireVA_APIMediaSurfacesINTEL )
         {
-            CALL_LOGGING_ENTER();
-            CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
-            CPU_PERFORMANCE_TIMING_START();
+            cl_int  retVal = CL_SUCCESS;
 
-            retVal = pIntercept->dispatchX().clEnqueueAcquireVA_APIMediaSurfacesINTEL(
-                command_queue,
-                num_objects,
-                mem_objects,
-                num_events_in_wait_list,
-                event_wait_list,
-                event);
+            CHECK_AUBCAPTURE_START( command_queue );
 
-            CPU_PERFORMANCE_TIMING_END();
-            DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
-            CHECK_ERROR( retVal );
-            ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( retVal, event );
+            if( pIntercept->nullEnqueue() == false )
+            {
+                CALL_LOGGING_ENTER();
+                CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                DEVICE_PERFORMANCE_TIMING_START( event );
+                CPU_PERFORMANCE_TIMING_START();
+
+                retVal = dispatchX.clEnqueueAcquireVA_APIMediaSurfacesINTEL(
+                    command_queue,
+                    num_objects,
+                    mem_objects,
+                    num_events_in_wait_list,
+                    event_wait_list,
+                    event);
+
+                CPU_PERFORMANCE_TIMING_END();
+                DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
+                CHECK_ERROR( retVal );
+                ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
+                CALL_LOGGING_EXIT_EVENT( retVal, event );
+            }
+
+            FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
+            CHECK_AUBCAPTURE_STOP( command_queue );
+
+            return retVal;
         }
-
-        FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
-        CHECK_AUBCAPTURE_STOP( command_queue );
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -8035,40 +8210,44 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseVA_APIMediaSurfacesINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clEnqueueReleaseVA_APIMediaSurfacesINTEL )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
-
-        CHECK_AUBCAPTURE_START( command_queue );
-
-        if( pIntercept->nullEnqueue() == false )
+        auto dispatchX = pIntercept->dispatchX(command_queue);
+        if( dispatchX.clEnqueueReleaseVA_APIMediaSurfacesINTEL )
         {
-            CALL_LOGGING_ENTER();
-            CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
-            CPU_PERFORMANCE_TIMING_START();
+            cl_int  retVal = CL_SUCCESS;
 
-            retVal = pIntercept->dispatchX().clEnqueueReleaseVA_APIMediaSurfacesINTEL(
-                command_queue,
-                num_objects,
-                mem_objects,
-                num_events_in_wait_list,
-                event_wait_list,
-                event);
+            CHECK_AUBCAPTURE_START( command_queue );
 
-            CPU_PERFORMANCE_TIMING_END();
-            DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
-            CHECK_ERROR( retVal );
-            ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( retVal, event );
+            if( pIntercept->nullEnqueue() == false )
+            {
+                CALL_LOGGING_ENTER();
+                CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                DEVICE_PERFORMANCE_TIMING_START( event );
+                CPU_PERFORMANCE_TIMING_START();
+
+                retVal = dispatchX.clEnqueueReleaseVA_APIMediaSurfacesINTEL(
+                    command_queue,
+                    num_objects,
+                    mem_objects,
+                    num_events_in_wait_list,
+                    event_wait_list,
+                    event);
+
+                CPU_PERFORMANCE_TIMING_END();
+                DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
+                CHECK_ERROR( retVal );
+                ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
+                CALL_LOGGING_EXIT_EVENT( retVal, event );
+            }
+
+            FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
+            CHECK_AUBCAPTURE_STOP( command_queue );
+
+            DEVICE_PERFORMANCE_TIMING_CHECK();
+
+            return retVal;
         }
-
-        FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
-        CHECK_AUBCAPTURE_STOP( command_queue );
-
-        DEVICE_PERFORMANCE_TIMING_CHECK();
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -8086,29 +8265,33 @@ CL_API_ENTRY void* CL_API_CALL clHostMemAllocINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clHostMemAllocINTEL )
+    if( pIntercept )
     {
-        // TODO: Make properties string.
-        CALL_LOGGING_ENTER( "context = %p, properties = %p, size = %d, alignment = %d",
-            context,
-            properties,
-            size,
-            alignment );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clHostMemAllocINTEL )
+        {
+            // TODO: Make properties string.
+            CALL_LOGGING_ENTER( "context = %p, properties = %p, size = %d, alignment = %d",
+                context,
+                properties,
+                size,
+                alignment );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
 
-        void*   retVal = pIntercept->dispatchX().clHostMemAllocINTEL(
-            context,
-            properties,
-            size,
-            alignment,
-            errcode_ret );
+            void*   retVal = dispatchX.clHostMemAllocINTEL(
+                context,
+                properties,
+                size,
+                alignment,
+                errcode_ret );
 
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( errcode_ret[0] );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( errcode_ret[0] );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     return NULL;
@@ -8127,39 +8310,43 @@ CL_API_ENTRY void* CL_API_CALL clDeviceMemAllocINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clDeviceMemAllocINTEL )
+    if( pIntercept )
     {
-        std::string deviceInfo;
-        if( pIntercept->config().CallLogging )
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clDeviceMemAllocINTEL )
         {
-            pIntercept->getDeviceInfoString(
-                1,
-                &device,
-                deviceInfo );
+            std::string deviceInfo;
+            if( pIntercept->config().CallLogging )
+            {
+                pIntercept->getDeviceInfoString(
+                    1,
+                    &device,
+                    deviceInfo );
+            }
+            // TODO: Make properties string.
+            CALL_LOGGING_ENTER( "context = %p, device = [ %s ], properties = %p, size = %d, alignment = %d",
+                context,
+                deviceInfo.c_str(),
+                properties,
+                size,
+                alignment );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
+
+            void*   retVal = dispatchX.clDeviceMemAllocINTEL(
+                context,
+                device,
+                properties,
+                size,
+                alignment,
+                errcode_ret );
+
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( errcode_ret[0] );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+
+            return retVal;
         }
-        // TODO: Make properties string.
-        CALL_LOGGING_ENTER( "context = %p, device = [ %s ], properties = %p, size = %d, alignment = %d",
-            context,
-            deviceInfo.c_str(),
-            properties,
-            size,
-            alignment );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
-
-        void*   retVal = pIntercept->dispatchX().clDeviceMemAllocINTEL(
-            context,
-            device,
-            properties,
-            size,
-            alignment,
-            errcode_ret );
-
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( errcode_ret[0] );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
-
-        return retVal;
     }
 
     return NULL;
@@ -8178,39 +8365,43 @@ CL_API_ENTRY void* CL_API_CALL clSharedMemAllocINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clSharedMemAllocINTEL )
+    if( pIntercept )
     {
-        std::string deviceInfo;
-        if( pIntercept->config().CallLogging )
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clSharedMemAllocINTEL )
         {
-            pIntercept->getDeviceInfoString(
-                1,
-                &device,
-                deviceInfo );
+            std::string deviceInfo;
+            if( pIntercept->config().CallLogging )
+            {
+                pIntercept->getDeviceInfoString(
+                    1,
+                    &device,
+                    deviceInfo );
+            }
+            // TODO: Make properties string.
+            CALL_LOGGING_ENTER( "context = %p, device = [ %s ], properties = %p, size = %d, alignment = %d",
+                context,
+                deviceInfo.c_str(),
+                properties,
+                size,
+                alignment );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
+
+            void*   retVal = dispatchX.clSharedMemAllocINTEL(
+                context,
+                device,
+                properties,
+                size,
+                alignment,
+                errcode_ret );
+
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( errcode_ret[0] );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+
+            return retVal;
         }
-        // TODO: Make properties string.
-        CALL_LOGGING_ENTER( "context = %p, device = [ %s ], properties = %p, size = %d, alignment = %d",
-            context,
-            deviceInfo.c_str(),
-            properties,
-            size,
-            alignment );
-        CHECK_ERROR_INIT( errcode_ret );
-        CPU_PERFORMANCE_TIMING_START();
-
-        void*   retVal = pIntercept->dispatchX().clSharedMemAllocINTEL(
-            context,
-            device,
-            properties,
-            size,
-            alignment,
-            errcode_ret );
-
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( errcode_ret[0] );
-        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
@@ -8225,22 +8416,26 @@ CL_API_ENTRY cl_int CL_API_CALL clMemFreeINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clMemFreeINTEL )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER( "context = %p, ptr = %p",
-            context,
-            ptr );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clMemFreeINTEL )
+        {
+            CALL_LOGGING_ENTER( "context = %p, ptr = %p",
+                context,
+                ptr );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatchX().clMemFreeINTEL(
-            context,
-            ptr );
+            cl_int  retVal = dispatchX.clMemFreeINTEL(
+                context,
+                ptr );
 
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT( retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -8256,22 +8451,26 @@ clMemBlockingFreeINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clMemBlockingFreeINTEL )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER( "context = %p, ptr = %p",
-            context,
-            ptr );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clMemBlockingFreeINTEL )
+        {
+            CALL_LOGGING_ENTER( "context = %p, ptr = %p",
+                context,
+                ptr );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatchX().clMemBlockingFreeINTEL(
-            context,
-            ptr );
+            cl_int  retVal = dispatchX.clMemBlockingFreeINTEL(
+                context,
+                ptr );
 
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT( retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -8290,28 +8489,32 @@ CL_API_ENTRY cl_int CL_API_CALL clGetMemAllocInfoINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clGetMemAllocInfoINTEL )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER( "context = %p, ptr = %p, param_name = %s (%08X)",
-            context,
-            ptr,
-            pIntercept->enumName().name( param_name ).c_str(),
-            param_name );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clGetMemAllocInfoINTEL )
+        {
+            CALL_LOGGING_ENTER( "context = %p, ptr = %p, param_name = %s (%08X)",
+                context,
+                ptr,
+                pIntercept->enumName().name( param_name ).c_str(),
+                param_name );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatchX().clGetMemAllocInfoINTEL(
-            context,
-            ptr,
-            param_name,
-            param_value_size,
-            param_value,
-            param_value_size_ret );
+            cl_int  retVal = dispatchX.clGetMemAllocInfoINTEL(
+                context,
+                ptr,
+                param_name,
+                param_value_size,
+                param_value,
+                param_value_size_ret );
 
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT( retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -8327,27 +8530,31 @@ CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgMemPointerINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clSetKernelArgMemPointerINTEL )
+    if( pIntercept )
     {
-        CALL_LOGGING_ENTER_KERNEL(
-            kernel,
-            "kernel = %p, index = %d, value = %p",
-            kernel,
-            arg_index,
-            arg_value );
-        CHECK_KERNEL_ARG_USM_POINTER( kernel, arg_value );
-        CPU_PERFORMANCE_TIMING_START();
+        auto dispatchX = pIntercept->dispatchX(kernel);
+        if( dispatchX.clSetKernelArgMemPointerINTEL )
+        {
+            CALL_LOGGING_ENTER_KERNEL(
+                kernel,
+                "kernel = %p, index = %d, value = %p",
+                kernel,
+                arg_index,
+                arg_value );
+            CHECK_KERNEL_ARG_USM_POINTER( kernel, arg_value );
+            CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = pIntercept->dispatchX().clSetKernelArgMemPointerINTEL(
-            kernel,
-            arg_index,
-            arg_value );
+            cl_int  retVal = dispatchX.clSetKernelArgMemPointerINTEL(
+                kernel,
+                arg_index,
+                arg_value );
 
-        CPU_PERFORMANCE_TIMING_END();
-        CHECK_ERROR( retVal );
-        CALL_LOGGING_EXIT( retVal );
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
 
-        return retVal;
+            return retVal;
+        }
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -8367,43 +8574,47 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemsetINTEL(   // Deprecated
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clEnqueueMemsetINTEL )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
-
-        CHECK_AUBCAPTURE_START( queue );
-
-        if( pIntercept->nullEnqueue() == false )
+        auto dispatchX = pIntercept->dispatchX(queue);
+        if( dispatchX.clEnqueueMemsetINTEL )
         {
-            CALL_LOGGING_ENTER( "queue = %p, dst_ptr = %p, value = %d, size = %u",
-                queue,
-                dst_ptr,
-                value,
-                (cl_uint)size );
-            CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
-            CPU_PERFORMANCE_TIMING_START();
+            cl_int  retVal = CL_SUCCESS;
 
-            retVal = pIntercept->dispatchX().clEnqueueMemsetINTEL(
-                queue,
-                dst_ptr,
-                value,
-                size,
-                num_events_in_wait_list,
-                event_wait_list,
-                event );
+            CHECK_AUBCAPTURE_START( queue );
 
-            CPU_PERFORMANCE_TIMING_END();
-            DEVICE_PERFORMANCE_TIMING_END( queue, event );
-            CHECK_ERROR( retVal );
-            ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( retVal, event );
+            if( pIntercept->nullEnqueue() == false )
+            {
+                CALL_LOGGING_ENTER( "queue = %p, dst_ptr = %p, value = %d, size = %u",
+                    queue,
+                    dst_ptr,
+                    value,
+                    (cl_uint)size );
+                CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                DEVICE_PERFORMANCE_TIMING_START( event );
+                CPU_PERFORMANCE_TIMING_START();
+
+                retVal = dispatchX.clEnqueueMemsetINTEL(
+                    queue,
+                    dst_ptr,
+                    value,
+                    size,
+                    num_events_in_wait_list,
+                    event_wait_list,
+                    event );
+
+                CPU_PERFORMANCE_TIMING_END();
+                DEVICE_PERFORMANCE_TIMING_END( queue, event );
+                CHECK_ERROR( retVal );
+                ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
+                CALL_LOGGING_EXIT_EVENT( retVal, event );
+            }
+
+            FINISH_OR_FLUSH_AFTER_ENQUEUE( queue );
+            CHECK_AUBCAPTURE_STOP( queue  );
+
+            return retVal;
         }
-
-        FINISH_OR_FLUSH_AFTER_ENQUEUE( queue );
-        CHECK_AUBCAPTURE_STOP( queue  );
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -8424,44 +8635,48 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemFillINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clEnqueueMemFillINTEL )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
-
-        CHECK_AUBCAPTURE_START( queue );
-
-        if( pIntercept->nullEnqueue() == false )
+        auto dispatchX = pIntercept->dispatchX(queue);
+        if( dispatchX.clEnqueueMemFillINTEL )
         {
-            CALL_LOGGING_ENTER( "queue = %p, dst_ptr = %p, pattern_size = %u, size = %u",
-                queue,
-                dst_ptr,
-                (cl_uint)pattern_size,
-                (cl_uint)size );
-            CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
-            CPU_PERFORMANCE_TIMING_START();
+            cl_int  retVal = CL_SUCCESS;
 
-            retVal = pIntercept->dispatchX().clEnqueueMemFillINTEL(
-                queue,
-                dst_ptr,
-                pattern,
-                pattern_size,
-                size,
-                num_events_in_wait_list,
-                event_wait_list,
-                event );
+            CHECK_AUBCAPTURE_START( queue );
 
-            CPU_PERFORMANCE_TIMING_END();
-            DEVICE_PERFORMANCE_TIMING_END( queue, event );
-            CHECK_ERROR( retVal );
-            ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( retVal, event );
+            if( pIntercept->nullEnqueue() == false )
+            {
+                CALL_LOGGING_ENTER( "queue = %p, dst_ptr = %p, pattern_size = %u, size = %u",
+                    queue,
+                    dst_ptr,
+                    (cl_uint)pattern_size,
+                    (cl_uint)size );
+                CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                DEVICE_PERFORMANCE_TIMING_START( event );
+                CPU_PERFORMANCE_TIMING_START();
+
+                retVal = dispatchX.clEnqueueMemFillINTEL(
+                    queue,
+                    dst_ptr,
+                    pattern,
+                    pattern_size,
+                    size,
+                    num_events_in_wait_list,
+                    event_wait_list,
+                    event );
+
+                CPU_PERFORMANCE_TIMING_END();
+                DEVICE_PERFORMANCE_TIMING_END( queue, event );
+                CHECK_ERROR( retVal );
+                ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
+                CALL_LOGGING_EXIT_EVENT( retVal, event );
+            }
+
+            FINISH_OR_FLUSH_AFTER_ENQUEUE( queue );
+            CHECK_AUBCAPTURE_STOP( queue  );
+
+            return retVal;
         }
-
-        FINISH_OR_FLUSH_AFTER_ENQUEUE( queue );
-        CHECK_AUBCAPTURE_STOP( queue  );
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -8482,45 +8697,49 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemcpyINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clEnqueueMemcpyINTEL )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
-
-        CHECK_AUBCAPTURE_START( queue );
-
-        if( pIntercept->nullEnqueue() == false )
+        auto dispatchX = pIntercept->dispatchX(queue);
+        if( dispatchX.clEnqueueMemcpyINTEL )
         {
-            CALL_LOGGING_ENTER( "queue = %p, %s, dst_ptr = %p, src_ptr = %p, size = %u",
-                queue,
-                blocking ? "blocking" : "non-blocking",
-                dst_ptr,
-                src_ptr,
-                (cl_uint)size );
-            CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
-            CPU_PERFORMANCE_TIMING_START();
+            cl_int  retVal = CL_SUCCESS;
 
-            retVal = pIntercept->dispatchX().clEnqueueMemcpyINTEL(
-                queue,
-                blocking,
-                dst_ptr,
-                src_ptr,
-                size,
-                num_events_in_wait_list,
-                event_wait_list,
-                event );
+            CHECK_AUBCAPTURE_START( queue );
 
-            CPU_PERFORMANCE_TIMING_END();
-            DEVICE_PERFORMANCE_TIMING_END( queue, event );
-            CHECK_ERROR( retVal );
-            ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( retVal, event );
+            if( pIntercept->nullEnqueue() == false )
+            {
+                CALL_LOGGING_ENTER( "queue = %p, %s, dst_ptr = %p, src_ptr = %p, size = %u",
+                    queue,
+                    blocking ? "blocking" : "non-blocking",
+                    dst_ptr,
+                    src_ptr,
+                    (cl_uint)size );
+                CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                DEVICE_PERFORMANCE_TIMING_START( event );
+                CPU_PERFORMANCE_TIMING_START();
+
+                retVal = dispatchX.clEnqueueMemcpyINTEL(
+                    queue,
+                    blocking,
+                    dst_ptr,
+                    src_ptr,
+                    size,
+                    num_events_in_wait_list,
+                    event_wait_list,
+                    event );
+
+                CPU_PERFORMANCE_TIMING_END();
+                DEVICE_PERFORMANCE_TIMING_END( queue, event );
+                CHECK_ERROR( retVal );
+                ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
+                CALL_LOGGING_EXIT_EVENT( retVal, event );
+            }
+
+            FINISH_OR_FLUSH_AFTER_ENQUEUE( queue );
+            CHECK_AUBCAPTURE_STOP( queue );
+
+            return retVal;
         }
-
-        FINISH_OR_FLUSH_AFTER_ENQUEUE( queue );
-        CHECK_AUBCAPTURE_STOP( queue );
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -8540,44 +8759,48 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMigrateMemINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clEnqueueMigrateMemINTEL )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
-
-        CHECK_AUBCAPTURE_START( queue );
-
-        if( pIntercept->nullEnqueue() == false )
+        auto dispatchX = pIntercept->dispatchX(queue);
+        if( dispatchX.clEnqueueMigrateMemINTEL )
         {
-            CALL_LOGGING_ENTER( "queue = %p, ptr = %p, size = %u, flags = %s (%llX)",
-                queue,
-                ptr,
-                (cl_uint)size,
-                pIntercept->enumName().name_mem_migration_flags( flags ).c_str(),
-                flags );
-            CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
-            CPU_PERFORMANCE_TIMING_START();
+            cl_int  retVal = CL_SUCCESS;
 
-            retVal = pIntercept->dispatchX().clEnqueueMigrateMemINTEL(
-                queue,
-                ptr,
-                size,
-                flags,
-                num_events_in_wait_list,
-                event_wait_list,
-                event );
+            CHECK_AUBCAPTURE_START( queue );
 
-            CPU_PERFORMANCE_TIMING_END();
-            DEVICE_PERFORMANCE_TIMING_END( queue, event );
-            CHECK_ERROR( retVal );
-            ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( retVal, event );
+            if( pIntercept->nullEnqueue() == false )
+            {
+                CALL_LOGGING_ENTER( "queue = %p, ptr = %p, size = %u, flags = %s (%llX)",
+                    queue,
+                    ptr,
+                    (cl_uint)size,
+                    pIntercept->enumName().name_mem_migration_flags( flags ).c_str(),
+                    flags );
+                CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                DEVICE_PERFORMANCE_TIMING_START( event );
+                CPU_PERFORMANCE_TIMING_START();
+
+                retVal = dispatchX.clEnqueueMigrateMemINTEL(
+                    queue,
+                    ptr,
+                    size,
+                    flags,
+                    num_events_in_wait_list,
+                    event_wait_list,
+                    event );
+
+                CPU_PERFORMANCE_TIMING_END();
+                DEVICE_PERFORMANCE_TIMING_END( queue, event );
+                CHECK_ERROR( retVal );
+                ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
+                CALL_LOGGING_EXIT_EVENT( retVal, event );
+            }
+
+            FINISH_OR_FLUSH_AFTER_ENQUEUE( queue );
+            CHECK_AUBCAPTURE_STOP( queue );
+
+            return retVal;
         }
-
-        FINISH_OR_FLUSH_AFTER_ENQUEUE( queue );
-        CHECK_AUBCAPTURE_STOP( queue );
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();
@@ -8597,44 +8820,48 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemAdviseINTEL(
 {
     CLIntercept*    pIntercept = GetIntercept();
 
-    if( pIntercept && pIntercept->dispatchX().clEnqueueMemAdviseINTEL )
+    if( pIntercept )
     {
-        cl_int  retVal = CL_SUCCESS;
-
-        CHECK_AUBCAPTURE_START( queue );
-
-        if( pIntercept->nullEnqueue() == false )
+        auto dispatchX = pIntercept->dispatchX(queue);
+        if( dispatchX.clEnqueueMemAdviseINTEL )
         {
-            CALL_LOGGING_ENTER( "queue = %p, ptr = %p, size = %u, advice = %s (%llX)",
-                queue,
-                ptr,
-                (cl_uint)size,
-                pIntercept->enumName().name(advice).c_str(),
-                advice );
-            CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
-            CPU_PERFORMANCE_TIMING_START();
+            cl_int  retVal = CL_SUCCESS;
 
-            retVal = pIntercept->dispatchX().clEnqueueMemAdviseINTEL(
-                queue,
-                ptr,
-                size,
-                advice,
-                num_events_in_wait_list,
-                event_wait_list,
-                event );
+            CHECK_AUBCAPTURE_START( queue );
 
-            CPU_PERFORMANCE_TIMING_END();
-            DEVICE_PERFORMANCE_TIMING_END( queue, event );
-            CHECK_ERROR( retVal );
-            ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_EVENT( retVal, event );
+            if( pIntercept->nullEnqueue() == false )
+            {
+                CALL_LOGGING_ENTER( "queue = %p, ptr = %p, size = %u, advice = %s (%llX)",
+                    queue,
+                    ptr,
+                    (cl_uint)size,
+                    pIntercept->enumName().name(advice).c_str(),
+                    advice );
+                CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                DEVICE_PERFORMANCE_TIMING_START( event );
+                CPU_PERFORMANCE_TIMING_START();
+
+                retVal = dispatchX.clEnqueueMemAdviseINTEL(
+                    queue,
+                    ptr,
+                    size,
+                    advice,
+                    num_events_in_wait_list,
+                    event_wait_list,
+                    event );
+
+                CPU_PERFORMANCE_TIMING_END();
+                DEVICE_PERFORMANCE_TIMING_END( queue, event );
+                CHECK_ERROR( retVal );
+                ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
+                CALL_LOGGING_EXIT_EVENT( retVal, event );
+            }
+
+            FINISH_OR_FLUSH_AFTER_ENQUEUE( queue );
+            CHECK_AUBCAPTURE_STOP( queue );
+
+            return retVal;
         }
-
-        FINISH_OR_FLUSH_AFTER_ENQUEUE( queue );
-        CHECK_AUBCAPTURE_STOP( queue );
-
-        return retVal;
     }
 
     NULL_FUNCTION_POINTER_RETURN_ERROR();

--- a/intercept/src/dispatch.h
+++ b/intercept/src/dispatch.h
@@ -482,6 +482,20 @@ struct CLdispatch
     void*   (CLI_API_CALL *clGetExtensionFunctionAddress) (
                 const char* func_name );
 
+    // clGetGLContextInfoKHR is a special-case.
+    // It's an extension function and is part of cl_khr_gl_sharing, but it
+    // doesn't necessarily pass a dispatchable object as its first argument,
+    // and is implemented in the ICD loader and called into via the core API
+    // dispatch table.  This means that we can install it into our core API
+    // dispatch table as well, and don't need to look it up per-platform.
+
+    cl_int  (CLI_API_CALL *clGetGLContextInfoKHR) (
+                const cl_context_properties *properties,
+                cl_gl_context_info param_name,
+                size_t param_value_size,
+                void* param_value,
+                size_t* param_value_size_ret);
+
     // OpenCL 1.1
 
     cl_int  (CLI_API_CALL *clSetEventCallback) (
@@ -930,14 +944,6 @@ struct CLdispatchX
                 cl_uint num_events_in_wait_list,
                 const cl_event* event_wait_list,
                 cl_event* event);
-
-    // cl_khr_gl_sharing
-    cl_int  (CLI_API_CALL *clGetGLContextInfoKHR) (
-                const cl_context_properties *properties,
-                cl_gl_context_info param_name,
-                size_t param_value_size,
-                void* param_value,
-                size_t* param_value_size_ret);
 
 #if defined(_WIN32)
     // cl_khr_d3d10_sharing

--- a/intercept/src/dispatch.h
+++ b/intercept/src/dispatch.h
@@ -28,6 +28,8 @@
 #define CLI_API_ENTRY   CL_API_ENTRY
 #define CLI_API_CALL    CL_API_CALL
 
+// Dispatch table for core APIs:
+
 struct CLdispatch
 {
     cl_int  (CLI_API_CALL *clGetPlatformIDs) (
@@ -55,22 +57,6 @@ struct CLdispatch
                 size_t param_value_size,
                 void* param_value,
                 size_t* param_value_size_ret );
-
-    // OpenCL 1.2
-    cl_int  (CLI_API_CALL *clCreateSubDevices) (
-                cl_device_id in_device,
-                const cl_device_partition_property* properties,
-                cl_uint num_devices,
-                cl_device_id* out_devices,
-                cl_uint* num_devices_ret );
-
-    // OpenCL 1.2
-    cl_int  (CLI_API_CALL *clRetainDevice) (
-                cl_device_id device );
-
-    // OpenCL 1.2
-    cl_int  (CLI_API_CALL *clReleaseDevice) (
-                cl_device_id device );
 
     cl_context  (CLI_API_CALL *clCreateContext) (
                 const cl_context_properties* properties,
@@ -133,23 +119,6 @@ struct CLdispatch
                 void* host_ptr,
                 cl_int* errcode_ret );
 
-    // OpenCL 1.1
-    cl_mem  (CLI_API_CALL *clCreateSubBuffer) (
-                cl_mem buffer,
-                cl_mem_flags flags,
-                cl_buffer_create_type buffer_create_type,
-                const void *buffer_create_info,
-                cl_int *errcode_ret );
-
-    // OpenCL 1.2
-    cl_mem  (CLI_API_CALL *clCreateImage) (
-                cl_context context,
-                cl_mem_flags flags,
-                const cl_image_format* image_format,
-                const cl_image_desc* image_desc,
-                void* host_ptr,
-                cl_int* errcode_ret );
-
     // deprecated OpenCL 1.1
     cl_mem  (CLI_API_CALL *clCreateImage2D) (
                 cl_context context,
@@ -202,12 +171,6 @@ struct CLdispatch
                 void* param_value,
                 size_t* param_value_size_ret );
 
-    // OpenCL 1.1
-    cl_int  (CLI_API_CALL *clSetMemObjectDestructorCallback) (
-                cl_mem memobj,
-                void (CL_CALLBACK *pfn_notify)( cl_mem, void* ),
-                void *user_data );
-
     cl_sampler  (CLI_API_CALL *clCreateSampler) (
                 cl_context context,
                 cl_bool normalized_coords,
@@ -244,14 +207,6 @@ struct CLdispatch
                 cl_int* binary_status,
                 cl_int* errcode_ret );
 
-    // OpenCL 1.2
-    cl_program  (CLI_API_CALL *clCreateProgramWithBuiltInKernels) (
-                cl_context context,
-                cl_uint num_devices,
-                const cl_device_id* device_list,
-                const char* kernel_names,
-                cl_int* errcode_ret);
-
     cl_int  (CLI_API_CALL *clRetainProgram) (
                 cl_program program );
 
@@ -265,34 +220,6 @@ struct CLdispatch
                 const char* options,
                 void (CL_CALLBACK *pfn_notify)(cl_program program, void* user_data),
                 void* user_data );
-
-    // OpenCL 1.2
-    cl_int  (CLI_API_CALL *clCompileProgram) (
-                cl_program program,
-                cl_uint num_devices,
-                const cl_device_id* device_list,
-                const char* options,
-                cl_uint num_input_headers,
-                const cl_program* input_headers,
-                const char** header_include_names,
-                void (CL_CALLBACK *pfn_notify)(cl_program program , void* user_data),
-                void* user_data );
-
-    // OpenCL 1.2
-    cl_program  (CLI_API_CALL *clLinkProgram) (
-                cl_context context,
-                cl_uint num_devices,
-                const cl_device_id* device_list,
-                const char* options,
-                cl_uint num_input_programs,
-                const cl_program* input_programs,
-                void (CL_CALLBACK *pfn_notify)(cl_program program, void* user_data),
-                void* user_data,
-                cl_int* errcode_ret );
-
-    // OpenCL 1.2
-    cl_int  (CLI_API_CALL *clUnloadPlatformCompiler) (
-                cl_platform_id platform );
 
     // deprecated OpenCL 1.1
     cl_int  (CLI_API_CALL *clUnloadCompiler) ( void );
@@ -342,15 +269,6 @@ struct CLdispatch
                 void* param_value,
                 size_t* param_value_size_ret );
 
-    // OpenCL 1.2
-    cl_int  (CLI_API_CALL *clGetKernelArgInfo) (
-                cl_kernel kernel,
-                cl_uint arg_indx,
-                cl_kernel_arg_info param_name,
-                size_t param_value_size,
-                void* param_value,
-                size_t* param_value_size_ret );
-
     cl_int  (CLI_API_CALL *clGetKernelWorkGroupInfo) (
                 cl_kernel kernel,
                 cl_device_id device,
@@ -370,28 +288,11 @@ struct CLdispatch
                 void* param_value,
                 size_t* param_value_size_ret );
 
-    // OpenCL 1.1
-    cl_event (CLI_API_CALL *clCreateUserEvent) (
-                cl_context context,
-                cl_int *errcode_ret );
-
     cl_int  (CLI_API_CALL *clRetainEvent) (
                 cl_event event );
 
     cl_int  (CLI_API_CALL *clReleaseEvent) (
                 cl_event event );
-
-    // OpenCL 1.1
-    cl_int  (CLI_API_CALL *clSetUserEventStatus) (
-                cl_event event,
-                cl_int execution_status );
-
-    // OpenCL 1.1
-    cl_int  (CLI_API_CALL *clSetEventCallback) (
-                cl_event event,
-                cl_int command_exec_callback_type,
-                void (CL_CALLBACK *pfn_notify)( cl_event, cl_int, void * ),
-                void *user_data );
 
     cl_int  (CLI_API_CALL *clGetEventProfilingInfo) (
                 cl_event event,
@@ -417,23 +318,6 @@ struct CLdispatch
                 const cl_event* event_wait_list,
                 cl_event* event );
 
-    // OpenCL 1.1
-    cl_int  (CLI_API_CALL *clEnqueueReadBufferRect) (
-                cl_command_queue command_queue,
-                cl_mem buffer,
-                cl_bool blocking_read,
-                const size_t *buffer_origin,
-                const size_t *host_origin,
-                const size_t *region,
-                size_t buffer_row_pitch,
-                size_t buffer_slice_pitch,
-                size_t host_row_pitch,
-                size_t host_slice_pitch,
-                void *ptr,
-                cl_uint num_events_in_wait_list,
-                const cl_event *event_wait_list,
-                cl_event *event );
-
     cl_int  (CLI_API_CALL *clEnqueueWriteBuffer) (
                 cl_command_queue command_queue,
                 cl_mem buffer,
@@ -441,35 +325,6 @@ struct CLdispatch
                 size_t offset,
                 size_t cb,
                 const void* ptr,
-                cl_uint num_events_in_wait_list,
-                const cl_event* event_wait_list,
-                cl_event* event );
-
-    // OpenCL 1.1
-    cl_int  (CLI_API_CALL *clEnqueueWriteBufferRect) (
-                cl_command_queue command_queue,
-                cl_mem buffer,
-                cl_bool blocking_write,
-                const size_t *buffer_origin,
-                const size_t *host_origin,
-                const size_t *region,
-                size_t buffer_row_pitch,
-                size_t buffer_slice_pitch,
-                size_t host_row_pitch,
-                size_t host_slice_pitch,
-                const void *ptr,
-                cl_uint num_events_in_wait_list,
-                const cl_event *event_wait_list,
-                cl_event *event );
-
-    // OpenCL 1.2
-    cl_int  (CLI_API_CALL *clEnqueueFillBuffer) (
-                cl_command_queue command_queue,
-                cl_mem buffer,
-                const void* pattern,
-                size_t pattern_size,
-                size_t offset,
-                size_t size,
                 cl_uint num_events_in_wait_list,
                 const cl_event* event_wait_list,
                 cl_event* event );
@@ -484,22 +339,6 @@ struct CLdispatch
                 cl_uint num_events_in_wait_list,
                 const cl_event* event_wait_list,
                 cl_event* event );
-
-    // OpenCL 1.1
-    cl_int  (CLI_API_CALL *clEnqueueCopyBufferRect) (
-                cl_command_queue command_queue,
-                cl_mem src_buffer,
-                cl_mem dst_buffer,
-                const size_t *src_origin,
-                const size_t *dst_origin,
-                const size_t *region,
-                size_t src_row_pitch,
-                size_t src_slice_pitch,
-                size_t dst_row_pitch,
-                size_t dst_slice_pitch,
-                cl_uint num_events_in_wait_list,
-                const cl_event *event_wait_list,
-                cl_event *event );
 
     cl_int  (CLI_API_CALL *clEnqueueReadImage) (
                 cl_command_queue command_queue,
@@ -523,17 +362,6 @@ struct CLdispatch
                 size_t input_row_pitch,
                 size_t input_slice_pitch,
                 const void* ptr,
-                cl_uint num_events_in_wait_list,
-                const cl_event* event_wait_list,
-                cl_event* event );
-
-    // OpenCL 1.2
-    cl_int  (CLI_API_CALL *clEnqueueFillImage) (
-                cl_command_queue command_queue,
-                cl_mem image,
-                const void* fill_color,
-                const size_t* origin,
-                const size_t* region,
                 cl_uint num_events_in_wait_list,
                 const cl_event* event_wait_list,
                 cl_event* event );
@@ -605,16 +433,6 @@ struct CLdispatch
                 const cl_event* event_wait_list,
                 cl_event* event );
 
-    // OpenCL 1.2
-    cl_int  (CLI_API_CALL *clEnqueueMigrateMemObjects) (
-                cl_command_queue command_queue,
-                cl_uint num_mem_objects,
-                const cl_mem* mem_objects,
-                cl_mem_migration_flags flags,
-                cl_uint num_events_in_wait_list,
-                const cl_event* event_wait_list,
-                cl_event* event );
-
     cl_int  (CLI_API_CALL *clEnqueueNDRangeKernel) (
                 cl_command_queue command_queue,
                 cl_kernel kernel,
@@ -660,101 +478,216 @@ struct CLdispatch
     cl_int  (CLI_API_CALL *clEnqueueBarrier) (
                 cl_command_queue command_queue );
 
+    // deprecated OpenCL 1.2
+    void*   (CLI_API_CALL *clGetExtensionFunctionAddress) (
+                const char* func_name );
+
+    // OpenCL 1.1
+
+    cl_int  (CLI_API_CALL *clSetEventCallback) (
+                cl_event event,
+                cl_int command_exec_callback_type,
+                void (CL_CALLBACK *pfn_notify)( cl_event, cl_int, void * ),
+                void *user_data );
+
+    cl_mem  (CLI_API_CALL *clCreateSubBuffer) (
+                cl_mem buffer,
+                cl_mem_flags flags,
+                cl_buffer_create_type buffer_create_type,
+                const void *buffer_create_info,
+                cl_int *errcode_ret );
+
+    cl_int  (CLI_API_CALL *clSetMemObjectDestructorCallback) (
+                cl_mem memobj,
+                void (CL_CALLBACK *pfn_notify)( cl_mem, void* ),
+                void *user_data );
+
+    cl_event (CLI_API_CALL *clCreateUserEvent) (
+                cl_context context,
+                cl_int *errcode_ret );
+
+    cl_int  (CLI_API_CALL *clSetUserEventStatus) (
+                cl_event event,
+                cl_int execution_status );
+
+    cl_int  (CLI_API_CALL *clEnqueueReadBufferRect) (
+                cl_command_queue command_queue,
+                cl_mem buffer,
+                cl_bool blocking_read,
+                const size_t *buffer_origin,
+                const size_t *host_origin,
+                const size_t *region,
+                size_t buffer_row_pitch,
+                size_t buffer_slice_pitch,
+                size_t host_row_pitch,
+                size_t host_slice_pitch,
+                void *ptr,
+                cl_uint num_events_in_wait_list,
+                const cl_event *event_wait_list,
+                cl_event *event );
+
+    cl_int  (CLI_API_CALL *clEnqueueWriteBufferRect) (
+                cl_command_queue command_queue,
+                cl_mem buffer,
+                cl_bool blocking_write,
+                const size_t *buffer_origin,
+                const size_t *host_origin,
+                const size_t *region,
+                size_t buffer_row_pitch,
+                size_t buffer_slice_pitch,
+                size_t host_row_pitch,
+                size_t host_slice_pitch,
+                const void *ptr,
+                cl_uint num_events_in_wait_list,
+                const cl_event *event_wait_list,
+                cl_event *event );
+
+    cl_int  (CLI_API_CALL *clEnqueueCopyBufferRect) (
+                cl_command_queue command_queue,
+                cl_mem src_buffer,
+                cl_mem dst_buffer,
+                const size_t *src_origin,
+                const size_t *dst_origin,
+                const size_t *region,
+                size_t src_row_pitch,
+                size_t src_slice_pitch,
+                size_t dst_row_pitch,
+                size_t dst_slice_pitch,
+                cl_uint num_events_in_wait_list,
+                const cl_event *event_wait_list,
+                cl_event *event );
+
     // OpenCL 1.2
+
+    cl_int  (CLI_API_CALL *clCreateSubDevices) (
+                cl_device_id in_device,
+                const cl_device_partition_property* properties,
+                cl_uint num_devices,
+                cl_device_id* out_devices,
+                cl_uint* num_devices_ret );
+
+    cl_int  (CLI_API_CALL *clRetainDevice) (
+                cl_device_id device );
+
+    cl_int  (CLI_API_CALL *clReleaseDevice) (
+                cl_device_id device );
+
+    cl_mem  (CLI_API_CALL *clCreateImage) (
+                cl_context context,
+                cl_mem_flags flags,
+                const cl_image_format* image_format,
+                const cl_image_desc* image_desc,
+                void* host_ptr,
+                cl_int* errcode_ret );
+
+    cl_program  (CLI_API_CALL *clCreateProgramWithBuiltInKernels) (
+                cl_context context,
+                cl_uint num_devices,
+                const cl_device_id* device_list,
+                const char* kernel_names,
+                cl_int* errcode_ret);
+
+    cl_int  (CLI_API_CALL *clCompileProgram) (
+                cl_program program,
+                cl_uint num_devices,
+                const cl_device_id* device_list,
+                const char* options,
+                cl_uint num_input_headers,
+                const cl_program* input_headers,
+                const char** header_include_names,
+                void (CL_CALLBACK *pfn_notify)(cl_program program , void* user_data),
+                void* user_data );
+
+    cl_program  (CLI_API_CALL *clLinkProgram) (
+                cl_context context,
+                cl_uint num_devices,
+                const cl_device_id* device_list,
+                const char* options,
+                cl_uint num_input_programs,
+                const cl_program* input_programs,
+                void (CL_CALLBACK *pfn_notify)(cl_program program, void* user_data),
+                void* user_data,
+                cl_int* errcode_ret );
+
+    cl_int  (CLI_API_CALL *clUnloadPlatformCompiler) (
+                cl_platform_id platform );
+
+    cl_int  (CLI_API_CALL *clGetKernelArgInfo) (
+                cl_kernel kernel,
+                cl_uint arg_indx,
+                cl_kernel_arg_info param_name,
+                size_t param_value_size,
+                void* param_value,
+                size_t* param_value_size_ret );
+
+    cl_int  (CLI_API_CALL *clEnqueueFillBuffer) (
+                cl_command_queue command_queue,
+                cl_mem buffer,
+                const void* pattern,
+                size_t pattern_size,
+                size_t offset,
+                size_t size,
+                cl_uint num_events_in_wait_list,
+                const cl_event* event_wait_list,
+                cl_event* event );
+
+    cl_int  (CLI_API_CALL *clEnqueueFillImage) (
+                cl_command_queue command_queue,
+                cl_mem image,
+                const void* fill_color,
+                const size_t* origin,
+                const size_t* region,
+                cl_uint num_events_in_wait_list,
+                const cl_event* event_wait_list,
+                cl_event* event );
+
+    cl_int  (CLI_API_CALL *clEnqueueMigrateMemObjects) (
+                cl_command_queue command_queue,
+                cl_uint num_mem_objects,
+                const cl_mem* mem_objects,
+                cl_mem_migration_flags flags,
+                cl_uint num_events_in_wait_list,
+                const cl_event* event_wait_list,
+                cl_event* event );
+
     cl_int  (CLI_API_CALL *clEnqueueMarkerWithWaitList) (
                 cl_command_queue command_queue,
                 cl_uint num_events_in_wait_list,
                 const cl_event* event_wait_list,
                 cl_event* event );
 
-    // OpenCL 1.2
     cl_int  (CLI_API_CALL *clEnqueueBarrierWithWaitList) (
                 cl_command_queue command_queue,
                 cl_uint num_events_in_wait_list,
                 const cl_event* event_wait_list,
                 cl_event* event );
 
-    // Optional?
-    // deprecated OpenCL 1.1
-    void*   (CLI_API_CALL *clGetExtensionFunctionAddress) (
-                const char* func_name );
-
-    // Optional?
-    // OpenCL 1.2
     void*   (CLI_API_CALL *clGetExtensionFunctionAddressForPlatform)(
                 cl_platform_id platform,
                 const char* func_name );
 
-    // CL-GL Sharing
+    // OpenCL 2.0
 
-    cl_mem  (CLI_API_CALL *clCreateFromGLBuffer) (
+    cl_command_queue (CLI_API_CALL *clCreateCommandQueueWithProperties) (
                 cl_context context,
-                cl_mem_flags flags,
-                cl_GLuint bufobj,
-                int* errcode_ret);  // Not cl_int*?
-
-    // OpenCL 1.2
-    cl_mem  (CLI_API_CALL *clCreateFromGLTexture) (
-                cl_context context,
-                cl_mem_flags flags,
-                cl_GLenum target,
-                cl_GLint miplevel,
-                cl_GLuint texture,
-                cl_int* errcode_ret );
-
-    // deprecated OpenCL 1.1
-    cl_mem  (CLI_API_CALL *clCreateFromGLTexture2D) (
-                cl_context context,
-                cl_mem_flags flags,
-                cl_GLenum target,
-                cl_GLint miplevel,
-                cl_GLuint texture,
+                cl_device_id device,
+                const cl_queue_properties* properties,
                 cl_int* errcode_ret);
 
-    // deprecated OpenCL 1.1
-    cl_mem  (CLI_API_CALL *clCreateFromGLTexture3D) (
+    cl_mem (CLI_API_CALL *clCreatePipe) (
                 cl_context context,
                 cl_mem_flags flags,
-                cl_GLenum target,
-                cl_GLint miplevel,
-                cl_GLuint texture,
+                cl_uint pipe_packet_size,
+                cl_uint pipe_max_packets,
+                const cl_pipe_properties* properties,
                 cl_int* errcode_ret);
 
-    cl_mem  (CLI_API_CALL *clCreateFromGLRenderbuffer) (
-                cl_context context,
-                cl_mem_flags flags,
-                cl_GLuint renderbuffer,
-                cl_int* errcode_ret);
-
-    cl_int  (CLI_API_CALL *clGetGLObjectInfo) (
-                cl_mem memobj,
-                cl_gl_object_type* gl_object_type,
-                cl_GLuint* gl_object_name);
-
-    cl_int  (CLI_API_CALL *clGetGLTextureInfo) (
-                cl_mem memobj,
-                cl_gl_texture_info param_name,
+    cl_int (CLI_API_CALL *clGetPipeInfo) (
+                cl_mem pipe,
+                cl_pipe_info param_name,
                 size_t param_value_size,
                 void* param_value,
                 size_t* param_value_size_ret);
-
-    cl_int  (CLI_API_CALL *clEnqueueAcquireGLObjects) (
-                cl_command_queue command_queue,
-                cl_uint num_objects,
-                const cl_mem* mem_objects,
-                cl_uint num_events_in_wait_list,
-                const cl_event* event_wait_list,
-                cl_event* event);
-
-    cl_int  (CLI_API_CALL *clEnqueueReleaseGLObjects) (
-                cl_command_queue command_queue,
-                cl_uint num_objects,
-                const cl_mem* mem_objects,
-                cl_uint num_events_in_wait_list,
-                const cl_event* event_wait_list,
-                cl_event* event);
-
-    // OpenCL 2.0
 
     void* (CLI_API_CALL *clSVMAlloc) (
                 cl_context context,
@@ -817,6 +750,11 @@ struct CLdispatch
                 const cl_event* event_wait_list,
                 cl_event* event);
 
+    cl_sampler (CLI_API_CALL *clCreateSamplerWithProperties) (
+                cl_context context,
+                const cl_sampler_properties* sampler_properties,
+                cl_int* errcode_ret);
+
     cl_int (CLI_API_CALL *clSetKernelArgSVMPointer) (
                 cl_kernel kernel,
                 cl_uint arg_index,
@@ -828,67 +766,17 @@ struct CLdispatch
                 size_t param_value_size,
                 const void* param_value);
 
-    cl_mem (CLI_API_CALL *clCreatePipe) (
-                cl_context context,
-                cl_mem_flags flags,
-                cl_uint pipe_packet_size,
-                cl_uint pipe_max_packets,
-                const cl_pipe_properties* properties,
-                cl_int* errcode_ret);
-
-    cl_int (CLI_API_CALL *clGetPipeInfo) (
-                cl_mem pipe,
-                cl_pipe_info param_name,
-                size_t param_value_size,
-                void* param_value,
-                size_t* param_value_size_ret);
-
-    cl_command_queue (CLI_API_CALL *clCreateCommandQueueWithProperties) (
-                cl_context context,
-                cl_device_id device,
-                const cl_queue_properties* properties,
-                cl_int* errcode_ret);
-
-    cl_sampler (CLI_API_CALL *clCreateSamplerWithProperties) (
-                cl_context context,
-                const cl_sampler_properties* sampler_properties,
-                cl_int* errcode_ret);
-
     // OpenCL 2.1
 
-    cl_int (CLI_API_CALL *clSetDefaultDeviceCommandQueue) (
-                cl_context context,
-                cl_device_id device,
-                cl_command_queue command_queue );
-
-    cl_int (CLI_API_CALL *clGetDeviceAndHostTimer) (
-                cl_device_id device,
-                cl_ulong* device_timestamp,
-                cl_ulong* host_timestamp );
-
-    cl_int (CLI_API_CALL *clGetHostTimer) (
-                cl_device_id device,
-                cl_ulong* host_timestamp );
+    cl_kernel (CLI_API_CALL *clCloneKernel) (
+                cl_kernel source_kernel,
+                cl_int* errcode_ret );
 
     cl_program (CLI_API_CALL *clCreateProgramWithIL) (
                 cl_context context,
                 const void *il,
                 size_t length,
                 cl_int *errcode_ret);
-
-    cl_kernel (CLI_API_CALL *clCloneKernel) (
-                cl_kernel source_kernel,
-                cl_int* errcode_ret );
-
-    cl_int (CLI_API_CALL *clGetKernelSubGroupInfo) (
-                cl_kernel kernel,
-                cl_device_id device,
-                cl_kernel_sub_group_info param_name,
-                size_t input_value_size,
-                const void* input_value,
-                size_t param_value_size,
-                void* param_value,
-                size_t* param_value_size_ret );
 
     cl_int (CLI_API_CALL *clEnqueueSVMMigrateMem) (
                 cl_command_queue command_queue,
@@ -900,13 +788,37 @@ struct CLdispatch
                 const cl_event* event_wait_list,
                 cl_event* event );
 
+    cl_int (CLI_API_CALL *clGetDeviceAndHostTimer) (
+                cl_device_id device,
+                cl_ulong* device_timestamp,
+                cl_ulong* host_timestamp );
+
+    cl_int (CLI_API_CALL *clGetHostTimer) (
+                cl_device_id device,
+                cl_ulong* host_timestamp );
+
+    cl_int (CLI_API_CALL *clGetKernelSubGroupInfo) (
+                cl_kernel kernel,
+                cl_device_id device,
+                cl_kernel_sub_group_info param_name,
+                size_t input_value_size,
+                const void* input_value,
+                size_t param_value_size,
+                void* param_value,
+                size_t* param_value_size_ret );
+
+    cl_int (CLI_API_CALL *clSetDefaultDeviceCommandQueue) (
+                cl_context context,
+                cl_device_id device,
+                cl_command_queue command_queue );
+
     // OpenCL 2.2
+
     cl_int  (CLI_API_CALL *clSetProgramReleaseCallback) (
                 cl_program program,
                 void (CL_CALLBACK *pfn_notify)(cl_program program, void* user_data),
                 void* user_data );
 
-    // OpenCL 2.2
     cl_int  (CLI_API_CALL *clSetProgramSpecializationConstant) (
                 cl_program program,
                 cl_uint spec_id,
@@ -914,6 +826,7 @@ struct CLdispatch
                 const void* spec_value );
 
     // OpenCL 3.0
+
     cl_mem (CLI_API_CALL *clCreateBufferWithProperties) (
                 cl_context context,
                 const cl_mem_properties* properties,
@@ -922,7 +835,6 @@ struct CLdispatch
                 void* host_ptr,
                 cl_int* errcode_ret);
 
-    // OpenCL 3.0
     cl_mem (CLI_API_CALL *clCreateImageWithProperties) (
                 cl_context context,
                 const cl_mem_properties* properties,
@@ -931,10 +843,93 @@ struct CLdispatch
                 const cl_image_desc* image_desc,
                 void* host_ptr,
                 cl_int* errcode_ret);
+};
 
-    // These are Khronos Extensions.
-    // They aren't exported from the ICD or from this DLL, but we'll still
-    // put a pointer to them in the CLIntercept dispatch table.
+// Dispatch table for extension APIs:
+
+struct CLdispatchX
+{
+    // cl_khr_gl_event
+    cl_event    (CLI_API_CALL *clCreateEventFromGLsyncKHR) (
+                cl_context context,
+                cl_GLsync sync,
+                cl_int* errcode_ret);
+
+    // cl_khr_gl_sharing
+    cl_mem  (CLI_API_CALL *clCreateFromGLBuffer) (
+                cl_context context,
+                cl_mem_flags flags,
+                cl_GLuint bufobj,
+                int* errcode_ret);  // Not cl_int*?
+
+    // cl_khr_gl_sharing
+    // deprecated OpenCL 1.1
+    cl_mem  (CLI_API_CALL *clCreateFromGLTexture2D) (
+                cl_context context,
+                cl_mem_flags flags,
+                cl_GLenum target,
+                cl_GLint miplevel,
+                cl_GLuint texture,
+                cl_int* errcode_ret);
+
+    // cl_khr_gl_sharing
+    // deprecated OpenCL 1.1
+    cl_mem  (CLI_API_CALL *clCreateFromGLTexture3D) (
+                cl_context context,
+                cl_mem_flags flags,
+                cl_GLenum target,
+                cl_GLint miplevel,
+                cl_GLuint texture,
+                cl_int* errcode_ret);
+
+    // cl_khr_gl_sharing
+    // OpenCL 1.2
+    cl_mem  (CLI_API_CALL *clCreateFromGLTexture) (
+                cl_context context,
+                cl_mem_flags flags,
+                cl_GLenum target,
+                cl_GLint miplevel,
+                cl_GLuint texture,
+                cl_int* errcode_ret );
+
+    // cl_khr_gl_sharing
+    cl_mem  (CLI_API_CALL *clCreateFromGLRenderbuffer) (
+                cl_context context,
+                cl_mem_flags flags,
+                cl_GLuint renderbuffer,
+                cl_int* errcode_ret);
+
+    // cl_khr_gl_sharing
+    cl_int  (CLI_API_CALL *clGetGLObjectInfo) (
+                cl_mem memobj,
+                cl_gl_object_type* gl_object_type,
+                cl_GLuint* gl_object_name);
+
+    // cl_khr_gl_sharing
+    cl_int  (CLI_API_CALL *clGetGLTextureInfo) (
+                cl_mem memobj,
+                cl_gl_texture_info param_name,
+                size_t param_value_size,
+                void* param_value,
+                size_t* param_value_size_ret);
+
+    // cl_khr_gl_sharing
+    cl_int  (CLI_API_CALL *clEnqueueAcquireGLObjects) (
+                cl_command_queue command_queue,
+                cl_uint num_objects,
+                const cl_mem* mem_objects,
+                cl_uint num_events_in_wait_list,
+                const cl_event* event_wait_list,
+                cl_event* event);
+
+    // cl_khr_gl_sharing
+    cl_int  (CLI_API_CALL *clEnqueueReleaseGLObjects) (
+                cl_command_queue command_queue,
+                cl_uint num_objects,
+                const cl_mem* mem_objects,
+                cl_uint num_events_in_wait_list,
+                const cl_event* event_wait_list,
+                cl_event* event);
 
     // cl_khr_gl_sharing
     cl_int  (CLI_API_CALL *clGetGLContextInfoKHR) (
@@ -943,12 +938,6 @@ struct CLdispatch
                 size_t param_value_size,
                 void* param_value,
                 size_t* param_value_size_ret);
-
-    // cl_khr_gl_event
-    cl_event    (CLI_API_CALL *clCreateEventFromGLsyncKHR) (
-                cl_context context,
-                cl_GLsync sync,
-                cl_int* errcode_ret);
 
 #if defined(_WIN32)
     // cl_khr_d3d10_sharing
@@ -1116,10 +1105,6 @@ struct CLdispatch
             cl_device_id device,
             const cl_queue_properties_khr* properties,
             cl_int* errcode_ret);
-
-    // These are Intel Vendor Extensions.
-    // They aren't exported from the ICD or from this DLL, but we'll still
-    // put a pointer to them in the CLIntercept dispatch table.
 
 #if defined(_WIN32)
     // cl_intel_dx9_media_sharing

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -11340,7 +11340,6 @@ bool CLIntercept::initDispatch( void )
     INIT_CL_FUNC(clGetKernelArgInfo);
     INIT_CL_FUNC(clEnqueueFillBuffer);
     INIT_CL_FUNC(clEnqueueFillImage);
-    INIT_CL_FUNC(clCreateFromGLTexture);
     INIT_CL_FUNC(clEnqueueMigrateMemObjects);
     INIT_CL_FUNC(clEnqueueMarkerWithWaitList);
     INIT_CL_FUNC(clEnqueueBarrierWithWaitList);

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -5331,7 +5331,7 @@ void CLIntercept::addAcceleratorInfo(
     {
         std::lock_guard<std::mutex> lock(m_Mutex);
 
-        m_AcceleratorInfoMap[accelerator] = NULL;
+        m_AcceleratorInfoMap[accelerator] = getPlatform(context);
     }
 }
 

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -11316,51 +11316,35 @@ bool CLIntercept::initDispatch( void )
     INIT_CL_FUNC(clEnqueueMarker);
     INIT_CL_FUNC(clEnqueueWaitForEvents);
     INIT_CL_FUNC(clEnqueueBarrier);
-
-    // Optional features?
     INIT_CL_FUNC(clGetExtensionFunctionAddress);
-    INIT_CL_FUNC(clGetExtensionFunctionAddressForPlatform);
 
-    // OpenCL 1.1 Entry Points (optional)
+    // OpenCL 1.1 Entry Points
+    INIT_CL_FUNC(clSetEventCallback);
     INIT_CL_FUNC(clCreateSubBuffer);
     INIT_CL_FUNC(clSetMemObjectDestructorCallback);
     INIT_CL_FUNC(clCreateUserEvent);
     INIT_CL_FUNC(clSetUserEventStatus);
-    INIT_CL_FUNC(clSetEventCallback);
     INIT_CL_FUNC(clEnqueueReadBufferRect);
     INIT_CL_FUNC(clEnqueueWriteBufferRect);
     INIT_CL_FUNC(clEnqueueCopyBufferRect);
 
-    // OpenCL 1.2 Entry Points (optional)
-    INIT_CL_FUNC(clCompileProgram);
-    INIT_CL_FUNC(clCreateFromGLTexture);
+    // OpenCL 1.2 Entry Points
+    INIT_CL_FUNC(clCreateSubDevices);
+    INIT_CL_FUNC(clRetainDevice);
+    INIT_CL_FUNC(clReleaseDevice);
     INIT_CL_FUNC(clCreateImage);
     INIT_CL_FUNC(clCreateProgramWithBuiltInKernels);
-    INIT_CL_FUNC(clCreateSubDevices);
-    INIT_CL_FUNC(clEnqueueBarrierWithWaitList);
+    INIT_CL_FUNC(clCompileProgram);
+    INIT_CL_FUNC(clLinkProgram);
+    INIT_CL_FUNC(clUnloadPlatformCompiler);
+    INIT_CL_FUNC(clGetKernelArgInfo);
     INIT_CL_FUNC(clEnqueueFillBuffer);
     INIT_CL_FUNC(clEnqueueFillImage);
-    INIT_CL_FUNC(clEnqueueMarkerWithWaitList);
+    INIT_CL_FUNC(clCreateFromGLTexture);
     INIT_CL_FUNC(clEnqueueMigrateMemObjects);
-    INIT_CL_FUNC(clGetKernelArgInfo);
-    INIT_CL_FUNC(clLinkProgram);
-    INIT_CL_FUNC(clReleaseDevice);
-    INIT_CL_FUNC(clRetainDevice);
-    INIT_CL_FUNC(clUnloadPlatformCompiler);
-
-    // CL-GL Entry Points (optional)
-    INIT_CL_FUNC(clCreateFromGLBuffer);
-    INIT_CL_FUNC(clCreateFromGLTexture);   // OpenCL 1.2
-    INIT_CL_FUNC(clCreateFromGLTexture2D);
-    INIT_CL_FUNC(clCreateFromGLTexture3D);
-    INIT_CL_FUNC(clCreateFromGLRenderbuffer);
-    INIT_CL_FUNC(clGetGLObjectInfo);
-    INIT_CL_FUNC(clGetGLTextureInfo);
-    INIT_CL_FUNC(clEnqueueAcquireGLObjects);
-    INIT_CL_FUNC(clEnqueueReleaseGLObjects);
-
-    // Extensions (optional)
-    // Extensions get loaded into the dispatch table on the fly.
+    INIT_CL_FUNC(clEnqueueMarkerWithWaitList);
+    INIT_CL_FUNC(clEnqueueBarrierWithWaitList);
+    INIT_CL_FUNC(clGetExtensionFunctionAddressForPlatform);
 
     return true;
 }

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -641,6 +641,7 @@ public:
 
     const OS::Services& OS() const;
     const CLdispatch&   dispatch() const;
+    const CLdispatchX&  dispatchX() const;
     const CEnumNameMap& enumName() const;
 
     const Config&   config() const;
@@ -791,6 +792,7 @@ private:
 
     OS::Services    m_OS;
     CLdispatch      m_Dispatch;
+    CLdispatchX     m_DispatchX;
     CEnumNameMap    m_EnumNameMap;
     CObjectTracker  m_ObjectTracker;
 
@@ -1139,6 +1141,13 @@ private:
 inline const CLdispatch& CLIntercept::dispatch() const
 {
     return m_Dispatch;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+inline const CLdispatchX& CLIntercept::dispatchX() const
+{
+    return m_DispatchX;
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description of Changes

Previously, the intercept layer tracked all API functions, be they for core APIs or extension APIs, in the same dispatch table.  This was fine so long as extension APIs were associated with a single platform.  When extension APIs were used for two different platforms though, the intercept layer could not differentiate between calls into each platform, which meant that some extension API function calls were unusable (and likely generated unexpected OpenCL errors).

This change separates the dispatch table into core APIs and extension APIs, and tracks a table of extension APIs for each platform.  When an extension API is called, the intercept layer determines which table to use and then calls through that table, enabling extension functions to be use from each platform.

## Testing Done

* Ran basic USM samples to test basic operation with a vendor extension.
* Ran CL-GL sharing interop conformance tests to test a KHR extension and `clGetGLContextInfoKHR` in particular.
* Ran a custom targeted test to test behavior for `cl_intel_accelerator`, since special handling is needed for accelerator objects.
* Ran a custom SYCL USM test using devices from two different SYCL / OpenCL platforms, to test proper behavior calling extension APIs from multiple platforms.