### PR TITLE
Build cliloader by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ elseif(UNIX)
     endif()
 endif()
 
-option(ENABLE_CLILOADER "Enable cliloader Support and Build the Executable")
+option(ENABLE_CLILOADER "Enable cliloader Support and Build the Executable" ON)
 option(ENABLE_CLIPROF "Enable cliprof Support and Build the Executable")
 option(ENABLE_ITT "Enable ITT (Instrumentation Tracing Technology) API Support")
 option(ENABLE_MDAPI "Enable MDAPI Support" ON)

--- a/docs/build.md
+++ b/docs/build.md
@@ -122,7 +122,7 @@ See your CMake documentation for more details.
 |:---------|:-----|:------------|
 | CMAKE\_BUILD\_TYPE | STRING | Build type.  Does not affect multi-configuration generators, such as Visual Studio solution files.  Default: `Release`.  Other options: `Debug`
 | CMAKE\_INSTALL\_PREFIX | PATH | Install directory prefix.
-| ENABLE_CLILOADER | BOOL | Enables building the cliloader utilty (cliloader is intended to replace the old cliprof utility).  Additionally, when required, enables code in the Intercept Layer for OpenCL Applications itself to enable cliloader functionality.  Default: `FALSE`
+| ENABLE_CLILOADER | BOOL | Enables building the cliloader utilty (cliloader is intended to replace the old cliprof utility).  Additionally, when required, enables code in the Intercept Layer for OpenCL Applications itself to enable cliloader functionality.  Default: `TRUE`
 | ENABLE_CLIPROF | BOOL | Enables building the old cliprof loader utility.  Additionally, when required, enables code in the Intercept Layer for OpenCL Applications itself to enable cliprof functionality.  Default: `FALSE`
 | ENABLE_ITT | BOOL | Enables support for Instrumentation and Tracing Techology APIs, which can be used to display OpenCL events on Intel(R) VTune(tm) timegraphs.  Default: `FALSE`
 | ENABLE_KERNEL_OVERRIDES | BOOL | Enables embedding kernel strings to override precompiled kernels and built-in kernels.  Supported for Linux and Android builds only, since Windows builds always embeds kernel strings, and embedding kernel strings is not support for OSX (yet!).  Default: `TRUE`

--- a/docs/cliloader.md
+++ b/docs/cliloader.md
@@ -8,13 +8,9 @@ That's it!
 
 ## How to Build cliloader
 
-`cliloader` is currently not built by default.
-To build `cliloader`, set `ENABLE_CLILOADER` when generating build files using CMake.
-For example:
+`cliloader` is built by default.
 
-````
-> cmake -DENABLE_CLILOADER=1 ..
-````
+To not build `cliloader`, pass `-DENABLE_CLILOADER=FALSE` to `cmake`.
 
 Some operating systems require additional code in the Intercept Layer for OpenCL Applications DLL / shared library to function correctly with the `cliloader` loader utility.
 When needed, this additional code is included when build files are generated when `ENABLE_CLILOADER` is set.


### PR DESCRIPTION
I don't think it hurts, and makes building easier.

Tested.