### PR TITLE
alphabetizes extensions in the enum headers and enummap

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -26,27 +26,19 @@
 extern "C" {
 #endif
 
-// cl_khr_fp16
-#define CL_DEVICE_HALF_FP_CONFIG                         0x1033
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_create_command_queue
 
-// cl_khr_gl_sharing
+typedef cl_properties cl_queue_properties_khr;
 extern CL_API_ENTRY
-cl_int CL_API_CALL clGetGLContextInfoKHR(
-    const cl_context_properties *properties,
-    cl_gl_context_info param_name,
-    size_t param_value_size,
-    void* param_value,
-    size_t* param_value_size_ret);
-
-// cl_khr_gl_event
-#define CL_COMMAND_GL_FENCE_SYNC_OBJECT_KHR     0x200D
-
-// cl_khr_gl_event
-extern CL_API_ENTRY
-cl_event CL_API_CALL clCreateEventFromGLsyncKHR(
+cl_command_queue CL_API_CALL clCreateCommandQueueWithPropertiesKHR(
     cl_context context,
-    cl_GLsync sync,
+    cl_device_id device,
+    const cl_queue_properties_khr* properties,
     cl_int* errcode_ret);
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_d3d10_sharing
 
 #if defined(_WIN32)
 
@@ -133,6 +125,13 @@ cl_int CL_API_CALL clEnqueueReleaseD3D10ObjectsKHR(
     const cl_event* event_wait_list,
     cl_event* event);
 
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_d3d11_sharing
+
+#if defined(_WIN32)
+
 // Minimal set of types for cl_khr_d3d11_sharing.
 // Don't include cl_d3d11.h here because we don't want a dependency on d3d10.h.
 typedef cl_uint cl_d3d11_device_source_khr;
@@ -216,6 +215,13 @@ cl_int CL_API_CALL clEnqueueReleaseD3D11ObjectsKHR(
     const cl_event* event_wait_list,
     cl_event* event);
 
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_dx9_media_sharing
+
+#if defined(_WIN32)
+
 // Minimal set of types for cl_khr_dx9_media_sharing.
 // Don't include cl_d3d9.h here because we don't want a dependency on d3d9.h.
 typedef cl_uint cl_dx9_media_adapter_type_khr;
@@ -286,7 +292,299 @@ cl_int CL_API_CALL clEnqueueReleaseDX9MediaSurfacesKHR(
     const cl_event* event_wait_list,
     cl_event* event);
 
-// Minimal set of types for cl_intel_d3d9_media_sharing.
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_extended_versioning
+
+#define CL_PLATFORM_NUMERIC_VERSION_KHR                  0x0906
+#define CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR          0x0907
+#define CL_DEVICE_NUMERIC_VERSION_KHR                    0x105E
+#define CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR           0x105F
+#define CL_DEVICE_EXTENSIONS_WITH_VERSION_KHR            0x1060
+#define CL_DEVICE_ILS_WITH_VERSION_KHR                   0x1061
+#define CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR      0x1062
+
+#define CL_VERSION_MAJOR_BITS_KHR (10)
+#define CL_VERSION_MINOR_BITS_KHR (10)
+#define CL_VERSION_PATCH_BITS_KHR (12)
+
+#define CL_VERSION_MAJOR_MASK_KHR ((1 << CL_VERSION_MAJOR_BITS_KHR) - 1)
+#define CL_VERSION_MINOR_MASK_KHR ((1 << CL_VERSION_MINOR_BITS_KHR) - 1)
+#define CL_VERSION_PATCH_MASK_KHR ((1 << CL_VERSION_PATCH_BITS_KHR) - 1)
+
+#define CL_VERSION_MAJOR_KHR(version) ((version) >> (CL_VERSION_MINOR_BITS_KHR + CL_VERSION_PATCH_BITS_KHR))
+#define CL_VERSION_MINOR_KHR(version) (((version) >> CL_VERSION_PATCH_BITS_KHR) & CL_VERSION_MINOR_MASK_KHR)
+#define CL_VERSION_PATCH_KHR(version) ((version) & CL_VERSION_PATCH_MASK_KHR)
+
+#define CL_MAKE_VERSION_KHR(major, minor, patch) \
+    ((((major) & CL_VERSION_MAJOR_MASK_KHR) << (CL_VERSION_MINOR_BITS_KHR + CL_VERSION_PATCH_BITS_KHR)) | \
+    (((minor) &  CL_VERSION_MINOR_MASK_KHR) << CL_VERSION_PATCH_BITS_KHR) | \
+    ((patch) & CL_VERSION_PATCH_MASK_KHR))
+
+typedef cl_uint cl_version_khr;
+
+#define CL_NAME_VERSION_MAX_NAME_SIZE_KHR 64
+
+typedef struct _cl_name_version_khr
+{
+    cl_version_khr version;
+    char name[CL_NAME_VERSION_MAX_NAME_SIZE_KHR];
+} cl_name_version_khr;
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_fp16
+
+#define CL_DEVICE_HALF_FP_CONFIG                         0x1033
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_gl_event
+
+#define CL_COMMAND_GL_FENCE_SYNC_OBJECT_KHR     0x200D
+
+extern CL_API_ENTRY
+cl_event CL_API_CALL clCreateEventFromGLsyncKHR(
+    cl_context context,
+    cl_GLsync sync,
+    cl_int* errcode_ret);
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_gl_sharing
+
+extern CL_API_ENTRY
+cl_int CL_API_CALL clGetGLContextInfoKHR(
+    const cl_context_properties *properties,
+    cl_gl_context_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret);
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_icd
+
+#define CL_PLATFORM_ICD_SUFFIX_KHR                  0x0920
+#define CL_PLATFORM_NOT_FOUND_KHR                   -1001
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_il_program
+
+#define CL_DEVICE_IL_VERSION_KHR                        0x105B
+#define CL_PROGRAM_IL_KHR                               0x1169
+extern CL_API_ENTRY
+cl_program CL_API_CALL clCreateProgramWithILKHR(
+    cl_context context,
+    const void* il,
+    size_t length,
+    cl_int* errcode_ret );
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_initalize_memory
+
+#define CL_CONTEXT_MEMORY_INITIALIZE_KHR            0x2030
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_priority_hints
+
+#define CL_QUEUE_PRIORITY_KHR 0x1096
+#define CL_QUEUE_PRIORITY_HIGH_KHR (1<<0)
+#define CL_QUEUE_PRIORITY_MED_KHR (1<<1)
+#define CL_QUEUE_PRIORITY_LOW_KHR (1<<2)
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_spir
+
+#define CL_DEVICE_SPIR_VERSIONS                     0x40E0
+#define CL_PROGRAM_BINARY_TYPE_INTERMEDIATE         0x40E1
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_subgroups
+
+#define CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR    0x2033
+#define CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR   0x2034
+
+typedef cl_uint  cl_kernel_sub_group_info;
+extern CL_API_ENTRY
+cl_int CL_API_CALL clGetKernelSubGroupInfoKHR(
+    cl_kernel kernel,
+    cl_device_id device,
+    cl_kernel_sub_group_info param_name,
+    size_t input_value_size,
+    const void* input_value,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret);
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_terminate_context
+
+#define CL_DEVICE_TERMINATE_CAPABILITY_KHR          0x2031
+#define CL_CONTEXT_TERMINATE_KHR                    0x2032
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_throttle_hints
+
+#define CL_QUEUE_THROTTLE_KHR 0x1097
+#define CL_QUEUE_THROTTLE_HIGH_KHR (1<<0)
+#define CL_QUEUE_THROTTLE_MED_KHR (1<<1)
+#define CL_QUEUE_THROTTLE_LOW_KHR (1<<2)
+
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_ext_atomic_counters
+
+#define CL_DEVICE_MAX_ATOMIC_COUNTERS_EXT           0x4032
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_ext_device_fission
+
+#define CL_DEVICE_PARTITION_EQUALLY_EXT             0x4050
+#define CL_DEVICE_PARTITION_BY_COUNTS_EXT           0x4051
+#define CL_DEVICE_PARTITION_BY_NAMES_EXT            0x4052
+#define CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_EXT  0x4053
+#define CL_DEVICE_PARENT_DEVICE_EXT                 0x4054
+#define CL_DEVICE_PARTITION_TYPES_EXT               0x4055
+#define CL_DEVICE_AFFINITY_DOMAINS_EXT              0x4056
+#define CL_DEVICE_REFERENCE_COUNT_EXT               0x4057
+#define CL_DEVICE_PARTITION_STYLE_EXT               0x4058
+
+#define CL_DEVICE_PARTITION_FAILED_EXT              -1057
+#define CL_INVALID_PARTITION_COUNT_EXT              -1058
+#define CL_INVALID_PARTITION_NAME_EXT               -1059
+
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_altera_compiler_mode
+
+#define CL_CONTEXT_COMPILER_MODE_ALTERA                 0x40F0
+#define CL_CONTEXT_PROGRAM_EXE_LIBRARY_ROOT_ALTERA      0x40F1
+#define CL_CONTEXT_OFFLINE_DEVICE_ALTERA                0x40F2
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_altera_device_temperature
+
+#define CL_DEVICE_CORE_TEMPERATURE_ALTERA               0x40F3
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_amd_device_attribute_query
+
+#define CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_AMD     0x4030
+#define CL_DEVICE_MAX_WORK_GROUP_SIZE_AMD           0x4031
+#define CL_DEVICE_PREFERRED_CONSTANT_BUFFER_SIZE_AMD    0x4033
+#define CL_DEVICE_PCIE_ID_AMD                       0x4034
+#define CL_DEVICE_PROFILING_TIMER_OFFSET_AMD        0x4036
+#define CL_DEVICE_TOPOLOGY_AMD                      0x4037
+#define CL_DEVICE_BOARD_NAME_AMD                    0x4038
+#define CL_DEVICE_GLOBAL_FREE_MEMORY_AMD            0x4039
+#define CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD         0x4040
+#define CL_DEVICE_SIMD_WIDTH_AMD                    0x4041
+#define CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD        0x4042
+#define CL_DEVICE_WAVEFRONT_WIDTH_AMD               0x4043
+#define CL_DEVICE_GLOBAL_MEM_CHANNELS_AMD           0x4044
+#define CL_DEVICE_GLOBAL_MEM_CHANNEL_BANKS_AMD      0x4045
+#define CL_DEVICE_GLOBAL_MEM_CHANNEL_BANK_WIDTH_AMD 0x4046
+#define CL_DEVICE_LOCAL_MEM_SIZE_PER_COMPUTE_UNIT_AMD   0x4047
+#define CL_DEVICE_LOCAL_MEM_BANKS_AMD               0x4048
+#define CL_DEVICE_THREAD_TRACE_SUPPORTED_AMD        0x4049
+#define CL_DEVICE_GFXIP_MAJOR_AMD                   0x404A
+#define CL_DEVICE_GFXIP_MINOR_AMD                   0x404B
+#define CL_DEVICE_AVAILABLE_ASYNC_QUEUES_AMD        0x404C
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_amd_offline_devices
+
+#define CL_CONTEXT_OFFLINE_DEVICES_AMD              0x403F
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_arm_get_core_id
+
+#define CL_DEVICE_COMPUTE_UNITS_BITFIELD_ARM        0x40BF
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_arm_job_slot_selection
+
+#define CL_DEVICE_JOB_SLOTS_ARM                     0x41E0
+#define CL_QUEUE_JOB_SLOT_ARM                       0x41E1
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_arm_printf
+
+#define CL_PRINTF_CALLBACK_ARM                      0x40B0
+#define CL_PRINTF_BUFFERSIZE_ARM                    0x40B1
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_arm_scheduling_controls
+
+#define CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_ARM          0x41E4
+#define CL_DEVICE_SCHEDULING_KERNEL_BATCHING_ARM                (1 << 0)
+#define CL_DEVICE_SCHEDULING_WORKGROUP_BATCH_SIZE_ARM           (1 << 1)
+#define CL_DEVICE_SCHEDULING_WORKGROUP_BATCH_SIZE_MODIFIER_ARM  (1 << 2)
+#define CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_ARM            0x41E5
+#define CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_MODIFIER_ARM   0x41E6
+#define CL_QUEUE_KERNEL_BATCHING_ARM                            0x41E7
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_intel_accelerator
+
+typedef struct _cl_accelerator_intel*     cl_accelerator_intel;
+typedef cl_uint                           cl_accelerator_type_intel;
+typedef cl_uint                           cl_accelerator_info_intel;
+
+// Error Codes
+#define CL_INVALID_ACCELERATOR_INTEL                    -1094
+#define CL_INVALID_ACCELERATOR_TYPE_INTEL               -1095
+#define CL_INVALID_ACCELERATOR_DESC_INTEL               -1096
+#define CL_ACCELERATOR_TYPE_NOT_SUPPORTED_INTEL         -1097
+
+// cl_accelerator_info_intel
+#define CL_ACCELERATOR_DESCRIPTOR_INTEL                 0x4090
+#define CL_ACCELERATOR_REFERENCE_COUNT_INTEL            0x4091
+#define CL_ACCELERATOR_CONTEXT_INTEL                    0x4092
+#define CL_ACCELERATOR_TYPE_INTEL                       0x4093
+
+extern CL_API_ENTRY
+cl_accelerator_intel CL_API_CALL clCreateAcceleratorINTEL(
+    cl_context context,
+    cl_accelerator_type_intel accelerator_type,
+    size_t descriptor_size,
+    const void* descriptor,
+    cl_int* errcode_ret );
+
+extern CL_API_ENTRY
+cl_int CL_API_CALL clGetAcceleratorInfoINTEL(
+    cl_accelerator_intel accelerator,
+    cl_accelerator_info_intel param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret );
+
+extern CL_API_ENTRY
+cl_int CL_API_CALL clRetainAcceleratorINTEL(
+    cl_accelerator_intel accelerator );
+
+extern CL_API_ENTRY
+cl_int CL_API_CALL clReleaseAcceleratorINTEL(
+    cl_accelerator_intel accelerator );
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_intel_advanced_motion_estimation
+
+// cl_device_info
+#define CL_DEVICE_ME_VERSION_INTEL                      0x407E
+
+#define CL_ME_VERSION_LEGACY_INTEL                      0x0
+#define CL_ME_VERSION_ADVANCED_VER_1_INTEL              0x1
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_intel_driver_diagnostics
+
+#define CL_CONTEXT_SHOW_DIAGNOSTICS_INTEL           0x4106
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_intel_d3d9_media_sharing
+
+#if defined(_WIN32)
+
+// Minimal set of types for cl_khr_dx9_media_sharing.
 // Don't include cl_d3d9.h here because we don't want a dependency on d3d9.h.
 typedef cl_uint cl_dx9_device_source_intel;
 typedef cl_uint cl_dx9_device_set_intel;
@@ -357,141 +655,21 @@ cl_int CL_API_CALL clEnqueueReleaseDX9ObjectsINTEL(
 
 #endif
 
-// cl_khr_il_program
-#define CL_DEVICE_IL_VERSION_KHR                        0x105B
-#define CL_PROGRAM_IL_KHR                               0x1169
-extern CL_API_ENTRY
-cl_program CL_API_CALL clCreateProgramWithILKHR(
-    cl_context context,
-    const void* il,
-    size_t length,
-    cl_int* errcode_ret );
+///////////////////////////////////////////////////////////////////////////////
+// cl_intel_egl_image_yuv
 
-// cl_khr_subgroups
-typedef cl_uint  cl_kernel_sub_group_info;
-extern CL_API_ENTRY
-cl_int CL_API_CALL clGetKernelSubGroupInfoKHR(
-    cl_kernel kernel,
-    cl_device_id device,
-    cl_kernel_sub_group_info param_name,
-    size_t input_value_size,
-    const void* input_value,
-    size_t param_value_size,
-    void* param_value,
-    size_t* param_value_size_ret);
+#define CL_EGL_YUV_PLANE_INTEL                      0x4107
 
-// cl_khr_create_command_queue
-typedef cl_properties cl_queue_properties_khr;
-extern CL_API_ENTRY
-cl_command_queue CL_API_CALL clCreateCommandQueueWithPropertiesKHR(
-    cl_context context,
-    cl_device_id device,
-    const cl_queue_properties_khr* properties,
-    cl_int* errcode_ret);
+///////////////////////////////////////////////////////////////////////////////
+// cl_intel_mem_force_host_memory
 
-// cl_khr_priority_hints extension
-#define CL_QUEUE_PRIORITY_KHR 0x1096
-#define CL_QUEUE_PRIORITY_HIGH_KHR (1<<0)
-#define CL_QUEUE_PRIORITY_MED_KHR (1<<1)
-#define CL_QUEUE_PRIORITY_LOW_KHR (1<<2)
+#define CL_MEM_FORCE_HOST_MEMORY_INTEL              (1 << 20)
 
-// cl_khr_throttle_hints extension
-#define CL_QUEUE_THROTTLE_KHR 0x1097
-#define CL_QUEUE_THROTTLE_HIGH_KHR (1<<0)
-#define CL_QUEUE_THROTTLE_MED_KHR (1<<1)
-#define CL_QUEUE_THROTTLE_LOW_KHR (1<<2)
-
-// cl_khr_extended_versioning
-#define CL_PLATFORM_NUMERIC_VERSION_KHR                  0x0906
-#define CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR          0x0907
-#define CL_DEVICE_NUMERIC_VERSION_KHR                    0x105E
-#define CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR           0x105F
-#define CL_DEVICE_EXTENSIONS_WITH_VERSION_KHR            0x1060
-#define CL_DEVICE_ILS_WITH_VERSION_KHR                   0x1061
-#define CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR      0x1062
-
-#define CL_VERSION_MAJOR_BITS_KHR (10)
-#define CL_VERSION_MINOR_BITS_KHR (10)
-#define CL_VERSION_PATCH_BITS_KHR (12)
-
-#define CL_VERSION_MAJOR_MASK_KHR ((1 << CL_VERSION_MAJOR_BITS_KHR) - 1)
-#define CL_VERSION_MINOR_MASK_KHR ((1 << CL_VERSION_MINOR_BITS_KHR) - 1)
-#define CL_VERSION_PATCH_MASK_KHR ((1 << CL_VERSION_PATCH_BITS_KHR) - 1)
-
-#define CL_VERSION_MAJOR_KHR(version) ((version) >> (CL_VERSION_MINOR_BITS_KHR + CL_VERSION_PATCH_BITS_KHR))
-#define CL_VERSION_MINOR_KHR(version) (((version) >> CL_VERSION_PATCH_BITS_KHR) & CL_VERSION_MINOR_MASK_KHR)
-#define CL_VERSION_PATCH_KHR(version) ((version) & CL_VERSION_PATCH_MASK_KHR)
-
-#define CL_MAKE_VERSION_KHR(major, minor, patch) \
-    ((((major) & CL_VERSION_MAJOR_MASK_KHR) << (CL_VERSION_MINOR_BITS_KHR + CL_VERSION_PATCH_BITS_KHR)) | \
-    (((minor) &  CL_VERSION_MINOR_MASK_KHR) << CL_VERSION_PATCH_BITS_KHR) | \
-    ((patch) & CL_VERSION_PATCH_MASK_KHR))
-
-typedef cl_uint cl_version_khr;
-
-#define CL_NAME_VERSION_MAX_NAME_SIZE_KHR 64
-
-typedef struct _cl_name_version_khr
-{
-    cl_version_khr version;
-    char name[CL_NAME_VERSION_MAX_NAME_SIZE_KHR];
-} cl_name_version_khr;
-
-// Unofficial MDAPI extension:
-extern CL_API_ENTRY
-cl_command_queue CL_API_CALL clCreatePerfCountersCommandQueueINTEL(
-    cl_context context,
-    cl_device_id device,
-    cl_command_queue_properties properties,
-    cl_uint configuration,
-    cl_int* errcode_ret);
-
-extern CL_API_ENTRY
-cl_int CL_API_CALL clSetPerformanceConfigurationINTEL(
-    cl_device_id    device,
-    cl_uint         count,
-    cl_uint*        offsets,
-    cl_uint*        values );
-
-// Unofficial kernel profiling extension:
-#define CL_CONTEXT_KERNEL_PROFILING_MODES_COUNT_INTEL   0x407A
-#define CL_CONTEXT_KERNEL_PROFILING_MODE_INFO_INTEL     0x407B
-#define CL_KERNEL_IL_SYMBOLS_INTEL                      0x407C
-#define CL_KERNEL_BINARY_PROGRAM_INTEL                  0x407D
-
-// Unofficial VTune Debug Info extension:
-#define CL_PROGRAM_DEBUG_INFO_INTEL                     0x4100
-#define CL_PROGRAM_DEBUG_INFO_SIZES_INTEL               0x4101
-#define CL_KERNEL_BINARIES_INTEL                        0x4102
-#define CL_KERNEL_BINARY_SIZES_INTEL                    0x4103
-
-// VME
-
-typedef struct _cl_accelerator_intel*     cl_accelerator_intel;
-typedef cl_uint                           cl_accelerator_type_intel;
-typedef cl_uint                           cl_accelerator_info_intel;
-
-// Error Codes
-#define CL_INVALID_ACCELERATOR_INTEL                    -1094
-#define CL_INVALID_ACCELERATOR_TYPE_INTEL               -1095
-#define CL_INVALID_ACCELERATOR_DESC_INTEL               -1096
-#define CL_ACCELERATOR_TYPE_NOT_SUPPORTED_INTEL         -1097
-
-// cl_device_info
-#define CL_DEVICE_ME_VERSION_INTEL                      0x407E
-#define CL_DEVICE_TRANSFORM_MASK_MAX_WIDTH_INTEL        0x409C
-#define CL_DEVICE_TRANSFORM_MASK_MAX_HEIGHT_INTEL       0x409D
-#define CL_DEVICE_TRANSFORM_FILTER_MAX_WIDTH_INTEL      0x409E
-#define CL_DEVICE_TRANSFORM_FILTER_MAX_HEIGHT_INTEL     0x409F
+///////////////////////////////////////////////////////////////////////////////
+// cl_intel_motion_estimation
 
 // cl_accelerator_type_intel
 #define CL_ACCELERATOR_TYPE_MOTION_ESTIMATION_INTEL     0x0
-
-// cl_accelerator_info_intel
-#define CL_ACCELERATOR_DESCRIPTOR_INTEL                 0x4090
-#define CL_ACCELERATOR_REFERENCE_COUNT_INTEL            0x4091
-#define CL_ACCELERATOR_CONTEXT_INTEL                    0x4092
-#define CL_ACCELERATOR_TYPE_INTEL                       0x4093
 
 // cl_motion_detect_desc_intel flags
 #define CL_ME_MB_TYPE_16x16_INTEL                       0x0
@@ -522,9 +700,6 @@ typedef cl_uint                           cl_accelerator_info_intel;
 #define CL_ME_COST_PRECISION_PEL_INTEL                  0x2
 #define CL_ME_COST_PRECISION_DPEL_INTEL                 0x3
 
-#define CL_ME_VERSION_LEGACY_INTEL                      0x0
-#define CL_ME_VERSION_ADVANCED_VER_1_INTEL              0x1
-
 typedef struct _cl_motion_estimation_desc_intel {
     cl_uint mb_block_type;
     cl_uint subpixel_mode;
@@ -532,103 +707,15 @@ typedef struct _cl_motion_estimation_desc_intel {
     cl_uint search_path_type;
 } cl_motion_estimation_desc_intel;
 
-extern CL_API_ENTRY
-cl_accelerator_intel CL_API_CALL clCreateAcceleratorINTEL(
-    cl_context context,
-    cl_accelerator_type_intel accelerator_type,
-    size_t descriptor_size,
-    const void* descriptor,
-    cl_int* errcode_ret );
-
-extern CL_API_ENTRY
-cl_int CL_API_CALL clGetAcceleratorInfoINTEL(
-    cl_accelerator_intel accelerator,
-    cl_accelerator_info_intel param_name,
-    size_t param_value_size,
-    void* param_value,
-    size_t* param_value_size_ret );
-
-extern CL_API_ENTRY
-cl_int CL_API_CALL clRetainAcceleratorINTEL(
-    cl_accelerator_intel accelerator );
-
-extern CL_API_ENTRY
-cl_int CL_API_CALL clReleaseAcceleratorINTEL(
-    cl_accelerator_intel accelerator );
-
-// cl_intel_egl_image_yuv
-#define CL_EGL_YUV_PLANE_INTEL                      0x4107
-
-// cl_intel_simultaneous_sharing
-#define CL_DEVICE_SIMULTANEOUS_INTEROPS_INTEL       0x4104
-#define CL_DEVICE_NUM_SIMULTANEOUS_INTEROPS_INTEL   0x4105
-
-// cl_intel_thread_local_exec
-#define CL_QUEUE_THREAD_LOCAL_EXEC_ENABLE_INTEL     (((cl_bitfield)1) << 31)
-
-// cl_intel_va_api_media_sharing
-
-#define CL_VA_API_DISPLAY_INTEL                     0x4094
-#define CL_PREFERRED_DEVICES_FOR_VA_API_INTEL       0x4095
-#define CL_ALL_DEVICES_FOR_VA_API_INTEL             0x4096
-#define CL_CONTEXT_VA_API_DISPLAY_INTEL             0x4097
-#define CL_MEM_VA_API_SURFACE_INTEL                 0x4098
-#define CL_IMAGE_VA_API_PLANE_INTEL                 0x4099
-#define CL_COMMAND_ACQUIRE_VA_API_MEDIA_SURFACES_INTEL 0x409A
-#define CL_COMMAND_RELEASE_VA_API_MEDIA_SURFACES_INTEL 0x409B
-
-#define CL_INVALID_VA_API_MEDIA_ADAPTER_INTEL       -1098
-#define CL_INVALID_VA_API_MEDIA_SURFACE_INTEL       -1099
-#define CL_VA_API_MEDIA_SURFACE_ALREADY_ACQUIRED_INTEL -1100
-#define CL_VA_API_MEDIA_SURFACE_NOT_ACQUIRED_INTEL  -1101
-
-// Minimal set of types for cl_intel_va_api_media_sharing.
-typedef cl_uint cl_va_api_device_source_intel;
-typedef cl_uint cl_va_api_device_set_intel;
-struct VASurfaceID;
-
-extern CL_API_ENTRY
-cl_int CL_API_CALL clGetDeviceIDsFromVA_APIMediaAdapterINTEL(
-    cl_platform_id platform,
-    cl_va_api_device_source_intel media_adapter_type,
-    void *media_adapter,
-    cl_va_api_device_set_intel media_adapter_set,
-    cl_uint num_entries,
-    cl_device_id *devices,
-    cl_uint *num_devices);
-
-extern CL_API_ENTRY
-cl_mem CL_API_CALL clCreateFromVA_APIMediaSurfaceINTEL(
-    cl_context context,
-    cl_mem_flags flags,
-    VASurfaceID *surface,
-    cl_uint plane,
-    cl_int *errcode_ret);
-
-extern CL_API_ENTRY
-cl_int CL_API_CALL clEnqueueAcquireVA_APIMediaSurfacesINTEL(
-    cl_command_queue command_queue,
-    cl_uint num_objects,
-    const cl_mem *mem_objects,
-    cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event);
-
-extern CL_API_ENTRY
-cl_int CL_API_CALL clEnqueueReleaseVA_APIMediaSurfacesINTEL(
-    cl_command_queue command_queue,
-    cl_uint num_objects,
-    const cl_mem *mem_objects,
-    cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event);
-
+///////////////////////////////////////////////////////////////////////////////
 // cl_intel_packed_yuv
+
 #define CL_YUYV_INTEL                               0x4076
 #define CL_UYVY_INTEL                               0x4077
 #define CL_YVYU_INTEL                               0x4078
 #define CL_VYUY_INTEL                               0x4079
 
+///////////////////////////////////////////////////////////////////////////////
 // cl_intel_planar_yuv
 
 // cl_channel_order
@@ -642,103 +729,30 @@ cl_int CL_API_CALL clEnqueueReleaseVA_APIMediaSurfacesINTEL(
 #define CL_DEVICE_PLANAR_YUV_MAX_WIDTH_INTEL        0x417E
 #define CL_DEVICE_PLANAR_YUV_MAX_HEIGHT_INTEL       0x417F
 
+///////////////////////////////////////////////////////////////////////////////
 // cl_intel_required_subgroup_size
+
 #define CL_DEVICE_SUB_GROUP_SIZES_INTEL             0x4108
 #define CL_KERNEL_SPILL_MEM_SIZE_INTEL              0x4109
 #define CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL      0x410A
 
-// cl_intel_driver_diagnostics
-#define CL_CONTEXT_SHOW_DIAGNOSTICS_INTEL           0x4106
+///////////////////////////////////////////////////////////////////////////////
+// cl_intel_simultaneous_sharing
 
-// cl_intelx_video_enhancement
-// This is the base-functionality VEBox extension.
-// Note: These are preview enum names and values!
+#define CL_DEVICE_SIMULTANEOUS_INTEROPS_INTEL       0x4104
+#define CL_DEVICE_NUM_SIMULTANEOUS_INTEROPS_INTEL   0x4105
 
-// cl_device_info
-#define CL_DEVICE_VE_VERSION_INTEL                      0x4160
-#define CL_DEVICE_VE_ENGINE_COUNT_INTEL                 0x4161
+///////////////////////////////////////////////////////////////////////////////
+// cl_intel_thread_local_exec
 
-// cl_queue_properties / cl_command_queue_info
-#define CL_QUEUE_VE_ENABLE_INTEL                        0x4162
+#define CL_QUEUE_THREAD_LOCAL_EXEC_ENABLE_INTEL     (((cl_bitfield)1) << 31)
 
-// attribute_ids for cl_vebox_attrib_desc_intel
-#define CL_VE_ACCELERATOR_ATTRIB_DENOISE_INTEL          0x4163
-#define CL_VE_ACCELERATOR_ATTRIB_DEINTERLACE_INTEL      0x4164
-#define CL_VE_ACCELERATOR_ATTRIB_HOT_PIXEL_CORR_INTEL   0x4165
-
-// cl_accelerator_info_intel
-#define CL_VE_ACCELERATOR_HISTOGRAMS_INTEL              0x4166
-#define CL_VE_ACCELERATOR_STATISTICS_INTEL              0x4167
-#define CL_VE_ACCELERATOR_STMM_INPUT_INTEL              0x4168
-#define CL_VE_ACCELERATOR_STMM_OUTPUT_INTEL             0x4169
-
-// cl_intelx_ve_color_pipeline
-// Note: These are preview enum names and values!
-
-// cl_device_info
-#define CL_DEVICE_VE_COLOR_PIPE_VERSION_INTEL           0x416A
-
-// attribute_ids for cl_vebox_attrib_desc_intel
-#define CL_VE_ACCELERATOR_ATTRIB_STD_STE_INTEL          0x416B
-#define CL_VE_ACCELERATOR_ATTRIB_GAMUT_COMP_INTEL       0x416C
-#define CL_VE_ACCELERATOR_ATTRIB_GECC_INTEL             0x416D
-#define CL_VE_ACCELERATOR_ATTRIB_ACE_INTEL              0x416E
-#define CL_VE_ACCELERATOR_ATTRIB_ACE_ADV_INTEL          0x416F
-#define CL_VE_ACCELERATOR_ATTRIB_TCC_INTEL              0x4170
-#define CL_VE_ACCELERATOR_ATTRIB_PROC_AMP_INTEL         0x4171
-#define CL_VE_ACCELERATOR_ATTRIB_BACK_END_CSC_INTEL     0x4172
-#define CL_VE_ACCELERATOR_ATTRIB_AOI_ALPHA_INTEL        0x4173
-#define CL_VE_ACCELERATOR_ATTRIB_CCM_INTEL              0x4174
-#define CL_VE_ACCELERATOR_ATTRIB_FWD_GAMMA_CORRECT_INTEL 0x4175
-#define CL_VE_ACCELERATOR_ATTRIB_FRONT_END_CSC_INTEL    0x4176
-
-// cl_intelx_ve_camera_pipeline
-// Note, these are preview enum names and values!
-
-// cl_device_info
-#define CL_DEVICE_VE_CAMERA_PIPE_VERSION_INTEL          0x4177
-
-// attribute_ids for cl_vebox_attrib_desc_intel
-#define CL_VE_ACCELERATOR_ATTRIB_BLACK_LEVEL_CORR_INTEL 0x4178
-#define CL_VE_ACCELERATOR_ATTRIB_DEMOSAIC_INTEL         0x4179
-#define CL_VE_ACCELERATOR_ATTRIB_WHITE_BALANCE_CORR_INTEL 0x417A
-#define CL_VE_ACCELERATOR_ATTRIB_VIGNETTE_INTEL         0x417B
-
-// HEVC PAK
-// Note, this extension is still in development!
-
-// cl_device_info
-#define CL_DEVICE_PAK_VERSION_INTEL                     0x4180
-#define CL_DEVICE_PAK_AVAILABLE_CODECS_INTEL            0x4181
-
-// cl_queue_properties / cl_command_queue_info
-#define CL_QUEUE_PAK_ENABLE_INTEL                       0x4189
-
-// cl_accelerator_info_intel
-#define CL_PAK_CTU_COUNT_INTEL                          0x4182
-#define CL_PAK_CTU_WIDTH_INTEL                          0x4183
-#define CL_PAK_CTU_HEIGHT_INTEL                         0x4184
-#define CL_PAK_MAX_INTRA_DEPTH_INTEL                    0x4185
-#define CL_PAK_MAX_INTER_DEPTH_INTEL                    0x4186
-#define CL_PAK_NUM_CUS_PER_CTU_INTEL                    0x4187
-#define CL_PAK_MV_BUFFER_SIZE_INTEL                     0x4188
-
-// Error Codes
-// These are currently all mapped to CL_INVALID_VALUE.
-// Need official error code assignment.
-#define CL_INVALID_PAK_CTU_SIZE_INTEL                   CL_INVALID_VALUE
-#define CL_INVALID_PAK_TU_SIZE_INTEL                    CL_INVALID_VALUE
-#define CL_INVALID_PAK_TU_INTRA_DEPTH_INTEL             CL_INVALID_VALUE
-#define CL_INVALID_PAK_TU_INTER_DEPTH_INTEL             CL_INVALID_VALUE
-#define CL_INVALID_PAK_BITRATE_RANGE_INTEL              CL_INVALID_VALUE
-#define CL_INVALID_PAK_INSERTION_INTEL                  CL_INVALID_VALUE
-#define CL_INVALID_PAK_CTU_POSITION_INTEL               CL_INVALID_VALUE
-#define CL_INVALID_PAK_REFERENCE_IMAGE_INDEX_INTEL      CL_INVALID_VALUE
-
+///////////////////////////////////////////////////////////////////////////////
 // cl_intel_unified_shared_memory POC
+
 // These enums are in sync with revision Q of the USM spec.
 
-/* cl_device_info */
+// cl_device_info
 #define CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL                   0x4190
 #define CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL                 0x4191
 #define CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL   0x4192
@@ -747,7 +761,7 @@ cl_int CL_API_CALL clEnqueueReleaseVA_APIMediaSurfacesINTEL(
 
 typedef cl_bitfield cl_device_unified_shared_memory_capabilities_intel;
 
-/* cl_unified_shared_memory_capabilities_intel - bitfield */
+// cl_unified_shared_memory_capabilities_intel - bitfield
 #define CL_UNIFIED_SHARED_MEMORY_ACCESS_INTEL                   (1 << 0)
 #define CL_UNIFIED_SHARED_MEMORY_ATOMIC_ACCESS_INTEL            (1 << 1)
 #define CL_UNIFIED_SHARED_MEMORY_CONCURRENT_ACCESS_INTEL        (1 << 2)
@@ -755,17 +769,17 @@ typedef cl_bitfield cl_device_unified_shared_memory_capabilities_intel;
 
 typedef cl_properties cl_mem_properties_intel;
 
-/* cl_mem_properties_intel */
+// cl_mem_properties_intel
 #define CL_MEM_ALLOC_FLAGS_INTEL        0x4195
 
 typedef cl_bitfield cl_mem_alloc_flags_intel;
 
-/* cl_mem_alloc_flags_intel - bitfield */
+// cl_mem_alloc_flags_intel - bitfield
 #define CL_MEM_ALLOC_WRITE_COMBINED_INTEL               (1 << 0)
 
 typedef cl_uint cl_mem_info_intel;
 
-/* cl_mem_alloc_info_intel */
+// cl_mem_alloc_info_intel
 #define CL_MEM_ALLOC_TYPE_INTEL         0x419A
 #define CL_MEM_ALLOC_BASE_PTR_INTEL     0x419B
 #define CL_MEM_ALLOC_SIZE_INTEL         0x419C
@@ -776,7 +790,7 @@ typedef cl_uint cl_mem_info_intel;
 
 typedef cl_uint cl_unified_shared_memory_type_intel;
 
-/* cl_unified_shared_memory_type_intel */
+// cl_unified_shared_memory_type_intel
 #define CL_MEM_TYPE_UNKNOWN_INTEL       0x4196
 #define CL_MEM_TYPE_HOST_INTEL          0x4197
 #define CL_MEM_TYPE_DEVICE_INTEL        0x4198
@@ -784,7 +798,7 @@ typedef cl_uint cl_unified_shared_memory_type_intel;
 
 typedef cl_uint cl_mem_advice_intel;
 
-/* cl_mem_advice_intel */
+// cl_mem_advice_intel
 #define CL_MEM_ADVICE_TBD0_INTEL        0x4208  /* reserved for future */
 #define CL_MEM_ADVICE_TBD1_INTEL        0x4209  /* reserved for future */
 #define CL_MEM_ADVICE_TBD2_INTEL        0x420A  /* reserved for future */
@@ -794,13 +808,13 @@ typedef cl_uint cl_mem_advice_intel;
 #define CL_MEM_ADVICE_TBD6_INTEL        0x420E  /* reserved for future */
 #define CL_MEM_ADVICE_TBD7_INTEL        0x420F  /* reserved for future */
 
-/* cl_kernel_exec_info */
+// cl_kernel_exec_info
 #define CL_KERNEL_EXEC_INFO_INDIRECT_HOST_ACCESS_INTEL      0x4200
 #define CL_KERNEL_EXEC_INFO_INDIRECT_DEVICE_ACCESS_INTEL    0x4201
 #define CL_KERNEL_EXEC_INFO_INDIRECT_SHARED_ACCESS_INTEL    0x4202
 #define CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL                  0x4203
 
-/* cl_command_type */
+// cl_command_type
 #define CL_COMMAND_MEMFILL_INTEL        0x4204
 #define CL_COMMAND_MEMCPY_INTEL         0x4205
 #define CL_COMMAND_MIGRATEMEM_INTEL     0x4206
@@ -911,53 +925,67 @@ clEnqueueMemAdviseINTEL(
             const cl_event* event_wait_list,
             cl_event* event);
 
-// cl_intel_mem_force_host_memory
-#define CL_MEM_FORCE_HOST_MEMORY_INTEL              (1 << 20)
+///////////////////////////////////////////////////////////////////////////////
+// cl_intel_va_api_media_sharing
 
-// Altera Extensions:
+#define CL_VA_API_DISPLAY_INTEL                     0x4094
+#define CL_PREFERRED_DEVICES_FOR_VA_API_INTEL       0x4095
+#define CL_ALL_DEVICES_FOR_VA_API_INTEL             0x4096
+#define CL_CONTEXT_VA_API_DISPLAY_INTEL             0x4097
+#define CL_MEM_VA_API_SURFACE_INTEL                 0x4098
+#define CL_IMAGE_VA_API_PLANE_INTEL                 0x4099
+#define CL_COMMAND_ACQUIRE_VA_API_MEDIA_SURFACES_INTEL 0x409A
+#define CL_COMMAND_RELEASE_VA_API_MEDIA_SURFACES_INTEL 0x409B
 
-// cl_altera_device_temperature
-#define CL_DEVICE_CORE_TEMPERATURE_ALTERA               0x40F3
+#define CL_INVALID_VA_API_MEDIA_ADAPTER_INTEL       -1098
+#define CL_INVALID_VA_API_MEDIA_SURFACE_INTEL       -1099
+#define CL_VA_API_MEDIA_SURFACE_ALREADY_ACQUIRED_INTEL -1100
+#define CL_VA_API_MEDIA_SURFACE_NOT_ACQUIRED_INTEL  -1101
 
-// cl_altera_compiler_mode
-#define CL_CONTEXT_COMPILER_MODE_ALTERA                 0x40F0
-#define CL_CONTEXT_PROGRAM_EXE_LIBRARY_ROOT_ALTERA      0x40F1
-#define CL_CONTEXT_OFFLINE_DEVICE_ALTERA                0x40F2
+// Minimal set of types for cl_intel_va_api_media_sharing.
+typedef cl_uint cl_va_api_device_source_intel;
+typedef cl_uint cl_va_api_device_set_intel;
+struct VASurfaceID;
 
-// These are from the Khronos cl_ext.h:
+extern CL_API_ENTRY
+cl_int CL_API_CALL clGetDeviceIDsFromVA_APIMediaAdapterINTEL(
+    cl_platform_id platform,
+    cl_va_api_device_source_intel media_adapter_type,
+    void *media_adapter,
+    cl_va_api_device_set_intel media_adapter_set,
+    cl_uint num_entries,
+    cl_device_id *devices,
+    cl_uint *num_devices);
 
-// cl_khr_icd
-#define CL_PLATFORM_ICD_SUFFIX_KHR                  0x0920
-#define CL_PLATFORM_NOT_FOUND_KHR                   -1001
+extern CL_API_ENTRY
+cl_mem CL_API_CALL clCreateFromVA_APIMediaSurfaceINTEL(
+    cl_context context,
+    cl_mem_flags flags,
+    VASurfaceID *surface,
+    cl_uint plane,
+    cl_int *errcode_ret);
 
-// cl_khr_initalize_memory
-#define CL_CONTEXT_MEMORY_INITIALIZE_KHR            0x2030
+extern CL_API_ENTRY
+cl_int CL_API_CALL clEnqueueAcquireVA_APIMediaSurfacesINTEL(
+    cl_command_queue command_queue,
+    cl_uint num_objects,
+    const cl_mem *mem_objects,
+    cl_uint num_events_in_wait_list,
+    const cl_event *event_wait_list,
+    cl_event *event);
 
-// cl_khr_terminate_context
-#define CL_DEVICE_TERMINATE_CAPABILITY_KHR          0x2031
-#define CL_CONTEXT_TERMINATE_KHR                    0x2032
+extern CL_API_ENTRY
+cl_int CL_API_CALL clEnqueueReleaseVA_APIMediaSurfacesINTEL(
+    cl_command_queue command_queue,
+    cl_uint num_objects,
+    const cl_mem *mem_objects,
+    cl_uint num_events_in_wait_list,
+    const cl_event *event_wait_list,
+    cl_event *event);
 
-// cl_khr_spir
-#define CL_DEVICE_SPIR_VERSIONS                     0x40E0
-#define CL_PROGRAM_BINARY_TYPE_INTERMEDIATE         0x40E1
-
-// cl_khr_subgroups
-#define CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR    0x2033
-#define CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR   0x2034
-
-// cl_nv_device_attribute_query
-#define CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV       0x4000
-#define CL_DEVICE_COMPUTE_CAPABILITY_MINOR_NV       0x4001
-#define CL_DEVICE_REGISTERS_PER_BLOCK_NV            0x4002
-#define CL_DEVICE_WARP_SIZE_NV                      0x4003
-#define CL_DEVICE_GPU_OVERLAP_NV                    0x4004
-#define CL_DEVICE_KERNEL_EXEC_TIMEOUT_NV            0x4005
-#define CL_DEVICE_INTEGRATED_MEMORY_NV              0x4006
-#define CL_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT_NV   0x4007
-#define CL_DEVICE_PCI_BUS_ID_NV                     0x4008
-#define CL_DEVICE_PCI_SLOT_ID_NV                    0x4009
-
+///////////////////////////////////////////////////////////////////////////////
 // cl_nv_create_buffer
+
 typedef cl_bitfield         cl_mem_flags_NV;
 
 extern CL_API_ENTRY cl_mem CL_API_CALL
@@ -972,51 +1000,23 @@ clCreateBufferNV(
 #define CL_MEM_LOCATION_HOST_NV                     (1 << 0)
 #define CL_MEM_PINNED_NV                            (1 << 1)
 
-// cl_ext_atomic_counters
-#define CL_DEVICE_MAX_ATOMIC_COUNTERS_EXT           0x4032
+///////////////////////////////////////////////////////////////////////////////
+// cl_nv_device_attribute_query
 
-// cl_amd_device_attribute_query
-#define CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_AMD     0x4030
-#define CL_DEVICE_MAX_WORK_GROUP_SIZE_AMD           0x4031
-#define CL_DEVICE_PREFERRED_CONSTANT_BUFFER_SIZE_AMD    0x4033
-#define CL_DEVICE_PCIE_ID_AMD                       0x4034
-#define CL_DEVICE_PROFILING_TIMER_OFFSET_AMD        0x4036
-#define CL_DEVICE_TOPOLOGY_AMD                      0x4037
-#define CL_DEVICE_BOARD_NAME_AMD                    0x4038
-#define CL_DEVICE_GLOBAL_FREE_MEMORY_AMD            0x4039
-#define CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD         0x4040
-#define CL_DEVICE_SIMD_WIDTH_AMD                    0x4041
-#define CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD        0x4042
-#define CL_DEVICE_WAVEFRONT_WIDTH_AMD               0x4043
-#define CL_DEVICE_GLOBAL_MEM_CHANNELS_AMD           0x4044
-#define CL_DEVICE_GLOBAL_MEM_CHANNEL_BANKS_AMD      0x4045
-#define CL_DEVICE_GLOBAL_MEM_CHANNEL_BANK_WIDTH_AMD 0x4046
-#define CL_DEVICE_LOCAL_MEM_SIZE_PER_COMPUTE_UNIT_AMD   0x4047
-#define CL_DEVICE_LOCAL_MEM_BANKS_AMD               0x4048
-#define CL_DEVICE_THREAD_TRACE_SUPPORTED_AMD        0x4049
-#define CL_DEVICE_GFXIP_MAJOR_AMD                   0x404A
-#define CL_DEVICE_GFXIP_MINOR_AMD                   0x404B
-#define CL_DEVICE_AVAILABLE_ASYNC_QUEUES_AMD        0x404C
+#define CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV       0x4000
+#define CL_DEVICE_COMPUTE_CAPABILITY_MINOR_NV       0x4001
+#define CL_DEVICE_REGISTERS_PER_BLOCK_NV            0x4002
+#define CL_DEVICE_WARP_SIZE_NV                      0x4003
+#define CL_DEVICE_GPU_OVERLAP_NV                    0x4004
+#define CL_DEVICE_KERNEL_EXEC_TIMEOUT_NV            0x4005
+#define CL_DEVICE_INTEGRATED_MEMORY_NV              0x4006
+#define CL_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT_NV   0x4007
+#define CL_DEVICE_PCI_BUS_ID_NV                     0x4008
+#define CL_DEVICE_PCI_SLOT_ID_NV                    0x4009
 
-// cl_amd_offline_devices
-#define CL_CONTEXT_OFFLINE_DEVICES_AMD              0x403F
-
-// cl_ext_device_fission
-#define CL_DEVICE_PARTITION_EQUALLY_EXT             0x4050
-#define CL_DEVICE_PARTITION_BY_COUNTS_EXT           0x4051
-#define CL_DEVICE_PARTITION_BY_NAMES_EXT            0x4052
-#define CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_EXT  0x4053
-#define CL_DEVICE_PARENT_DEVICE_EXT                 0x4054
-#define CL_DEVICE_PARTITION_TYPES_EXT               0x4055
-#define CL_DEVICE_AFFINITY_DOMAINS_EXT              0x4056
-#define CL_DEVICE_REFERENCE_COUNT_EXT               0x4057
-#define CL_DEVICE_PARTITION_STYLE_EXT               0x4058
-
-#define CL_DEVICE_PARTITION_FAILED_EXT              -1057
-#define CL_INVALID_PARTITION_COUNT_EXT              -1058
-#define CL_INVALID_PARTITION_NAME_EXT               -1059
-
+///////////////////////////////////////////////////////////////////////////////
 // cl_qcom_ext_host_ptr
+
 #define CL_MEM_EXT_HOST_PTR_QCOM                    (1 << 29)
 
 #define CL_DEVICE_EXT_MEM_PADDING_IN_BYTES_QCOM     0x40A0
@@ -1028,28 +1028,44 @@ clCreateBufferNV(
 #define CL_MEM_HOST_WRITETHROUGH_QCOM               0x40A6
 #define CL_MEM_HOST_WRITE_COMBINING_QCOM            0x40A7
 
+///////////////////////////////////////////////////////////////////////////////
 // cl_qcom_ion_host_ptr
+
 #define CL_MEM_ION_HOST_PTR_QCOM                    0x40A8
 
-// cl_arm_printf
-#define CL_PRINTF_CALLBACK_ARM                      0x40B0
-#define CL_PRINTF_BUFFERSIZE_ARM                    0x40B1
+///////////////////////////////////////////////////////////////////////////////
+// Unofficial MDAPI extension:
 
-// cl_arm_get_core_id
-#define CL_DEVICE_COMPUTE_UNITS_BITFIELD_ARM        0x40BF
+extern CL_API_ENTRY
+cl_command_queue CL_API_CALL clCreatePerfCountersCommandQueueINTEL(
+    cl_context context,
+    cl_device_id device,
+    cl_command_queue_properties properties,
+    cl_uint configuration,
+    cl_int* errcode_ret);
 
-// cl_arm_job_slot_selection
-#define CL_DEVICE_JOB_SLOTS_ARM                     0x41E0
-#define CL_QUEUE_JOB_SLOT_ARM                       0x41E1
+extern CL_API_ENTRY
+cl_int CL_API_CALL clSetPerformanceConfigurationINTEL(
+    cl_device_id    device,
+    cl_uint         count,
+    cl_uint*        offsets,
+    cl_uint*        values );
 
-// cl_arm_scheduling_controls
-#define CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_ARM          0x41E4
-#define CL_DEVICE_SCHEDULING_KERNEL_BATCHING_ARM                (1 << 0)
-#define CL_DEVICE_SCHEDULING_WORKGROUP_BATCH_SIZE_ARM           (1 << 1)
-#define CL_DEVICE_SCHEDULING_WORKGROUP_BATCH_SIZE_MODIFIER_ARM  (1 << 2)
-#define CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_ARM            0x41E5
-#define CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_MODIFIER_ARM   0x41E6
-#define CL_QUEUE_KERNEL_BATCHING_ARM                            0x41E7
+///////////////////////////////////////////////////////////////////////////////
+// Unofficial kernel profiling extension:
+
+#define CL_CONTEXT_KERNEL_PROFILING_MODES_COUNT_INTEL   0x407A
+#define CL_CONTEXT_KERNEL_PROFILING_MODE_INFO_INTEL     0x407B
+#define CL_KERNEL_IL_SYMBOLS_INTEL                      0x407C
+#define CL_KERNEL_BINARY_PROGRAM_INTEL                  0x407D
+
+///////////////////////////////////////////////////////////////////////////////
+// Unofficial VTune Debug Info extension:
+
+#define CL_PROGRAM_DEBUG_INFO_INTEL                     0x4100
+#define CL_PROGRAM_DEBUG_INFO_SIZES_INTEL               0x4101
+#define CL_KERNEL_BINARIES_INTEL                        0x4102
+#define CL_KERNEL_BINARY_SIZES_INTEL                    0x4103
 
 #ifdef __cplusplus
 }

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -601,45 +601,264 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_device_device_enqueue_capabilities, CL_DEVICE_QUEUE_SUPPORTED );
     ADD_ENUM_NAME( m_cl_device_device_enqueue_capabilities, CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT );
 
-    // Intel Extensions
+    // cl_gl_object_type
+    ADD_ENUM_NAME( m_cl_int, CL_GL_OBJECT_BUFFER );
+    ADD_ENUM_NAME( m_cl_int, CL_GL_OBJECT_TEXTURE2D );
+    ADD_ENUM_NAME( m_cl_int, CL_GL_OBJECT_TEXTURE3D );
+    ADD_ENUM_NAME( m_cl_int, CL_GL_OBJECT_RENDERBUFFER );
+    ADD_ENUM_NAME( m_cl_int, CL_GL_OBJECT_TEXTURE2D_ARRAY );
+    ADD_ENUM_NAME( m_cl_int, CL_GL_OBJECT_TEXTURE1D );
+    ADD_ENUM_NAME( m_cl_int, CL_GL_OBJECT_TEXTURE1D_ARRAY );
+    ADD_ENUM_NAME( m_cl_int, CL_GL_OBJECT_TEXTURE_BUFFER );
 
-    // Unofficial kernel profiling extension:
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_KERNEL_PROFILING_MODES_COUNT_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_KERNEL_PROFILING_MODE_INFO_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_KERNEL_IL_SYMBOLS_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_KERNEL_BINARY_PROGRAM_INTEL );
+    // cl_gl_texture_info
+    ADD_ENUM_NAME( m_cl_int, CL_GL_TEXTURE_TARGET );
+    ADD_ENUM_NAME( m_cl_int, CL_GL_MIPMAP_LEVEL );
+    ADD_ENUM_NAME( m_cl_int, CL_GL_NUM_SAMPLES );
 
-    // Unofficial extension (for now) for VTune Debug Info:
-    ADD_ENUM_NAME( m_cl_int, CL_PROGRAM_DEBUG_INFO_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_PROGRAM_DEBUG_INFO_SIZES_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_KERNEL_BINARIES_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_KERNEL_BINARY_SIZES_INTEL );
+    // Error Code
+    ADD_ENUM_NAME( m_cl_int, CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR );
 
-    // VME and VA
+    // cl_gl_context_info
+    ADD_ENUM_NAME( m_cl_int, CL_CURRENT_DEVICE_FOR_GL_CONTEXT_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICES_FOR_GL_CONTEXT_KHR );
 
-    // clGetDeviceInfo
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_ME_VERSION_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_TRANSFORM_MASK_MAX_WIDTH_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_TRANSFORM_MASK_MAX_HEIGHT_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_TRANSFORM_FILTER_MAX_WIDTH_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_TRANSFORM_FILTER_MAX_HEIGHT_INTEL );
+    // cl_context_properties
+    ADD_ENUM_NAME( m_cl_int, CL_GL_CONTEXT_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_EGL_DISPLAY_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_GLX_DISPLAY_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_WGL_HDC_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_CGL_SHAREGROUP_KHR );
 
-    // Error Codes
+    // Extensions
+
+#if defined(_WIN32)
+    // cl_khr_d3d10_sharing
+    ADD_ENUM_NAME( m_cl_int, CL_INVALID_D3D10_DEVICE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_INVALID_D3D10_RESOURCE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_D3D10_RESOURCE_ALREADY_ACQUIRED_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_D3D10_RESOURCE_NOT_ACQUIRED_KHR );
+
+    // cl_khr_d3d10_sharing
+    ADD_ENUM_NAME( m_cl_int, CL_D3D10_DEVICE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_D3D10_DXGI_ADAPTER_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_PREFERRED_DEVICES_FOR_D3D10_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_ALL_DEVICES_FOR_D3D10_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_D3D10_DEVICE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_D3D10_PREFER_SHARED_RESOURCES_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_MEM_D3D10_RESOURCE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_IMAGE_D3D10_SUBRESOURCE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_ACQUIRE_D3D10_OBJECTS_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_RELEASE_D3D10_OBJECTS_KHR );
+#endif
+
+#if defined(_WIN32)
+    // cl_khr_d3d11_sharing
+    ADD_ENUM_NAME( m_cl_int, CL_INVALID_D3D11_DEVICE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_INVALID_D3D11_RESOURCE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_D3D11_RESOURCE_ALREADY_ACQUIRED_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_D3D11_RESOURCE_NOT_ACQUIRED_KHR );
+
+    // cl_khr_d3d11_sharing
+    ADD_ENUM_NAME( m_cl_int, CL_D3D11_DEVICE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_D3D11_DXGI_ADAPTER_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_PREFERRED_DEVICES_FOR_D3D11_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_ALL_DEVICES_FOR_D3D11_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_D3D11_DEVICE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_D3D11_PREFER_SHARED_RESOURCES_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_MEM_D3D11_RESOURCE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_IMAGE_D3D11_SUBRESOURCE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_ACQUIRE_D3D11_OBJECTS_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_RELEASE_D3D11_OBJECTS_KHR );
+#endif
+
+#if defined(_WIN32)
+    // cl_khr_dx9_media_sharing
+    ADD_ENUM_NAME( m_cl_int, CL_INVALID_DX9_MEDIA_ADAPTER_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_INVALID_DX9_MEDIA_SURFACE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_DX9_MEDIA_SURFACE_ALREADY_ACQUIRED_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_DX9_MEDIA_SURFACE_NOT_ACQUIRED_KHR );
+
+    // cl_khr_dx9_media_sharing
+    ADD_ENUM_NAME( m_cl_int, CL_ADAPTER_D3D9_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_ADAPTER_D3D9EX_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_ADAPTER_DXVA_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_PREFERRED_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_ALL_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_ADAPTER_D3D9_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_ADAPTER_D3D9EX_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_ADAPTER_DXVA_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_MEM_DX9_MEDIA_ADAPTER_TYPE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_MEM_DX9_MEDIA_SURFACE_INFO_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_IMAGE_DX9_MEDIA_PLANE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_ACQUIRE_DX9_MEDIA_SURFACES_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_RELEASE_DX9_MEDIA_SURFACES_KHR );
+#endif
+
+    // cl_khr_extended_versioning extension
+    // Most enums for this extension were added to OpenCL 3.0.
+    //CL_PLATFORM_NUMERIC_VERSION_KHR                  0x0906
+    //CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR          0x0907
+    //CL_DEVICE_NUMERIC_VERSION_KHR                    0x105E
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR );
+    //CL_DEVICE_EXTENSIONS_WITH_VERSION_KHR            0x1060
+    //CL_DEVICE_ILS_WITH_VERSION_KHR                   0x1061
+    //CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR      0x1062
+
+    // cl_khr_gl_event
+    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_GL_FENCE_SYNC_OBJECT_KHR );
+
+    // cl_khr_icd
+    ADD_ENUM_NAME( m_cl_int, CL_PLATFORM_ICD_SUFFIX_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_PLATFORM_NOT_FOUND_KHR );
+
+    // cl_khr_il_program
+    // These enums are core in OpenCL 2.1.
+    //CL_DEVICE_IL_VERSION_KHR                        0x105B
+    //CL_PROGRAM_IL_KHR                               0x1169
+
+    // cl_khr_initalize_memory
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_MEMORY_INITIALIZE_KHR );
+
+    // cl_khr_priority_hints extension
+    ADD_ENUM_NAME( m_cl_int, CL_QUEUE_PRIORITY_KHR );
+
+    // cl_khr_spir
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SPIR_VERSIONS );
+    ADD_ENUM_NAME( m_cl_int, CL_PROGRAM_BINARY_TYPE_INTERMEDIATE );
+
+    // cl_khr_subgroups
+    // These enums were promoted to core in OpenCL 2.1.
+    //CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR    0x2033
+    //CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR       0x2034
+
+    // cl_khr_terminate_context
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_TERMINATE_CAPABILITY_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_TERMINATE_KHR );
+
+    // cl_khr_throttle_hints extension
+    ADD_ENUM_NAME( m_cl_int, CL_QUEUE_THROTTLE_KHR );
+
+    // cl_ext_atomic_counters
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_MAX_ATOMIC_COUNTERS_EXT );
+
+    // cl_ext_device_fission
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARTITION_EQUALLY_EXT );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARTITION_BY_COUNTS_EXT );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARTITION_BY_NAMES_EXT );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_EXT );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARENT_DEVICE_EXT );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARTITION_TYPES_EXT );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_AFFINITY_DOMAINS_EXT );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_REFERENCE_COUNT_EXT );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARTITION_STYLE_EXT );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARTITION_FAILED_EXT );
+    ADD_ENUM_NAME( m_cl_int, CL_INVALID_PARTITION_COUNT_EXT );
+    ADD_ENUM_NAME( m_cl_int, CL_INVALID_PARTITION_NAME_EXT );
+
+    // cl_altera_compiler_mode
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_COMPILER_MODE_ALTERA );
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_PROGRAM_EXE_LIBRARY_ROOT_ALTERA );
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_OFFLINE_DEVICE_ALTERA );
+
+    // cl_altera_device_temperature
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_CORE_TEMPERATURE_ALTERA );
+
+    // cl_amd_device_attribute_query
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_MAX_WORK_GROUP_SIZE_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PREFERRED_CONSTANT_BUFFER_SIZE_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PCIE_ID_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PROFILING_TIMER_OFFSET_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_TOPOLOGY_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_BOARD_NAME_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_GLOBAL_FREE_MEMORY_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SIMD_WIDTH_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_WAVEFRONT_WIDTH_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_GLOBAL_MEM_CHANNELS_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_GLOBAL_MEM_CHANNEL_BANKS_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_GLOBAL_MEM_CHANNEL_BANK_WIDTH_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_LOCAL_MEM_SIZE_PER_COMPUTE_UNIT_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_LOCAL_MEM_BANKS_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_THREAD_TRACE_SUPPORTED_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_GFXIP_MAJOR_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_GFXIP_MINOR_AMD );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_AVAILABLE_ASYNC_QUEUES_AMD );
+
+    // cl_amd_offline_devices
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_OFFLINE_DEVICES_AMD );
+
+    // cl_arm_get_core_id
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_COMPUTE_UNITS_BITFIELD_ARM );
+
+    // cl_arm_job_slot_selection
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_JOB_SLOTS_ARM );
+    ADD_ENUM_NAME( m_cl_int, CL_QUEUE_JOB_SLOT_ARM );
+
+    // cl_arm_printf extension
+    ADD_ENUM_NAME( m_cl_int, CL_PRINTF_CALLBACK_ARM );
+    ADD_ENUM_NAME( m_cl_int, CL_PRINTF_BUFFERSIZE_ARM );
+
+    // cl_arm_scheduling_controls
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_ARM );
+    ADD_ENUM_NAME( m_cl_int, CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_ARM );
+    ADD_ENUM_NAME( m_cl_int, CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_MODIFIER_ARM );
+    ADD_ENUM_NAME( m_cl_int, CL_QUEUE_KERNEL_BATCHING_ARM );
+
+    // cl_intel_accelerator
     ADD_ENUM_NAME( m_cl_int, CL_INVALID_ACCELERATOR_INTEL );
     ADD_ENUM_NAME( m_cl_int, CL_INVALID_ACCELERATOR_TYPE_INTEL );
     ADD_ENUM_NAME( m_cl_int, CL_INVALID_ACCELERATOR_DESC_INTEL );
     ADD_ENUM_NAME( m_cl_int, CL_ACCELERATOR_TYPE_NOT_SUPPORTED_INTEL );
 
