### PR TITLE
add the devcloud path to libOpenCL.so as a default

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -106,6 +106,7 @@ For Linux:
 - `./real_libOpenCL.so`
 - `/usr/lib/x86_64-linux-gnu/libOpenCL.so`
 - `/opt/intel/opencl/lib64/libOpenCL.so`
+- `/glob/development-tools/oneapi/inteloneapi/compiler/latest/linux/lib/libOpenCL.so`
 
 For Android:
 

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -520,6 +520,7 @@ bool CLIntercept::init()
             "./real_libOpenCL.so",
             "/usr/lib/x86_64-linux-gnu/libOpenCL.so",
             "/opt/intel/opencl/lib64/libOpenCL.so",
+            "/glob/development-tools/oneapi/inteloneapi/compiler/latest/linux/lib/libOpenCL.so",
         };
 
 #else

--- a/scripts/generate_controls_doc.py
+++ b/scripts/generate_controls_doc.py
@@ -132,6 +132,7 @@ For Linux:
 - `./real_libOpenCL.so`
 - `/usr/lib/x86_64-linux-gnu/libOpenCL.so`
 - `/opt/intel/opencl/lib64/libOpenCL.so`
+- `/glob/development-tools/oneapi/inteloneapi/compiler/latest/linux/lib/libOpenCL.so`
 
 For Android:
 


### PR DESCRIPTION
## Description of Changes

Adds the DevCloud path to `libOpenCL.so` to the default search for the "real" `libOpenCL.so`.  The added path is:

`/glob/development-tools/oneapi/inteloneapi/compiler/latest/linux/lib/libOpenCL.so`

This means that DevCloud users do not need to manually setup the path to `libOpenCL.so` to debug or profile SYCL or OpenCL applications.

## Testing Done

Successfully ran an OpenCL application on DevCloud via `cliloader` without setting any environment variables or setting any config file options.
