### PR TITLE
include search for libOpenCL.so.1 on Linux

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -104,8 +104,11 @@ For Windows:
 For Linux:
 
 - `./real_libOpenCL.so`
+- `/usr/lib/x86_64-linux-gnu/libOpenCL.so.1`
 - `/usr/lib/x86_64-linux-gnu/libOpenCL.so`
+- `/opt/intel/opencl/lib64/libOpenCL.so.1`
 - `/opt/intel/opencl/lib64/libOpenCL.so`
+- `/glob/development-tools/oneapi/inteloneapi/compiler/latest/linux/lib/libOpenCL.so.1`
 - `/glob/development-tools/oneapi/inteloneapi/compiler/latest/linux/lib/libOpenCL.so`
 
 For Android:

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -518,8 +518,11 @@ bool CLIntercept::init()
         const std::string libNames[] =
         {
             "./real_libOpenCL.so",
+            "/usr/lib/x86_64-linux-gnu/libOpenCL.so.1",
             "/usr/lib/x86_64-linux-gnu/libOpenCL.so",
+            "/opt/intel/opencl/lib64/libOpenCL.so.1",
             "/opt/intel/opencl/lib64/libOpenCL.so",
+            "/glob/development-tools/oneapi/inteloneapi/compiler/latest/linux/lib/libOpenCL.so.1",
             "/glob/development-tools/oneapi/inteloneapi/compiler/latest/linux/lib/libOpenCL.so",
         };
 

--- a/scripts/generate_controls_doc.py
+++ b/scripts/generate_controls_doc.py
@@ -130,8 +130,11 @@ For Windows:
 For Linux:
 
 - `./real_libOpenCL.so`
+- `/usr/lib/x86_64-linux-gnu/libOpenCL.so.1`
 - `/usr/lib/x86_64-linux-gnu/libOpenCL.so`
+- `/opt/intel/opencl/lib64/libOpenCL.so.1`
 - `/opt/intel/opencl/lib64/libOpenCL.so`
+- `/glob/development-tools/oneapi/inteloneapi/compiler/latest/linux/lib/libOpenCL.so.1`
 - `/glob/development-tools/oneapi/inteloneapi/compiler/latest/linux/lib/libOpenCL.so`
 
 For Android:


### PR DESCRIPTION
## Description of Changes

Since some Linux systems and package managers only include a `libOpenCL.so` file when a dev package is installed, the intercept layer should also search for `libOpenCL.so.1` as the "real" OpenCL ICD loader, which is typically installed by ICD loader packages.

## Testing Done

Verified that OpenCL apps run correctly when using the `libOpenCL.so.1` file as the "real" OpenCL ICD loader.