-    // cl_accelerator_type_intel
-    //CL_ACCELERATOR_TYPE_MOTION_ESTIMATION_INTEL     0x0
-
-    // cl_accelerator_info_intel
+    // cl_intel_accelerator
     ADD_ENUM_NAME( m_cl_int, CL_ACCELERATOR_DESCRIPTOR_INTEL );
     ADD_ENUM_NAME( m_cl_int, CL_ACCELERATOR_REFERENCE_COUNT_INTEL );
     ADD_ENUM_NAME( m_cl_int, CL_ACCELERATOR_CONTEXT_INTEL );
     ADD_ENUM_NAME( m_cl_int, CL_ACCELERATOR_TYPE_INTEL );
 
-    // cl_motion_detect_desc_intel flags
+    // cl_intel_advanced_motion_estimation
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_ME_VERSION_INTEL );
+
+    // cl_intel_driver_diagnostics
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_SHOW_DIAGNOSTICS_INTEL );
+
+#if defined(_WIN32)
+    // cl_intel_dx9_media_sharing
+    // These error codes are shared with cl_khr_dx9_media_sharing.
+    //CL_INVALID_DX9_DEVICE_INTEL                   -1010
+    //CL_INVALID_DX9_RESOURCE_INTEL                 -1011
+    //CL_DX9_RESOURCE_ALREADY_ACQUIRED_INTEL        -1012
+    //CL_DX9_RESOURCE_NOT_ACQUIRED_INTEL            -1013
+
+    // cl_intel_dx9_media_sharing
+    ADD_ENUM_NAME( m_cl_int, CL_D3D9_DEVICE_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_D3D9EX_DEVICE_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_DXVA_DEVICE_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_PREFERRED_DEVICES_FOR_DX9_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_ALL_DEVICES_FOR_DX9_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_D3D9_DEVICE_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_D3D9EX_DEVICE_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_DXVA_DEVICE_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_MEM_DX9_RESOURCE_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_MEM_DX9_SHARED_HANDLE_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_IMAGE_DX9_PLANE_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_ACQUIRE_DX9_OBJECTS_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_RELEASE_DX9_OBJECTS_INTEL );
+#endif
+
+    // cl_intel_egl_image_yuv
+    ADD_ENUM_NAME( m_cl_int, CL_EGL_YUV_PLANE_INTEL );
+
+    // cl_intel_mem_force_host_memory
+    ADD_ENUM_NAME( m_cl_mem_flags, CL_MEM_FORCE_HOST_MEMORY_INTEL );
+
+    // cl_intel_motion_estimation
+
+    //CL_ACCELERATOR_TYPE_MOTION_ESTIMATION_INTEL     0x0
+
     //CL_ME_MB_TYPE_16x16_INTEL                       0x0
     //CL_ME_MB_TYPE_8x8_INTEL                         0x1
     //CL_ME_MB_TYPE_4x4_INTEL                         0x2
