### PR TITLE
ignore priority and throttle hints for perf counter queues

### DIFF
--- a/intercept/mdapi/intercept_mdapi.cpp
+++ b/intercept/mdapi/intercept_mdapi.cpp
@@ -39,8 +39,9 @@ static bool convertPropertiesToOCL1_2(
         // Convert properties from array of pairs (OCL2.0) to bitfield (OCL1.2)
         for( int i = 0; properties[ i ] != 0; i += 2 )
         {
-            if( properties[ i ] == CL_QUEUE_PROPERTIES )
+            switch( properties[ i ] )
             {
+            case CL_QUEUE_PROPERTIES:
                 switch( properties[ i + 1 ] )
                 {
                 case 0: // no special queue properties
@@ -52,9 +53,12 @@ static bool convertPropertiesToOCL1_2(
                 default:
                     return false;
                 }
-            }
-            else
-            {
+                break;
+            case CL_QUEUE_PRIORITY_KHR:
+            case CL_QUEUE_THROTTLE_KHR:
+                // Skip / ignore these properties.
+                break;
+            default:
                 return false;
             }
         }


### PR DESCRIPTION
## Description of Changes

Ignore priority hint and throttle hints when creating MDAPI perf counter command queues.  This may have an effect on the behavior of the program, but so will enabling performance counters, and by ignoring priority hints and throttle hints we are able to collect performance counters in more cases.

This may be a temporary change, only until we are able to create MDAPI perf counter command queues with other optional command queue properties.

## Testing Done

Verified that a perf counter command queue can be created even if the command queue properties include priority hints or throttle hints.
