### PR TITLE
update to latest OpenCL 3.0 APIs

### DIFF
--- a/intercept/CL/cl.h
+++ b/intercept/CL/cl.h
@@ -40,6 +40,7 @@ typedef struct _cl_sampler *        cl_sampler;
 
 typedef cl_uint             cl_bool;                     /* WARNING!  Unlike cl_ types in cl_platform.h, cl_bool is not guaranteed to be the same size as the bool in kernels. */
 typedef cl_ulong            cl_bitfield;
+typedef cl_ulong            cl_properties;
 typedef cl_bitfield         cl_device_type;
 typedef cl_uint             cl_platform_info;
 typedef cl_uint             cl_device_info;
@@ -59,7 +60,7 @@ typedef cl_bitfield         cl_device_affinity_domain;
 typedef intptr_t            cl_context_properties;
 typedef cl_uint             cl_context_info;
 #ifdef CL_VERSION_2_0
-typedef cl_bitfield         cl_queue_properties;
+typedef cl_properties       cl_queue_properties;
 #endif
 typedef cl_uint             cl_command_queue_info;
 typedef cl_uint             cl_channel_order;
@@ -106,13 +107,14 @@ typedef cl_uint             cl_event_info;
 typedef cl_uint             cl_command_type;
 typedef cl_uint             cl_profiling_info;
 #ifdef CL_VERSION_2_0
-typedef cl_bitfield         cl_sampler_properties;
+typedef cl_properties       cl_sampler_properties;
 typedef cl_uint             cl_kernel_exec_info;
 #endif
 #ifdef CL_VERSION_3_0
 typedef cl_bitfield         cl_device_atomic_capabilities;
+typedef cl_bitfield         cl_device_device_enqueue_capabilities;
 typedef cl_uint             cl_khronos_vendor_id;
-typedef cl_bitfield         cl_mem_properties;
+typedef cl_properties       cl_mem_properties;
 typedef cl_uint             cl_version;
 #endif
 