@@ -671,34 +890,8 @@ CEnumNameMap::CEnumNameMap()
     //CL_ME_VERSION_LEGACY_INTEL                      0x0
     //CL_ME_VERSION_ADVANCED_VER_1_INTEL              0x1
 
-    // cl_intel_egl_image_yuv
-    ADD_ENUM_NAME( m_cl_int, CL_EGL_YUV_PLANE_INTEL );
-
-    // cl_intel_simultaneous_sharing
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SIMULTANEOUS_INTEROPS_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_NUM_SIMULTANEOUS_INTEROPS_INTEL );
-
-    // cl_intel_thread_local_exec
-    ADD_ENUM_NAME( m_cl_command_queue_properties, CL_QUEUE_THREAD_LOCAL_EXEC_ENABLE_INTEL );
-
-    // cl_intel_va_api_media_sharing
-
-    ADD_ENUM_NAME( m_cl_int, CL_VA_API_DISPLAY_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_PREFERRED_DEVICES_FOR_VA_API_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_ALL_DEVICES_FOR_VA_API_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_VA_API_DISPLAY_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_MEM_VA_API_SURFACE_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_IMAGE_VA_API_PLANE_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_ACQUIRE_VA_API_MEDIA_SURFACES_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_RELEASE_VA_API_MEDIA_SURFACES_INTEL );
-
-    // Error Codes
-    ADD_ENUM_NAME( m_cl_int, CL_INVALID_VA_API_MEDIA_ADAPTER_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_INVALID_VA_API_MEDIA_SURFACE_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VA_API_MEDIA_SURFACE_ALREADY_ACQUIRED_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VA_API_MEDIA_SURFACE_NOT_ACQUIRED_INTEL );
-
     // cl_intel_packed_yuv
