### PR TITLE
only activate and deactivate metric sets once

### DIFF
--- a/intercept/mdapi/MetricsDiscoveryHelper.h
+++ b/intercept/mdapi/MetricsDiscoveryHelper.h
@@ -139,6 +139,7 @@ private:
     OpenMetricsDeviceFromFile_fn    OpenMetricsDeviceFromFile;
 
     bool                    m_Initialized;
+    bool                    m_Activated;
     bool                    m_IncludeMaxValues;
     uint32_t                m_APIMask;
     uint32_t                m_CategoryMask;

--- a/intercept/mdapi/intercept_mdapi.cpp
+++ b/intercept/mdapi/intercept_mdapi.cpp
@@ -187,8 +187,6 @@ cl_command_queue CLIntercept::createMDAPICommandQueue(
             {
                 log( "clCreatePerfCountersCommandQueueINTEL() returned NULL!\n" );
             }
-
-            m_pMDHelper->DeactivateMetricSet();
         }
         else
         {


### PR DESCRIPTION
## Description of Changes

Rather than activating and deactivating metric sets when a perf counter queue is created, activate metric sets once, then
deactivate metric sets as part of MDAPI shutdown.

## Testing Done

Tested a simple app and was able to collect MDAPI event-based metrics on Windows.  I was able to collect MDAPI event-based metrics on Linux also, but this may need a small fix for older kernels.  I will file a metrics-library issue to track the Linux fix.