### PR TITLE
improve Chrome Tracing when queues are recycled

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -761,9 +761,9 @@ CL_API_ENTRY cl_command_queue CL_API_CALL CLIRN(clCreateCommandQueue)(
         CREATE_COMMAND_QUEUE_PROPERTIES_CLEANUP( newProperties );
         CHECK_ERROR( errcode_ret[0] );
         ITT_REGISTER_COMMAND_QUEUE( retVal, false );
-        CHROME_REGISTER_COMMAND_QUEUE( retVal );
         ADD_OBJECT_ALLOCATION( retVal );
         CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+        ADD_QUEUE( retVal );
 
         return retVal;
     }
@@ -829,6 +829,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseCommandQueue)(
 
     if( pIntercept && pIntercept->dispatch().clReleaseCommandQueue )
     {
+        REMOVE_QUEUE( command_queue );
+
         cl_uint ref_count = 0;
         if( pIntercept->callLogging() )
         {
@@ -6335,6 +6337,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL CLIRN(clCreateCommandQueueWithProperti
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
         CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+        ADD_QUEUE( retVal );
 
         return retVal;
     }
@@ -6426,6 +6429,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithPropertiesKHR(
             CHECK_ERROR( errcode_ret[0] );
             ADD_OBJECT_ALLOCATION( retVal );
             CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+            ADD_QUEUE( retVal );
 
             return retVal;
         }
@@ -7939,7 +7943,6 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreatePerfCountersCommandQueueINTEL(
             CHECK_ERROR( errcode_ret[0] );
             ADD_OBJECT_ALLOCATION( retVal );
             ITT_REGISTER_COMMAND_QUEUE( retVal, true );
-            CHROME_REGISTER_COMMAND_QUEUE( retVal );
             CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
             return retVal;

--- a/intercept/src/instrumentation.h
+++ b/intercept/src/instrumentation.h
@@ -167,9 +167,3 @@ inline void add_task_metadata_array(
 #define ITT_RELEASE_COMMAND_QUEUE(_queue)
 
 #endif
-
-#define CHROME_REGISTER_COMMAND_QUEUE(_queue)                                                   \
-    if( pIntercept->config().ChromePerformanceTiming )                                          \
-    {                                                                                           \
-        pIntercept->chromeRegisterCommandQueue( _queue );                                       \
-    }


### PR DESCRIPTION
## Description of Changes

Assigns a unique queue number to each command queue and uses this for chrome tracing instead of the queue address.  This properly handles the case when queues are recycled and two different queues end up with the same address.

Also, names the host thread, for clarity.

## Testing Done

Tested chrome tracing with an app that frequently creates and destroys queues.  Confirmed that chrome tracing shows an unique track for each queue even when two queues have the same address.