+
     ADD_ENUM_NAME( m_cl_int, CL_YUYV_INTEL );
     ADD_ENUM_NAME( m_cl_int, CL_UYVY_INTEL );
     ADD_ENUM_NAME( m_cl_int, CL_YVYU_INTEL );
@@ -719,93 +912,12 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_int, CL_KERNEL_SPILL_MEM_SIZE_INTEL );
     ADD_ENUM_NAME( m_cl_int, CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL );
 
-    // cl_intel_driver_diagnostics
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_SHOW_DIAGNOSTICS_INTEL );
+    // cl_intel_simultaneous_sharing
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SIMULTANEOUS_INTEROPS_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_NUM_SIMULTANEOUS_INTEROPS_INTEL );
 
-    // cl_intelx_video_enhancement
-    // This is the base-functionality VEBox extension.
-    // Note: These are preview enum names and values!
-
-    // cl_device_info
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_VE_VERSION_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_VE_ENGINE_COUNT_INTEL );
-
-    // cl_queue_properties - TBD: is this a general purpose enum or a bit?
-    ADD_ENUM_NAME( m_cl_int, CL_QUEUE_VE_ENABLE_INTEL );
-
-    // attribute_ids for cl_vebox_attrib_desc_intel
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_DENOISE_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_DEINTERLACE_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_HOT_PIXEL_CORR_INTEL );
-
-    // cl_accelerator_info_intel
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_HISTOGRAMS_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_STATISTICS_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_STMM_INPUT_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_STMM_OUTPUT_INTEL );
-
-    // cl_intelx_ve_color_pipeline
-    // Note: These are preview enum names and values!
-
-    // cl_device_info
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_VE_COLOR_PIPE_VERSION_INTEL );
-
-    // attribute_ids for cl_vebox_attrib_desc_intel
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_STD_STE_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_GAMUT_COMP_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_GECC_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_ACE_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_ACE_ADV_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_TCC_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_PROC_AMP_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_BACK_END_CSC_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_AOI_ALPHA_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_CCM_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_FWD_GAMMA_CORRECT_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_FRONT_END_CSC_INTEL );
-
-    // cl_intelx_ve_camera_pipeline
-    // Note, these are preview enum names and values!
-
-    // cl_device_info
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_VE_CAMERA_PIPE_VERSION_INTEL );
-
-    // attribute_ids for cl_vebox_attrib_desc_intel
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_BLACK_LEVEL_CORR_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_DEMOSAIC_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_WHITE_BALANCE_CORR_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_VE_ACCELERATOR_ATTRIB_VIGNETTE_INTEL );
-
-    // HEVC PAK
-    // Note, this extension is still in development!
-
-    // cl_device_info
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PAK_VERSION_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PAK_AVAILABLE_CODECS_INTEL );
-
-    // cl_queue_properties / cl_command_queue_info
-    ADD_ENUM_NAME( m_cl_int, CL_QUEUE_PAK_ENABLE_INTEL );
-
-    // cl_accelerator_info_intel
-    ADD_ENUM_NAME( m_cl_int, CL_PAK_CTU_COUNT_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_PAK_CTU_WIDTH_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_PAK_CTU_HEIGHT_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_PAK_MAX_INTRA_DEPTH_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_PAK_MAX_INTER_DEPTH_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_PAK_NUM_CUS_PER_CTU_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_PAK_MV_BUFFER_SIZE_INTEL );
-
-    // Error Codes
-    // These are currently all mapped to CL_INVALID_VALUE.
-    // Need official error code assignment.
-    //ADD_ENUM_NAME( m_cl_int, CL_INVALID_PAK_CTU_SIZE_INTEL );
-    //ADD_ENUM_NAME( m_cl_int, CL_INVALID_PAK_TU_SIZE_INTEL );
-    //ADD_ENUM_NAME( m_cl_int, CL_INVALID_PAK_TU_INTRA_DEPTH_INTEL );
-    //ADD_ENUM_NAME( m_cl_int, CL_INVALID_PAK_TU_INTER_DEPTH_INTEL );
-    //ADD_ENUM_NAME( m_cl_int, CL_INVALID_PAK_BITRATE_RANGE_INTEL );
-    //ADD_ENUM_NAME( m_cl_int, CL_INVALID_PAK_INSERTION_INTEL );
-    //ADD_ENUM_NAME( m_cl_int, CL_INVALID_PAK_CTU_POSITION_INTEL );
-    //ADD_ENUM_NAME( m_cl_int, CL_INVALID_PAK_REFERENCE_IMAGE_INDEX_INTEL );
+    // cl_intel_thread_local_exec
+    ADD_ENUM_NAME( m_cl_command_queue_properties, CL_QUEUE_THREAD_LOCAL_EXEC_ENABLE_INTEL );
 
     // cl_intel_unified_shared_memory
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL );
@@ -848,97 +960,21 @@ CEnumNameMap::CEnumNameMap()
 
     ADD_ENUM_NAME( m_cl_mem_alloc_flags_intel, CL_MEM_ALLOC_WRITE_COMBINED_INTEL );
 