@@ -410,8 +412,9 @@ typedef struct _cl_name_version {
 #define CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT          0x1069
 /* 0x106A to 0x106E - Reserved for upcoming KHR extension */
 #define CL_DEVICE_OPENCL_C_FEATURES                      0x106F
-#define CL_DEVICE_DEVICE_ENQUEUE_SUPPORT                 0x1070
+#define CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES            0x1070
 #define CL_DEVICE_PIPE_SUPPORT                           0x1071
+#define CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED      0x1072
 #endif
 
 /* cl_device_fp_config - bitfield */
@@ -895,6 +898,12 @@ typedef struct _cl_name_version {
 #define CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES      (1 << 6)
 #endif
 
+/* cl_device_device_enqueue_capabilities - bitfield */
+#ifdef CL_VERSION_3_0
+#define CL_DEVICE_QUEUE_SUPPORTED               (1 << 0)
+#define CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT     (1 << 1)
+#endif
+
 /* cl_khronos_vendor_id */
 #define CL_KHRONOS_VENDOR_ID_CODEPLAY               0x10004
 
@@ -1024,6 +1033,16 @@ clGetContextInfo(cl_context         context,
                  size_t             param_value_size,
                  void *             param_value,
                  size_t *           param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+
+#ifdef CL_VERSION_3_0
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clSetContextDestructorCallback(cl_context         context,
+                               void (CL_CALLBACK* pfn_notify)(cl_context context,
+                                                              void* user_data),
+                               void*              user_data) CL_API_SUFFIX__VERSION_3_0;
+
+#endif
 
 /* Command Queue APIs */
 
@@ -1286,11 +1305,11 @@ clLinkProgram(cl_context           context,
 
 #ifdef CL_VERSION_2_2
 
-extern CL_API_ENTRY cl_int CL_API_CALL
+extern CL_API_ENTRY CL_EXT_PREFIX__VERSION_2_2_DEPRECATED cl_int CL_API_CALL
 clSetProgramReleaseCallback(cl_program          program,
                             void (CL_CALLBACK * pfn_notify)(cl_program program,
                                                             void * user_data),
-                            void *              user_data) CL_API_SUFFIX__VERSION_2_2;
+                            void *              user_data) CL_EXT_SUFFIX__VERSION_2_2_DEPRECATED;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clSetProgramSpecializationConstant(cl_program  program,

--- a/intercept/CL/cl_platform.h
+++ b/intercept/CL/cl_platform.h
@@ -357,7 +357,9 @@ typedef unsigned int cl_GLenum;
 
 /* Define basic vector types */
 #if defined( __VEC__ )
-   #include <altivec.h>   /* may be omitted depending on compiler. AltiVec spec provides no way to detect whether the header is required. */
+  #if !defined(__clang__)
+     #include <altivec.h>   /* may be omitted depending on compiler. AltiVec spec provides no way to detect whether the header is required. */
+  #endif
    typedef __vector unsigned char     __cl_uchar16;
    typedef __vector signed char       __cl_char16;
    typedef __vector unsigned short    __cl_ushort8;

--- a/intercept/src/clIntercept.def
+++ b/intercept/src/clIntercept.def
@@ -24,6 +24,7 @@ EXPORTS
     clCloneKernel
     clCompileProgram
     clCreateBuffer
+    clCreateBufferWithProperties
     clCreateCommandQueue
     clCreateCommandQueueWithProperties
     clCreateContext
@@ -34,6 +35,7 @@ EXPORTS
     clCreateFromGLTexture2D
     clCreateFromGLTexture3D
     clCreateImage
+    clCreateImageWithProperties
     clCreateImage2D
     clCreateImage3D
     clCreateKernel
@@ -126,6 +128,7 @@ EXPORTS
     clRetainProgram
     clRetainSampler
     clSetCommandQueueProperty
+    clSetContextDestructorCallback
     clSetDefaultDeviceCommandQueue
     clSetEventCallback
     clSetKernelArg

--- a/intercept/src/clIntercept.map
+++ b/intercept/src/clIntercept.map
@@ -173,3 +173,10 @@ OPENCL_2.2 {
         clSetProgramReleaseCallback;
         clSetProgramSpecializationConstant;
 } OPENCL_2.1;
+
+OPENCL_3.0 {
+    global:
+        clCreateBufferWithProperties;
+        clCreateImageWithProperties;
+        clSetContextDestructorCallback;
+} OPENCL_2.2;

--- a/intercept/src/cliprof_init.cpp
+++ b/intercept/src/cliprof_init.cpp
@@ -110,6 +110,7 @@ DWORD cliprof_init( void* dummy )
                     REPLACE_FUNCTION( name, clCloneKernel );
                     REPLACE_FUNCTION( name, clCompileProgram );
                     REPLACE_FUNCTION( name, clCreateBuffer );
+                    REPLACE_FUNCTION( name, clCreateBufferWithProperties );
                     REPLACE_FUNCTION( name, clCreateCommandQueue );
                     REPLACE_FUNCTION( name, clCreateCommandQueueWithProperties );
                     REPLACE_FUNCTION( name, clCreateContext );
@@ -120,6 +121,7 @@ DWORD cliprof_init( void* dummy )
                     REPLACE_FUNCTION( name, clCreateFromGLTexture2D );
                     REPLACE_FUNCTION( name, clCreateFromGLTexture3D );
                     REPLACE_FUNCTION( name, clCreateImage );
+                    REPLACE_FUNCTION( name, clCreateImageWithProperties );
                     REPLACE_FUNCTION( name, clCreateImage2D );
                     REPLACE_FUNCTION( name, clCreateImage3D );
                     REPLACE_FUNCTION( name, clCreateKernel );
@@ -212,6 +214,7 @@ DWORD cliprof_init( void* dummy )
                     REPLACE_FUNCTION( name, clRetainProgram );
                     REPLACE_FUNCTION( name, clRetainSampler );
                     REPLACE_FUNCTION( name, clSetCommandQueueProperty );
+                    REPLACE_FUNCTION( name, clSetContextDestructorCallback );
                     REPLACE_FUNCTION( name, clSetDefaultDeviceCommandQueue );
                     REPLACE_FUNCTION( name, clSetEventCallback );
                     REPLACE_FUNCTION( name, clSetKernelArg );

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -655,6 +655,36 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetContextInfo)(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+// OpenCL 3.0
+CL_API_ENTRY cl_int CL_API_CALL clSetContextDestructorCallback(
+    cl_context context,
+    void (CL_CALLBACK *pfn_notify)( cl_context, void* ),
+    void *user_data )
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept && pIntercept->dispatch().clSetContextDestructorCallback )
+    {
+        CALL_LOGGING_ENTER();
+        CPU_PERFORMANCE_TIMING_START();
+
+        cl_int  retVal = pIntercept->dispatch().clSetContextDestructorCallback(
+            context,
+            pfn_notify,
+            user_data );
+
+        CPU_PERFORMANCE_TIMING_END();
+        CHECK_ERROR( retVal );
+        CALL_LOGGING_EXIT( retVal );
+
+        return retVal;
+    }
+
+    NULL_FUNCTION_POINTER_RETURN_ERROR();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
 CL_API_ENTRY cl_command_queue CL_API_CALL CLIRN(clCreateCommandQueue)(
     cl_context context,
     cl_device_id device,
@@ -5180,7 +5210,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLBuffer)(
     cl_context context,
     cl_mem_flags flags,
     cl_GLuint bufobj,
-    int* errcode_ret)   // Not cl_int*?
+    cl_int* errcode_ret)
 {
     CLIntercept*    pIntercept = GetIntercept();
 

--- a/intercept/src/dispatch.h
+++ b/intercept/src/dispatch.h
@@ -857,6 +857,11 @@ struct CLdispatch
                 const cl_image_desc* image_desc,
                 void* host_ptr,
                 cl_int* errcode_ret);
+
+    cl_int (CL_API_CALL *clSetContextDestructorCallback) (
+                cl_context context,
+                void (CL_CALLBACK* pfn_notify)(cl_context context, void* user_data),
+                void* user_data);
 };
 
 // Dispatch table for extension APIs:
@@ -874,7 +879,7 @@ struct CLdispatchX
                 cl_context context,
                 cl_mem_flags flags,
                 cl_GLuint bufobj,
-                int* errcode_ret);  // Not cl_int*?
+                cl_int* errcode_ret);
 
     // cl_khr_gl_sharing
     // deprecated OpenCL 1.1

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -241,8 +241,9 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT );
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT );
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_OPENCL_C_FEATURES );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_DEVICE_ENQUEUE_SUPPORT );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES );
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PIPE_SUPPORT );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED );
 
     /* cl_device_fp_config - bitfield */
     ADD_ENUM_NAME( m_cl_device_fp_config, CL_FP_DENORM );
