### PR TITLE
fix a bug logging the CL_QUEUE_SIZE queue property

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -879,7 +879,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetCommandQueueInfo)(
 
     if( pIntercept && pIntercept->dispatch().clGetCommandQueueInfo )
     {
-        CALL_LOGGING_ENTER( "param_name = %s (%08X)",
+        CALL_LOGGING_ENTER( "command_queue = %p, param_name = %s (%08X)",
+            command_queue,
             pIntercept->enumName().name( param_name ).c_str(),
             param_name );
         CPU_PERFORMANCE_TIMING_START();

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -1979,7 +1979,8 @@ void CLIntercept::getCommandQueuePropertiesString(
             case CL_QUEUE_SIZE:
                 {
                     const cl_uint*  pu = (const cl_uint*)( properties + 1);
-                    str += pu[0];
+                    CLI_SPRINTF( s, 256, "%u", pu[0] );
+                    str += s;
                 }
                 break;
             case CL_QUEUE_PRIORITY_KHR:


### PR DESCRIPTION
## Description of Changes

Fixes a minor bug preventing the CL_QUEUE_SIZE property from being properly logged.

Also, logs which command queue is being queried for `clGetcommandQueueInfo`.

## Testing Done

Ran the new "queue array properties" CTS test and observed that the queue size is properly logged after this change.