-    // cl_intel_mem_force_host_memory
-    ADD_ENUM_NAME( m_cl_mem_flags, CL_MEM_FORCE_HOST_MEMORY_INTEL );
+    // cl_intel_va_api_media_sharing
 
-    // Altera Extensions:
+    ADD_ENUM_NAME( m_cl_int, CL_VA_API_DISPLAY_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_PREFERRED_DEVICES_FOR_VA_API_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_ALL_DEVICES_FOR_VA_API_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_VA_API_DISPLAY_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_MEM_VA_API_SURFACE_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_IMAGE_VA_API_PLANE_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_ACQUIRE_VA_API_MEDIA_SURFACES_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_RELEASE_VA_API_MEDIA_SURFACES_INTEL );
 
-    // cl_altera_device_temperature
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_CORE_TEMPERATURE_ALTERA );
-
-    // cl_altera_compiler_mode
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_COMPILER_MODE_ALTERA );
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_PROGRAM_EXE_LIBRARY_ROOT_ALTERA );
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_OFFLINE_DEVICE_ALTERA );
-
-    // These are enums from the Khronos cl_gl.h header file:
-
-    // cl_gl_object_type
-    ADD_ENUM_NAME( m_cl_int, CL_GL_OBJECT_BUFFER );
-    ADD_ENUM_NAME( m_cl_int, CL_GL_OBJECT_TEXTURE2D );
-    ADD_ENUM_NAME( m_cl_int, CL_GL_OBJECT_TEXTURE3D );
-    ADD_ENUM_NAME( m_cl_int, CL_GL_OBJECT_RENDERBUFFER );
-    ADD_ENUM_NAME( m_cl_int, CL_GL_OBJECT_TEXTURE2D_ARRAY );
-    ADD_ENUM_NAME( m_cl_int, CL_GL_OBJECT_TEXTURE1D );
-    ADD_ENUM_NAME( m_cl_int, CL_GL_OBJECT_TEXTURE1D_ARRAY );
-    ADD_ENUM_NAME( m_cl_int, CL_GL_OBJECT_TEXTURE_BUFFER );
-
-    // cl_gl_texture_info
-    ADD_ENUM_NAME( m_cl_int, CL_GL_TEXTURE_TARGET );
-    ADD_ENUM_NAME( m_cl_int, CL_GL_MIPMAP_LEVEL );
-    ADD_ENUM_NAME( m_cl_int, CL_GL_NUM_SAMPLES );
-
-    // Error Code
-    ADD_ENUM_NAME( m_cl_int, CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR );
-
-    // cl_gl_context_info
-    ADD_ENUM_NAME( m_cl_int, CL_CURRENT_DEVICE_FOR_GL_CONTEXT_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICES_FOR_GL_CONTEXT_KHR );
-
-    // cl_context_properties
-    ADD_ENUM_NAME( m_cl_int, CL_GL_CONTEXT_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_EGL_DISPLAY_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_GLX_DISPLAY_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_WGL_HDC_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_CGL_SHAREGROUP_KHR );
-
-    // These enums are from the Khronos cl_gl_ext.h header file:
-
-    // cl_khr_gl_event
-    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_GL_FENCE_SYNC_OBJECT_KHR );
-
-    // These are enums from the Khronos cl_ext.h header file:
-
-    // cl_khr_il_program
-    // These enums are core in OpenCL 2.1.
-    //CL_DEVICE_IL_VERSION_KHR                        0x105B
-    //CL_PROGRAM_IL_KHR                               0x1169
-
-    // cl_khr_icd
-    ADD_ENUM_NAME( m_cl_int, CL_PLATFORM_ICD_SUFFIX_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_PLATFORM_NOT_FOUND_KHR );
-
-    // cl_khr_initalize_memory
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_MEMORY_INITIALIZE_KHR );
-
-    // cl_khr_terminate_context
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_TERMINATE_CAPABILITY_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_TERMINATE_KHR );
-
-    // cl_khr_spir
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SPIR_VERSIONS );
-    ADD_ENUM_NAME( m_cl_int, CL_PROGRAM_BINARY_TYPE_INTERMEDIATE );
-
-    // cl_khr_subgroups
-    // These enums were promoted to core in OpenCL 2.1.
-    //CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR    0x2033
-    //CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR       0x2034
-
-    // cl_khr_priority_hints extension
-    ADD_ENUM_NAME( m_cl_int, CL_QUEUE_PRIORITY_KHR );
-
-    // cl_khr_throttle_hints extension
-    ADD_ENUM_NAME( m_cl_int, CL_QUEUE_THROTTLE_KHR );
-
-    // cl_khr_extended_versioning extension
-    // Most enums for this extension were added to OpenCL 3.0.
-    //CL_PLATFORM_NUMERIC_VERSION_KHR                  0x0906
-    //CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR          0x0907
-    //CL_DEVICE_NUMERIC_VERSION_KHR                    0x105E
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR );
-    //CL_DEVICE_EXTENSIONS_WITH_VERSION_KHR            0x1060
-    //CL_DEVICE_ILS_WITH_VERSION_KHR                   0x1061
-    //CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR      0x1062
+    ADD_ENUM_NAME( m_cl_int, CL_INVALID_VA_API_MEDIA_ADAPTER_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_INVALID_VA_API_MEDIA_SURFACE_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_VA_API_MEDIA_SURFACE_ALREADY_ACQUIRED_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_VA_API_MEDIA_SURFACE_NOT_ACQUIRED_INTEL );
 
     // cl_nv_device_attribute_query
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV );
@@ -951,49 +987,6 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT_NV );
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PCI_BUS_ID_NV );
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PCI_SLOT_ID_NV );
-
-    // cl_ext_atomic_counters
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_MAX_ATOMIC_COUNTERS_EXT );
-
-    // cl_amd_device_attribute_query
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_MAX_WORK_GROUP_SIZE_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PREFERRED_CONSTANT_BUFFER_SIZE_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PCIE_ID_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PROFILING_TIMER_OFFSET_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_TOPOLOGY_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_BOARD_NAME_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_GLOBAL_FREE_MEMORY_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SIMD_WIDTH_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_WAVEFRONT_WIDTH_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_GLOBAL_MEM_CHANNELS_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_GLOBAL_MEM_CHANNEL_BANKS_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_GLOBAL_MEM_CHANNEL_BANK_WIDTH_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_LOCAL_MEM_SIZE_PER_COMPUTE_UNIT_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_LOCAL_MEM_BANKS_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_THREAD_TRACE_SUPPORTED_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_GFXIP_MAJOR_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_GFXIP_MINOR_AMD );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_AVAILABLE_ASYNC_QUEUES_AMD );
-
-    // cl_amd_offline_devices
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_OFFLINE_DEVICES_AMD );
-
-    // cl_ext_device_fission extension
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARTITION_EQUALLY_EXT );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARTITION_BY_COUNTS_EXT );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARTITION_BY_NAMES_EXT );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_EXT );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARENT_DEVICE_EXT );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARTITION_TYPES_EXT );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_AFFINITY_DOMAINS_EXT );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_REFERENCE_COUNT_EXT );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARTITION_STYLE_EXT );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARTITION_FAILED_EXT );
-    ADD_ENUM_NAME( m_cl_int, CL_INVALID_PARTITION_COUNT_EXT );
-    ADD_ENUM_NAME( m_cl_int, CL_INVALID_PARTITION_NAME_EXT );
 
     // cl_qcom_ext_host_ptr extension
     ADD_ENUM_NAME( m_cl_mem_flags, CL_MEM_EXT_HOST_PTR_QCOM );
