### PR TITLE
add enum tracing for cl_intel_mem_force_host_memory

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -907,6 +907,9 @@ clEnqueueMemAdviseINTEL(
             const cl_event* event_wait_list,
             cl_event* event);
 
+// cl_intel_mem_force_host_memory
+#define CL_MEM_FORCE_HOST_MEMORY_INTEL              (1 << 20)
+
 // Altera Extensions:
 
 // cl_altera_device_temperature
@@ -1009,6 +1012,22 @@ clEnqueueMemAdviseINTEL(
 // cl_qcom_ion_host_ptr
 #define CL_MEM_ION_HOST_PTR_QCOM                    0x40A8
 
-// cl_arm_printf extension
+// cl_arm_printf
 #define CL_PRINTF_CALLBACK_ARM                      0x40B0
 #define CL_PRINTF_BUFFERSIZE_ARM                    0x40B1
+
+// cl_arm_get_core_id
+#define CL_DEVICE_COMPUTE_UNITS_BITFIELD_ARM        0x40BF
+
+// cl_arm_job_slot_selection
+#define CL_DEVICE_JOB_SLOTS_ARM                     0x41E0
+#define CL_QUEUE_JOB_SLOT_ARM                       0x41E1
+
+// cl_arm_scheduling_controls
+#define CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_ARM          0x41E4
+#define CL_DEVICE_SCHEDULING_KERNEL_BATCHING_ARM                (1 << 0)
+#define CL_DEVICE_SCHEDULING_WORKGROUP_BATCH_SIZE_ARM           (1 << 1)
+#define CL_DEVICE_SCHEDULING_WORKGROUP_BATCH_SIZE_MODIFIER_ARM  (1 << 2)
+#define CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_ARM            0x41E5
+#define CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_MODIFIER_ARM   0x41E6
+#define CL_QUEUE_KERNEL_BATCHING_ARM                            0x41E7

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -848,6 +848,9 @@ CEnumNameMap::CEnumNameMap()
 
     ADD_ENUM_NAME( m_cl_mem_alloc_flags_intel, CL_MEM_ALLOC_WRITE_COMBINED_INTEL );
 
+    // cl_intel_mem_force_host_memory
+    ADD_ENUM_NAME( m_cl_mem_flags, CL_MEM_FORCE_HOST_MEMORY_INTEL );
+
     // Altera Extensions:
 
     // cl_altera_device_temperature
@@ -949,7 +952,6 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PCI_BUS_ID_NV );
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PCI_SLOT_ID_NV );
 
-
     // cl_ext_atomic_counters
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_MAX_ATOMIC_COUNTERS_EXT );
 
@@ -1011,6 +1013,19 @@ CEnumNameMap::CEnumNameMap()
     // cl_arm_printf extension
     ADD_ENUM_NAME( m_cl_int, CL_PRINTF_CALLBACK_ARM );
     ADD_ENUM_NAME( m_cl_int, CL_PRINTF_BUFFERSIZE_ARM );
+
+    // cl_arm_get_core_id
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_COMPUTE_UNITS_BITFIELD_ARM );
+
+    // cl_arm_job_slot_selection
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_JOB_SLOTS_ARM );
+    ADD_ENUM_NAME( m_cl_int, CL_QUEUE_JOB_SLOT_ARM );
+
+    // cl_arm_scheduling_controls
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_ARM );
+    ADD_ENUM_NAME( m_cl_int, CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_ARM );
+    ADD_ENUM_NAME( m_cl_int, CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_MODIFIER_ARM );
+    ADD_ENUM_NAME( m_cl_int, CL_QUEUE_KERNEL_BATCHING_ARM );
 
 #if defined(_WIN32)
     // cl_khr_d3d10_sharing


### PR DESCRIPTION
## Description of Changes

Adds enum tracing for the `cl_intel_mem_force_host_memory` extension.  Also adds a few other missing enums that were recently added to the OpenCL headers.

## Testing Done

Verified correct tracing with an app that uses this new `cl_mem_flag`.
