### PR TITLE
remove newlines from injected build options

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -3621,6 +3621,18 @@ bool CLIntercept::injectProgramOptions(
 
                 is.read( newOptions, filesize );
 
+                // Replace any newline characters with spaces.
+                // Some editors insert newline characters, especially at the
+                // end of the file, which can cause build options to become
+                // invalid.
+                for( size_t i = 0; i < filesize; i++ )
+                {
+                    if( newOptions[i] == '\n' )
+                    {
+                        newOptions[i] = ' ';
+                    }
+                }
+
                 options = newOptions;
 
                 injected = true;


### PR DESCRIPTION
## Description of Changes

Program build options generally cannot contain newlines, but some editors can insert newlines into injected build options, particularly at the end of the file.  Since this can result in unexpected "invalid build options" errors, replace any newlines in injected build options with spaces.  This can also make injected build options more readable, by allowing newlines to separate long blocks of build options.

## Testing Done

Injected build options with a newline at the end of the file before these changes (failed with invalid build options) and after (succeeded).