@@ -1010,103 +1003,17 @@ CEnumNameMap::CEnumNameMap()
     // cl_qcom_ion_host_ptr extension
     ADD_ENUM_NAME( m_cl_int, CL_MEM_ION_HOST_PTR_QCOM );
 
-    // cl_arm_printf extension
-    ADD_ENUM_NAME( m_cl_int, CL_PRINTF_CALLBACK_ARM );
-    ADD_ENUM_NAME( m_cl_int, CL_PRINTF_BUFFERSIZE_ARM );
+    // Unofficial kernel profiling extension:
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_KERNEL_PROFILING_MODES_COUNT_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_KERNEL_PROFILING_MODE_INFO_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_KERNEL_IL_SYMBOLS_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_KERNEL_BINARY_PROGRAM_INTEL );
 
-    // cl_arm_get_core_id
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_COMPUTE_UNITS_BITFIELD_ARM );
-
-    // cl_arm_job_slot_selection
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_JOB_SLOTS_ARM );
-    ADD_ENUM_NAME( m_cl_int, CL_QUEUE_JOB_SLOT_ARM );
-
-    // cl_arm_scheduling_controls
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_ARM );
-    ADD_ENUM_NAME( m_cl_int, CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_ARM );
-    ADD_ENUM_NAME( m_cl_int, CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_MODIFIER_ARM );
-    ADD_ENUM_NAME( m_cl_int, CL_QUEUE_KERNEL_BATCHING_ARM );
-
-#if defined(_WIN32)
-    // cl_khr_d3d10_sharing
-    ADD_ENUM_NAME( m_cl_int, CL_INVALID_D3D10_DEVICE_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_INVALID_D3D10_RESOURCE_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_D3D10_RESOURCE_ALREADY_ACQUIRED_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_D3D10_RESOURCE_NOT_ACQUIRED_KHR );
-
-    // cl_khr_d3d10_sharing
-    ADD_ENUM_NAME( m_cl_int, CL_D3D10_DEVICE_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_D3D10_DXGI_ADAPTER_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_PREFERRED_DEVICES_FOR_D3D10_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_ALL_DEVICES_FOR_D3D10_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_D3D10_DEVICE_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_D3D10_PREFER_SHARED_RESOURCES_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_MEM_D3D10_RESOURCE_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_IMAGE_D3D10_SUBRESOURCE_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_ACQUIRE_D3D10_OBJECTS_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_RELEASE_D3D10_OBJECTS_KHR );
-
-    // cl_khr_d3d11_sharing
-    ADD_ENUM_NAME( m_cl_int, CL_INVALID_D3D11_DEVICE_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_INVALID_D3D11_RESOURCE_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_D3D11_RESOURCE_ALREADY_ACQUIRED_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_D3D11_RESOURCE_NOT_ACQUIRED_KHR );
-
-    // cl_khr_d3d11_sharing
-    ADD_ENUM_NAME( m_cl_int, CL_D3D11_DEVICE_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_D3D11_DXGI_ADAPTER_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_PREFERRED_DEVICES_FOR_D3D11_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_ALL_DEVICES_FOR_D3D11_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_D3D11_DEVICE_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_D3D11_PREFER_SHARED_RESOURCES_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_MEM_D3D11_RESOURCE_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_IMAGE_D3D11_SUBRESOURCE_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_ACQUIRE_D3D11_OBJECTS_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_RELEASE_D3D11_OBJECTS_KHR );
-
-    // cl_khr_dx9_media_sharing
-    ADD_ENUM_NAME( m_cl_int, CL_INVALID_DX9_MEDIA_ADAPTER_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_INVALID_DX9_MEDIA_SURFACE_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_DX9_MEDIA_SURFACE_ALREADY_ACQUIRED_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_DX9_MEDIA_SURFACE_NOT_ACQUIRED_KHR );
-
-    // cl_khr_dx9_media_sharing
-    ADD_ENUM_NAME( m_cl_int, CL_ADAPTER_D3D9_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_ADAPTER_D3D9EX_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_ADAPTER_DXVA_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_PREFERRED_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_ALL_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_ADAPTER_D3D9_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_ADAPTER_D3D9EX_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_ADAPTER_DXVA_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_MEM_DX9_MEDIA_ADAPTER_TYPE_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_MEM_DX9_MEDIA_SURFACE_INFO_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_IMAGE_DX9_MEDIA_PLANE_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_ACQUIRE_DX9_MEDIA_SURFACES_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_RELEASE_DX9_MEDIA_SURFACES_KHR );
-
-    // cl_intel_dx9_media_sharing
-    // These error codes are shared with cl_khr_dx9_media_sharing.
-    //CL_INVALID_DX9_DEVICE_INTEL                   -1010
-    //CL_INVALID_DX9_RESOURCE_INTEL                 -1011
-    //CL_DX9_RESOURCE_ALREADY_ACQUIRED_INTEL        -1012
-    //CL_DX9_RESOURCE_NOT_ACQUIRED_INTEL            -1013
-
-    // cl_intel_dx9_media_sharing
-    ADD_ENUM_NAME( m_cl_int, CL_D3D9_DEVICE_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_D3D9EX_DEVICE_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_DXVA_DEVICE_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_PREFERRED_DEVICES_FOR_DX9_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_ALL_DEVICES_FOR_DX9_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_D3D9_DEVICE_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_D3D9EX_DEVICE_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_DXVA_DEVICE_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_MEM_DX9_RESOURCE_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_MEM_DX9_SHARED_HANDLE_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_IMAGE_DX9_PLANE_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_ACQUIRE_DX9_OBJECTS_INTEL );
-    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_RELEASE_DX9_OBJECTS_INTEL );
-#endif
+    // Unofficial extension (for now) for VTune Debug Info:
+    ADD_ENUM_NAME( m_cl_int, CL_PROGRAM_DEBUG_INFO_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_PROGRAM_DEBUG_INFO_SIZES_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_KERNEL_BINARIES_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_KERNEL_BINARY_SIZES_INTEL );
 
 #if !defined(__ANDROID__) && !defined(__APPLE__)
     // gl texture targets


### PR DESCRIPTION
## Description of Changes

It was becoming difficult to find extensions in the intercept layer extension header file because they were added arbitrarily.  This
change alphabetizes them for easier maintenance.

I'll consider switching to the Khronos headers for extensions at some point (but not now).

## Testing Done

No functional changes, but I did basic touch testing to ensure I didn't unintentionally break something.
