### PR TITLE
add enum tracing for cl_ext_cxx_for_opencl

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -435,6 +435,11 @@ cl_int CL_API_CALL clGetKernelSubGroupInfoKHR(
 #define CL_DEVICE_MAX_ATOMIC_COUNTERS_EXT           0x4032
 
 ///////////////////////////////////////////////////////////////////////////////
+// cl_ext_cxx_for_opencl
+
+#define CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT 0x4230
+
+///////////////////////////////////////////////////////////////////////////////
 // cl_ext_device_fission
 
 #define CL_DEVICE_PARTITION_EQUALLY_EXT             0x4050

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -742,6 +742,10 @@ CEnumNameMap::CEnumNameMap()
     // cl_ext_atomic_counters
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_MAX_ATOMIC_COUNTERS_EXT );
 
+    // cl_ext_cxx_for_opencl
+
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT );
+
     // cl_ext_device_fission
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARTITION_EQUALLY_EXT );
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PARTITION_BY_COUNTS_EXT );


### PR DESCRIPTION
## Description of Changes

Add the `CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT` enum added by `cl_ext_cxx_for_opencl` to the enum map.

## Testing Done

Verified that `CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT` is properly decoded in a call log.