@@ -587,6 +588,7 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_svm_mem_flags, CL_MEM_SVM_FINE_GRAIN_BUFFER );
     ADD_ENUM_NAME( m_cl_svm_mem_flags, CL_MEM_SVM_ATOMICS );
 
+    /* cl_device_atomic_capabilities */
     ADD_ENUM_NAME( m_cl_device_atomic_capabilities, CL_DEVICE_ATOMIC_ORDER_RELAXED );
     ADD_ENUM_NAME( m_cl_device_atomic_capabilities, CL_DEVICE_ATOMIC_ORDER_ACQ_REL );
     ADD_ENUM_NAME( m_cl_device_atomic_capabilities, CL_DEVICE_ATOMIC_ORDER_SEQ_CST );
@@ -594,6 +596,10 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_device_atomic_capabilities, CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP );
     ADD_ENUM_NAME( m_cl_device_atomic_capabilities, CL_DEVICE_ATOMIC_SCOPE_DEVICE );
     ADD_ENUM_NAME( m_cl_device_atomic_capabilities, CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES );
+
+    /* cl_device_device_enqueue_capabilities */
+    ADD_ENUM_NAME( m_cl_device_device_enqueue_capabilities, CL_DEVICE_QUEUE_SUPPORTED );
+    ADD_ENUM_NAME( m_cl_device_device_enqueue_capabilities, CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT );
 
     // Intel Extensions
 

--- a/intercept/src/enummap.h
+++ b/intercept/src/enummap.h
@@ -108,6 +108,7 @@ public:
     GENERATE_MAP_AND_BITFIELD_FUNC( name_command_queue_properties,   cl_command_queue_properties     );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_device_affinity_domain,     cl_device_affinity_domain       );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_device_atomic_capabilities, cl_device_atomic_capabilities   );
+    GENERATE_MAP_AND_BITFIELD_FUNC( name_device_device_enqueue_capabilities, cl_device_device_enqueue_capabilities );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_device_exec_capabilities,   cl_device_exec_capabilities     );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_device_fp_config,           cl_device_fp_config             );
     GENERATE_MAP_AND_FUNC(          name_device_local_mem_type,      cl_device_local_mem_type        );

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -11227,6 +11227,7 @@ bool CLIntercept::initDispatch( const std::string& libName )
         // OpenCL 3.0 Entry Points (optional)
         INIT_EXPORTED_FUNC(clCreateBufferWithProperties);
         INIT_EXPORTED_FUNC(clCreateImageWithProperties);
+        INIT_EXPORTED_FUNC(clSetContextDestructorCallback);
 
         success = savedSuccess;
     }


### PR DESCRIPTION
## Description of Changes

Updates for recent changes to OpenCL 3.0:

- switched to device enqueue capabilities
- added CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED
- added clSetContextDestructorCallback

## Testing Done

Ran basic OpenCL 3.0 applications.