### PR TITLE
add tracing for cl_nv_create_buffer

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -953,6 +953,21 @@ clEnqueueMemAdviseINTEL(
 #define CL_DEVICE_PCI_BUS_ID_NV                     0x4008
 #define CL_DEVICE_PCI_SLOT_ID_NV                    0x4009
 
+// cl_nv_create_buffer
+typedef cl_bitfield         cl_mem_flags_NV;
+
+extern CL_API_ENTRY cl_mem CL_API_CALL
+clCreateBufferNV(
+            cl_context context,
+            cl_mem_flags flags,
+            cl_mem_flags_NV flags_NV,
+            size_t size,
+            void* host_ptr,
+            cl_int* errcode_ret);
+
+#define CL_MEM_LOCATION_HOST_NV                     (1 << 0)
+#define CL_MEM_PINNED_NV                            (1 << 1)
+
 // cl_ext_atomic_counters
 #define CL_DEVICE_MAX_ATOMIC_COUNTERS_EXT           0x4032
 

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -1034,6 +1034,58 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateBufferWithProperties)(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+// cl_nv_create_buffer
+CL_API_ENTRY cl_mem CL_API_CALL clCreateBufferNV(
+    cl_context context,
+    cl_mem_flags flags,
+    cl_mem_flags_NV flags_NV,
+    size_t size,
+    void* host_ptr,
+    cl_int* errcode_ret )
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept )
+    {
+        auto dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateBufferNV )
+        {
+            CALL_LOGGING_ENTER( "context = %p, flags = %s (%llX), flags_NV = %llX, size = %d, host_ptr = %p",
+                context,
+                pIntercept->enumName().name_mem_flags( flags ).c_str(),
+                flags,
+                flags_NV,
+                size,
+                host_ptr );
+            INITIALIZE_BUFFER_CONTENTS_INIT( flags, size, host_ptr );
+            CHECK_ERROR_INIT( errcode_ret );
+            CPU_PERFORMANCE_TIMING_START();
+
+            cl_mem  retVal = dispatchX.clCreateBufferNV(
+                context,
+                flags,
+                flags_NV,
+                size,
+                host_ptr,
+                errcode_ret );
+
+            CPU_PERFORMANCE_TIMING_END();
+            ADD_BUFFER( retVal );
+            INITIALIZE_BUFFER_CONTENTS_CLEANUP( flags, host_ptr );
+            DUMP_BUFFER_AFTER_CREATE( retVal, flags, host_ptr, size );
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+
+            return retVal;
+        }
+    }
+
+    NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
 // OpenCL 1.1
 CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateSubBuffer)(
     cl_mem buffer,

--- a/intercept/src/dispatch.h
+++ b/intercept/src/dispatch.h
@@ -1334,4 +1334,13 @@ struct CLdispatchX
         cl_uint num_events_in_wait_list,
         const cl_event* event_wait_list,
         cl_event* event);
+
+    // cl_nv_create_buffer
+    cl_mem (CLI_API_CALL *clCreateBufferNV) (
+        cl_context context,
+        cl_mem_flags flags,
+        cl_mem_flags_NV flags_NV,
+        size_t size,
+        void* host_ptr,
+        cl_int* errcode_ret);
 };

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -10970,6 +10970,9 @@ void* CLIntercept::getExtensionFunctionAddress(
         CHECK_RETURN_EXTENSION_FUNCTION( clEnqueueMemAdviseINTEL );
     }
 
+    // cl_nv_create_buffer
+    CHECK_RETURN_EXTENSION_FUNCTION( clCreateBufferNV );
+
     return NULL;
 }
 


### PR DESCRIPTION
## Description of Changes

Add handling for the `cl_nv_create_buffer` extension, specifically `clCreateBufferNV`.

## Testing Done

Wrote a simple app that created a buffer using `clCreateBufferNV` and observed that the API traced correctly using `CallLogging` and no that leaks were reported by `LeakChecking`.
