### PR TITLE
fix logging format specifiers for size_t

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -400,7 +400,7 @@ CL_API_ENTRY cl_context CL_API_CALL CLIRN(clCreateContext)(
                 devices,
                 deviceInfo );
         }
-        CALL_LOGGING_ENTER( "properties = [ %s ], num_devices = %d, devices = [ %s ]",
+        CALL_LOGGING_ENTER( "properties = [ %s ], num_devices = %u, devices = [ %s ]",
             contextProperties.c_str(),
             num_devices,
             deviceInfo.c_str() );
@@ -963,7 +963,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateBuffer)(
 
     if( pIntercept && pIntercept->dispatch().clCreateBuffer )
     {
-        CALL_LOGGING_ENTER( "context = %p, flags = %s (%llX), size = %d, host_ptr = %p",
+        CALL_LOGGING_ENTER( "context = %p, flags = %s (%llX), size = %zu, host_ptr = %p",
             context,
             pIntercept->enumName().name_mem_flags( flags ).c_str(),
             flags,
@@ -1016,7 +1016,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateBufferWithProperties)(
                 properties,
                 propsStr );
         }
-        CALL_LOGGING_ENTER( "context = %p, properties = [ %s ], flags = %s (%llX), size = %d, host_ptr = %p",
+        CALL_LOGGING_ENTER( "context = %p, properties = [ %s ], flags = %s (%llX), size = %zu, host_ptr = %p",
             context,
             propsStr.c_str(),
             pIntercept->enumName().name_mem_flags( flags ).c_str(),
@@ -1067,7 +1067,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateBufferNV(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clCreateBufferNV )
         {
-            CALL_LOGGING_ENTER( "context = %p, flags = %s (%llX), flags_NV = %llX, size = %d, host_ptr = %p",
+            CALL_LOGGING_ENTER( "context = %p, flags = %s (%llX), flags_NV = %llX, size = %zu, host_ptr = %p",
                 context,
                 pIntercept->enumName().name_mem_flags( flags ).c_str(),
                 flags,
@@ -1173,14 +1173,14 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateImage)(
                 "format->channel_order = %s, "
                 "format->channel_data_type = %s, "
                 "desc->type = %s, "
-                "desc->width = %d, "
-                "desc->height = %d, "
-                "desc->depth = %d, "
-                "desc->array_size = %d, "
-                "desc->row_pitch = %d, "
-                "desc->slice_pitch = %d, "
-                "desc->num_mip_levels = %d, "
-                "desc->num_samples = %d, "
+                "desc->width = %zu, "
+                "desc->height = %zu, "
+                "desc->depth = %zu, "
+                "desc->array_size = %zu, "
+                "desc->row_pitch = %zu, "
+                "desc->slice_pitch = %zu, "
+                "desc->num_mip_levels = %u, "
+                "desc->num_samples = %u, "
                 "desc->mem_object = %p, "
                 "host_ptr = %p ",
                 context,
@@ -1260,14 +1260,14 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateImageWithProperties)(
                 "format->channel_order = %s, "
                 "format->channel_data_type = %s, "
                 "desc->type = %s, "
-                "desc->width = %d, "
-                "desc->height = %d, "
-                "desc->depth = %d, "
-                "desc->array_size = %d, "
-                "desc->row_pitch = %d, "
-                "desc->slice_pitch = %d, "
-                "desc->num_mip_levels = %d, "
-                "desc->num_samples = %d, "
+                "desc->width = %zu, "
+                "desc->height = %zu, "
+                "desc->depth = %zu, "
+                "desc->array_size = %zu, "
+                "desc->row_pitch = %zu, "
+                "desc->slice_pitch = %zu, "
+                "desc->num_mip_levels = %u, "
+                "desc->num_samples = %u, "
                 "desc->mem_object = %p, "
                 "host_ptr = %p ",
                 context,
@@ -1340,9 +1340,9 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateImage2D)(
                 "flags = %s (%llX), "
                 "format->channel_order = %s, "
                 "format->channel_data_type = %s, "
-                "image_width = %d, "
-                "image_height = %d, "
-                "image_row_pitch = %d, "
+                "image_width = %zu, "
+                "image_height = %zu, "
+                "image_row_pitch = %zu, "
                 "host_ptr = %p ",
                 context,
                 pIntercept->enumName().name_mem_flags( flags ).c_str(),
@@ -1409,10 +1409,10 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateImage3D)(
                 "flags = %s (%llX), "
                 "format->channel_order = %s, "
                 "format->channel_data_type = %s, "
-                "image_width = %d, "
-                "image_height = %d, "
-                "image_row_pitch = %d, "
-                "image_slice_pitch = %d, "
+                "image_width = %zu, "
+                "image_height = %zu, "
+                "image_row_pitch = %zu, "
+                "image_slice_pitch = %zu, "
                 "host_ptr = %p ",
                 context,
                 pIntercept->enumName().name_mem_flags( flags ).c_str(),
@@ -1897,7 +1897,7 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clCreateProgramWithSource)(
         INJECT_PROGRAM_SOURCE( count, strings, lengths, singleString, hash );
         PREPEND_PROGRAM_SOURCE( count, strings, lengths, singleString, hash );
 
-        CALL_LOGGING_ENTER( "context = %p, count = %d",
+        CALL_LOGGING_ENTER( "context = %p, count = %u",
             context,
             count );
         CHECK_ERROR_INIT( errcode_ret );
@@ -1969,7 +1969,7 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clCreateProgramWithBinary)(
 
         COMPUTE_BINARY_HASH( num_devices, lengths, binaries, hash );
 
-        CALL_LOGGING_ENTER( "context = %p, num_devices = %d",
+        CALL_LOGGING_ENTER( "context = %p, num_devices = %u",
             context,
             num_devices );
         CHECK_ERROR_INIT( errcode_ret );
@@ -2030,7 +2030,7 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clCreateProgramWithBuiltInKernels)(
 
     if( pIntercept && pIntercept->dispatch().clCreateProgramWithBuiltInKernels )
     {
-        CALL_LOGGING_ENTER( "context = %p, num_devices = %d, kernel_names = [ %s ]",
+        CALL_LOGGING_ENTER( "context = %p, num_devices = %u, kernel_names = [ %s ]",
             context,
             num_devices,
             kernel_names );
@@ -2363,10 +2363,10 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetProgramSpecializationConstant)(
 
     if( pIntercept && pIntercept->dispatch().clSetProgramSpecializationConstant )
     {
-        CALL_LOGGING_ENTER( "program = %p, spec_id = %u, spec_size = %u",
+        CALL_LOGGING_ENTER( "program = %p, spec_id = %u, spec_size = %zu",
             program,
             spec_id,
-            (cl_uint)spec_size );
+            spec_size );
         CPU_PERFORMANCE_TIMING_START();
 
         cl_int  retVal = pIntercept->dispatch().clSetProgramSpecializationConstant(
@@ -3300,7 +3300,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReadBuffer)(
         if( pIntercept->nullEnqueue() == false )
         {
             CALL_LOGGING_ENTER(
-                "queue = %p, buffer = %p, %s, offset = %d, cb = %d, ptr = %p",
+                "queue = %p, buffer = %p, %s, offset = %zu, cb = %zu, ptr = %p",
                 command_queue,
                 buffer,
                 blocking_read ? "blocking" : "non-blocking",
@@ -3395,7 +3395,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReadBufferRect)(
                 ( region != NULL ) )
             {
                 CALL_LOGGING_ENTER(
-                    "queue = %p, buffer = %p, %s, buffer_origin = < %d, %d, %d >, host_origin = < %d, %d, %d >, region = < %d, %d, %d >, ptr = %p",
+                    "queue = %p, buffer = %p, %s, buffer_origin = < %zu, %zu, %zu >, host_origin = < %zu, %zu, %zu >, region = < %zu, %zu, %zu >, ptr = %p",
                     command_queue,
                     buffer,
                     blocking_read ? "blocking" : "non-blocking",
@@ -3480,7 +3480,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueWriteBuffer)(
         if( pIntercept->nullEnqueue() == false )
         {
             CALL_LOGGING_ENTER(
-                "queue = %p, buffer = %p, %s, offset = %d, cb = %d, ptr = %p",
+                "queue = %p, buffer = %p, %s, offset = %zu, cb = %zu, ptr = %p",
                 command_queue,
                 buffer,
                 blocking_write ? "blocking" : "non-blocking",
@@ -3575,7 +3575,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueWriteBufferRect)(
                 ( region != NULL ) )
             {
                 CALL_LOGGING_ENTER(
-                    "queue = %p, buffer = %p, %s, buffer_origin = < %d, %d, %d >, host_origin = < %d, %d, %d >, region = < %d, %d, %d >, ptr = %p",
+                    "queue = %p, buffer = %p, %s, buffer_origin = < %zu, %zu, %zu >, host_origin = < %zu, %zu, %zu >, region = < %zu, %zu, %zu >, ptr = %p",
                     command_queue,
                     buffer,
                     blocking_write ? "blocking" : "non-blocking",
@@ -3660,12 +3660,12 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueFillBuffer)(
 
         if( pIntercept->nullEnqueue() == false )
         {
-            CALL_LOGGING_ENTER( "queue = %p, buffer = %p, pattern_size = %u, offset = %u, size = %u",
+            CALL_LOGGING_ENTER( "queue = %p, buffer = %p, pattern_size = %zu, offset = %zu, size = %zu",
                 command_queue,
                 buffer,
-                (cl_uint)pattern_size,
-                (cl_uint)offset,
-                (cl_uint)size );
+                pattern_size,
+                offset,
+                size );
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
@@ -3720,13 +3720,13 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueCopyBuffer)(
 
         if( pIntercept->nullEnqueue() == false )
         {
-            CALL_LOGGING_ENTER("queue = %p, src_buffer = %p, dst_buffer = %p, src_offset = %u, dst_offset = %u, cb = %u",
+            CALL_LOGGING_ENTER("queue = %p, src_buffer = %p, dst_buffer = %p, src_offset = %zu, dst_offset = %zu, cb = %zu",
                 command_queue,
                 src_buffer,
                 dst_buffer,
-                (cl_uint)src_offset,
-                (cl_uint)dst_offset,
-                (cl_uint)cb );
+                src_offset,
+                dst_offset,
+                cb );
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
@@ -3807,7 +3807,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueCopyBufferRect)(
                 ( region != NULL ) )
             {
                 CALL_LOGGING_ENTER(
-                    "queue = %p, src_buffer = %p, dst_buffer = %p, src_origin = < %d, %d, %d >, dst_origin = < %d, %d, %d >, region = < %d, %d, %d >",
+                    "queue = %p, src_buffer = %p, dst_buffer = %p, src_origin = < %zu, %zu, %zu >, dst_origin = < %zu, %zu, %zu >, region = < %zu, %zu, %zu >",
                     command_queue,
                     src_buffer,
                     dst_buffer,
@@ -3887,7 +3887,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReadImage)(
                 ( region != NULL ) )
             {
                 CALL_LOGGING_ENTER(
-                    "queue = %p, image = %p, %s, origin = < %d, %d, %d >, region = < %d, %d, %d >, ptr = %p",
+                    "queue = %p, image = %p, %s, origin = < %zu, %zu, %zu >, region = < %zu, %zu, %zu >, ptr = %p",
                     command_queue,
                     image,
                     blocking_read ? "blocking" : "non-blocking",
@@ -4344,7 +4344,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapBuffer)(
                 }
             }
             CALL_LOGGING_ENTER(
-                "[ map count = %d ] queue = %p, buffer = %p, %s, map_flags = %s (%llX), offset = %d, cb = %d%s",
+                "[ map count = %d ] queue = %p, buffer = %p, %s, map_flags = %s (%llX), offset = %zu, cb = %zu%s",
                 map_count,
                 command_queue,
                 buffer,
@@ -4448,7 +4448,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapImage)(
                 ( region != NULL ) )
             {
                 CALL_LOGGING_ENTER(
-                    "[ map count = %d ] queue = %p, image = %p, %s, map_flags = %s (%llX), origin = < %d, %d, %d >, region = < %d, %d, %d >",
+                    "[ map count = %d ] queue = %p, image = %p, %s, map_flags = %s (%llX), origin = < %zu, %zu, %zu >, region = < %zu, %zu, %zu >",
                     map_count,
                     command_queue,
                     image,
@@ -5759,7 +5759,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clSVMAlloc) (
 
     if( pIntercept && pIntercept->dispatch().clSVMAlloc )
     {
-        CALL_LOGGING_ENTER( "flags = %s (%llX), size = %d, alignment = %d",
+        CALL_LOGGING_ENTER( "flags = %s (%llX), size = %zu, alignment = %u",
             pIntercept->enumName().name_svm_mem_flags( flags ).c_str(),
             flags,
             size,
@@ -5951,11 +5951,11 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMMemFill) (
 
         if( pIntercept->nullEnqueue() == false )
         {
-            CALL_LOGGING_ENTER( "queue = %p, svm_ptr = %p, pattern_size = %u, size = %u",
+            CALL_LOGGING_ENTER( "queue = %p, svm_ptr = %p, pattern_size = %zu, size = %zu",
                 command_queue,
                 svm_ptr,
-                (cl_uint)pattern_size,
-                (cl_uint)size );
+                pattern_size,
+                size );
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
             DEVICE_PERFORMANCE_TIMING_START( event );
             CPU_PERFORMANCE_TIMING_START();
@@ -6104,7 +6104,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetKernelArgSVMPointer) (
     {
         CALL_LOGGING_ENTER_KERNEL(
             kernel,
-            "kernel = %p, index = %d, value = %p",
+            "kernel = %p, index = %u, value = %p",
             kernel,
             arg_index,
             arg_value );
@@ -6584,9 +6584,9 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clCreateProgramWithIL) (
         COMPUTE_SPIRV_HASH( length, il, hash );
         INJECT_PROGRAM_SPIRV( length, il, injectedSPIRV, hash );
 
-        CALL_LOGGING_ENTER( "context = %p, length = %u",
+        CALL_LOGGING_ENTER( "context = %p, length = %zu",
             context,
-            (cl_uint)length );
+            length );
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
 
@@ -6634,7 +6634,7 @@ CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithILKHR(
             COMPUTE_SPIRV_HASH( length, il, hash );
             INJECT_PROGRAM_SPIRV( length, il, injectedSPIRV, hash );
 
-            CALL_LOGGING_ENTER( "context = %p, length = %u",
+            CALL_LOGGING_ENTER( "context = %p, length = %zu",
                 context,
                 length );
             CHECK_ERROR_INIT( errcode_ret );
@@ -8050,7 +8050,7 @@ CL_API_ENTRY cl_accelerator_intel CL_API_CALL clCreateAcceleratorINTEL(
             {
                 cl_motion_estimation_desc_intel* desc =
                     (cl_motion_estimation_desc_intel*)descriptor;
-                CALL_LOGGING_ENTER( "context = %p, motion_estimation_desc[ mb_block_type = %d, subpixel_mode = %d, sad_adjust_mode = %d, search_path_type = %d ]",
+                CALL_LOGGING_ENTER( "context = %p, motion_estimation_desc[ mb_block_type = %u, subpixel_mode = %u, sad_adjust_mode = %u, search_path_type = %u ]",
                     context,
                     desc->mb_block_type,
                     desc->subpixel_mode,
@@ -8061,7 +8061,7 @@ CL_API_ENTRY cl_accelerator_intel CL_API_CALL clCreateAcceleratorINTEL(
             {
                 CALL_LOGGING_ENTER( "context = %p, accelerator_type = %u",
                     context,
-                    (cl_uint)accelerator_type );
+                    accelerator_type );
             }
             CHECK_ERROR_INIT( errcode_ret );
             CPU_PERFORMANCE_TIMING_START();
@@ -8452,7 +8452,7 @@ CL_API_ENTRY void* CL_API_CALL clHostMemAllocINTEL(
         if( dispatchX.clHostMemAllocINTEL )
         {
             // TODO: Make properties string.
-            CALL_LOGGING_ENTER( "context = %p, properties = %p, size = %d, alignment = %d",
+            CALL_LOGGING_ENTER( "context = %p, properties = %p, size = %zu, alignment = %u",
                 context,
                 properties,
                 size,
@@ -8505,7 +8505,7 @@ CL_API_ENTRY void* CL_API_CALL clDeviceMemAllocINTEL(
                     deviceInfo );
             }
             // TODO: Make properties string.
-            CALL_LOGGING_ENTER( "context = %p, device = %s, properties = %p, size = %d, alignment = %d",
+            CALL_LOGGING_ENTER( "context = %p, device = %s, properties = %p, size = %zu, alignment = %u",
                 context,
                 deviceInfo.c_str(),
                 properties,
@@ -8560,7 +8560,7 @@ CL_API_ENTRY void* CL_API_CALL clSharedMemAllocINTEL(
                     deviceInfo );
             }
             // TODO: Make properties string.
-            CALL_LOGGING_ENTER( "context = %p, device = %s, properties = %p, size = %d, alignment = %d",
+            CALL_LOGGING_ENTER( "context = %p, device = %s, properties = %p, size = %zu, alignment = %u",
                 context,
                 deviceInfo.c_str(),
                 properties,
@@ -8718,7 +8718,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgMemPointerINTEL(
         {
             CALL_LOGGING_ENTER_KERNEL(
                 kernel,
-                "kernel = %p, index = %d, value = %p",
+                "kernel = %p, index = %u, value = %p",
                 kernel,
                 arg_index,
                 arg_value );
@@ -8766,11 +8766,11 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemsetINTEL(   // Deprecated
 
             if( pIntercept->nullEnqueue() == false )
             {
-                CALL_LOGGING_ENTER( "queue = %p, dst_ptr = %p, value = %d, size = %u",
+                CALL_LOGGING_ENTER( "queue = %p, dst_ptr = %p, value = %d, size = %zu",
                     queue,
                     dst_ptr,
                     value,
-                    (cl_uint)size );
+                    size );
                 CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
                 DEVICE_PERFORMANCE_TIMING_START( event );
                 CPU_PERFORMANCE_TIMING_START();
@@ -8827,11 +8827,11 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemFillINTEL(
 
             if( pIntercept->nullEnqueue() == false )
             {
-                CALL_LOGGING_ENTER( "queue = %p, dst_ptr = %p, pattern_size = %u, size = %u",
+                CALL_LOGGING_ENTER( "queue = %p, dst_ptr = %p, pattern_size = %zu, size = %zu",
                     queue,
                     dst_ptr,
-                    (cl_uint)pattern_size,
-                    (cl_uint)size );
+                    pattern_size,
+                    size );
                 CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
                 DEVICE_PERFORMANCE_TIMING_START( event );
                 CPU_PERFORMANCE_TIMING_START();
@@ -8889,12 +8889,12 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemcpyINTEL(
 
             if( pIntercept->nullEnqueue() == false )
             {
-                CALL_LOGGING_ENTER( "queue = %p, %s, dst_ptr = %p, src_ptr = %p, size = %u",
+                CALL_LOGGING_ENTER( "queue = %p, %s, dst_ptr = %p, src_ptr = %p, size = %zu",
                     queue,
                     blocking ? "blocking" : "non-blocking",
                     dst_ptr,
                     src_ptr,
-                    (cl_uint)size );
+                    size );
                 CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
                 DEVICE_PERFORMANCE_TIMING_START( event );
                 CPU_PERFORMANCE_TIMING_START();
@@ -8951,10 +8951,10 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMigrateMemINTEL(
 
             if( pIntercept->nullEnqueue() == false )
             {
-                CALL_LOGGING_ENTER( "queue = %p, ptr = %p, size = %u, flags = %s (%llX)",
+                CALL_LOGGING_ENTER( "queue = %p, ptr = %p, size = %zu, flags = %s (%llX)",
                     queue,
                     ptr,
-                    (cl_uint)size,
+                    size,
                     pIntercept->enumName().name_mem_migration_flags( flags ).c_str(),
                     flags );
                 CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
@@ -9012,10 +9012,10 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemAdviseINTEL(
 
             if( pIntercept->nullEnqueue() == false )
             {
-                CALL_LOGGING_ENTER( "queue = %p, ptr = %p, size = %u, advice = %s (%llX)",
+                CALL_LOGGING_ENTER( "queue = %p, ptr = %p, size = %zu, advice = %s (%llX)",
                     queue,
                     ptr,
-                    (cl_uint)size,
+                    size,
                     pIntercept->enumName().name(advice).c_str(),
                     advice );
                 CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -1411,6 +1411,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateImage3D)(
                 "format->channel_data_type = %s, "
                 "image_width = %zu, "
                 "image_height = %zu, "
+                "image_depth = %zu, "
                 "image_row_pitch = %zu, "
                 "image_slice_pitch = %zu, "
                 "host_ptr = %p ",
@@ -9012,7 +9013,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemAdviseINTEL(
 
             if( pIntercept->nullEnqueue() == false )
             {
-                CALL_LOGGING_ENTER( "queue = %p, ptr = %p, size = %zu, advice = %s (%llX)",
+                CALL_LOGGING_ENTER( "queue = %p, ptr = %p, size = %zu, advice = %s (%u)",
                     queue,
                     ptr,
                     size,

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -2113,45 +2113,45 @@ void CLIntercept::getKernelArgString(
             arg_value,
             str ) )
     {
-        CLI_SPRINTF( s, 256, "index = %d, size = %d, value = %s\n",
+        CLI_SPRINTF( s, 256, "index = %u, size = %zu, value = %s\n",
             arg_index,
-            (unsigned int)arg_size,
+            arg_size,
             str.c_str() );
     }
     else if( ( arg_value != NULL ) &&
              ( arg_size == sizeof(cl_mem) ) )
     {
         cl_mem* pMem = (cl_mem*)arg_value;
-        CLI_SPRINTF( s, 256, "index = %d, size = %d, value = %p",
+        CLI_SPRINTF( s, 256, "index = %u, size = %zu, value = %p",
             arg_index,
-            (unsigned int)arg_size,
+            arg_size,
             pMem[0] );
     }
     else if( ( arg_value != NULL ) &&
              ( arg_size == sizeof(cl_uint) ) )
     {
         cl_uint*    pData = (cl_uint*)arg_value;
-        CLI_SPRINTF( s, 256, "index = %d, size = %d, value = 0x%x",
+        CLI_SPRINTF( s, 256, "index = %u, size = %zu, value = 0x%x",
             arg_index,
-            (unsigned int)arg_size,
+            arg_size,
             pData[0] );
     }
     else if( ( arg_value != NULL ) &&
              ( arg_size == sizeof(cl_ulong) ) )
     {
         cl_ulong*   pData = (cl_ulong*)arg_value;
-        CLI_SPRINTF( s, 256, "index = %d, size = %d, value = 0x%jx",
+        CLI_SPRINTF( s, 256, "index = %u, size = %zu, value = 0x%jx",
             arg_index,
-            (unsigned int)arg_size,
+            arg_size,
             pData[0] );
     }
     else if( ( arg_value != NULL ) &&
              ( arg_size == sizeof(cl_int4) ) )
     {
         cl_int4*   pData = (cl_int4*)arg_value;
-        CLI_SPRINTF( s, 256, "index = %d, size = %d, valueX = 0x%0x, valueY = 0x%0x, valueZ = 0x%0x, valueW = 0x%0x",
+        CLI_SPRINTF( s, 256, "index = %u, size = %zu, valueX = 0x%0x, valueY = 0x%0x, valueZ = 0x%0x, valueW = 0x%0x",
             arg_index,
-            (unsigned int)arg_size,
+            arg_size,
             pData->s[0],
             pData->s[1],
             pData->s[2],
@@ -2159,9 +2159,9 @@ void CLIntercept::getKernelArgString(
     }
     else
     {
-        CLI_SPRINTF( s, 256, "index = %d, size = %d",
+        CLI_SPRINTF( s, 256, "index = %u, size = %zu",
             arg_index,
-            (unsigned int)arg_size );
+            arg_size );
     }
 
     str = s;
@@ -2464,8 +2464,7 @@ void CLIntercept::logBuild(
 
                     char    str[256] = "";
 
-                    CLI_SPRINTF( str, 256, "Build Status for device %u = ",
-                        (unsigned int)i );
+                    CLI_SPRINTF( str, 256, "Build Status for device %u = ", i );
 
                     std::string message = str;
 
@@ -2699,11 +2698,11 @@ void CLIntercept::logKernelInfo(
                     if( config().KernelInfoLogging ||
                         config().PreferredWorkGroupSizeMultipleLogging )
                     {
-                        logf( "        Preferred Work Group Size Multiple: %u\n", (cl_uint)pwgsm);
+                        logf( "        Preferred Work Group Size Multiple: %zu\n", pwgsm);
                     }
                     if( config().KernelInfoLogging )
                     {
-                        logf( "        Work Group Size: %u\n", (cl_uint)wgs);
+                        logf( "        Work Group Size: %zu\n", wgs);
                         logf( "        Private Mem Size: %u\n", (cl_uint)pms);
                         logf( "        Local Mem Size: %u\n", (cl_uint)lms);
                         if( errorCode_sms == CL_SUCCESS )
@@ -2933,9 +2932,9 @@ void CLIntercept::contextCallback(
     size_t cb )
 {
     char    str[256] = "";
-    CLI_SPRINTF( str, 256, "=======> Context Callback (private_info = %p, cb = %u):\n",
+    CLI_SPRINTF( str, 256, "=======> Context Callback (private_info = %p, cb = %zu):\n",
         private_info,
-        (unsigned int)cb );
+        cb );
 
     std::lock_guard<std::mutex> lock(m_Mutex);
     log( str + errinfo + "\n" + "<======= End of Context Callback\n" );
@@ -3139,9 +3138,9 @@ void CLIntercept::overrideNullLocalWorkSize(
                 else
                 {
                     std::lock_guard<std::mutex> lock(m_Mutex);
-                    logf( "Couldn't override NULL local work size: < %u > %% < %u > != 0!\n",
-                        (unsigned int)global_work_size[0],
-                        (unsigned int)m_Config.NullLocalWorkSizeX );
+                    logf( "Couldn't override NULL local work size: < %zu > %% < %zu > != 0!\n",
+                        global_work_size[0],
+                        m_Config.NullLocalWorkSizeX );
                 }
             }
             break;
@@ -3157,11 +3156,11 @@ void CLIntercept::overrideNullLocalWorkSize(
                 else
                 {
                     std::lock_guard<std::mutex> lock(m_Mutex);
-                    logf( "Couldn't override NULL local work size: < %u x %u > %% < %u x %u > != 0!\n",
-                        (unsigned int)global_work_size[0],
-                        (unsigned int)global_work_size[1],
-                        (unsigned int)m_Config.NullLocalWorkSizeX,
-                        (unsigned int)m_Config.NullLocalWorkSizeY );
+                    logf( "Couldn't override NULL local work size: < %zu x %zu > %% < %zu x %zu > != 0!\n",
+                        global_work_size[0],
+                        global_work_size[1],
+                        m_Config.NullLocalWorkSizeX,
+                        m_Config.NullLocalWorkSizeY );
                 }
             }
             break;
@@ -3179,13 +3178,13 @@ void CLIntercept::overrideNullLocalWorkSize(
                 else
                 {
                     std::lock_guard<std::mutex> lock(m_Mutex);
-                    logf( "Couldn't override NULL local work size: < %u x %u x %u > %% < %u x %u x %u > != 0!\n",
-                        (unsigned int)global_work_size[0],
-                        (unsigned int)global_work_size[1],
-                        (unsigned int)global_work_size[2],
-                        (unsigned int)m_Config.NullLocalWorkSizeX,
-                        (unsigned int)m_Config.NullLocalWorkSizeY,
-                        (unsigned int)m_Config.NullLocalWorkSizeZ );
+                    logf( "Couldn't override NULL local work size: < %zu x %zu x %zu > %% < %zu x %zu x %zu > != 0!\n",
+                        global_work_size[0],
+                        global_work_size[1],
+                        global_work_size[2],
+                        m_Config.NullLocalWorkSizeX,
+                        m_Config.NullLocalWorkSizeY,
+                        m_Config.NullLocalWorkSizeZ );
                 }
             }
             break;
@@ -5036,7 +5035,7 @@ void CLIntercept::addTimingEvent(
 
                 if( simd )
                 {
-                    ss << " SIMD" << (unsigned int)simd;
+                    ss << " SIMD" << simd;
                 }
             }
             {
@@ -5050,7 +5049,7 @@ void CLIntercept::addTimingEvent(
                     NULL );
                 if( slm )
                 {
-                    ss << " SLM=" << (unsigned int)slm;
+                    ss << " SLM=" << slm;
                 }
             }
             {
@@ -5064,7 +5063,7 @@ void CLIntercept::addTimingEvent(
                     NULL );
                 if( tpm )
                 {
-                    ss << " TPM=" << (unsigned int)tpm;
+                    ss << " TPM=" << tpm;
                 }
             }
             {
@@ -5078,7 +5077,7 @@ void CLIntercept::addTimingEvent(
                     NULL );
                 if( spill )
                 {
-                    ss << " SPILL=" << (unsigned int)spill;
+                    ss << " SPILL=" << spill;
                 }
             }
             node.KernelName += ss.str();
@@ -6169,11 +6168,11 @@ void CLIntercept::dumpImagesForKernel(
 
             // Add the image dimensions to the file name
             {
-                CLI_SPRINTF( tmpStr, MAX_PATH, "_%ux%ux%u_%ubpp",
-                    (unsigned int)info.Region[0],
-                    (unsigned int)info.Region[1],
-                    (unsigned int)info.Region[2],
-                    (unsigned int)info.ElementSize * 8 );
+                CLI_SPRINTF( tmpStr, MAX_PATH, "_%zux%zux%zu_%zubpp",
+                    info.Region[0],
+                    info.Region[1],
+                    info.Region[2],
+                    info.ElementSize * 8 );
 
                 fileName += tmpStr;
             }
@@ -6359,8 +6358,8 @@ void CLIntercept::dumpBuffer(
         {
             char    offsetName[ MAX_PATH ];
 
-            CLI_SPRINTF( offsetName, MAX_PATH, "%04u",
-                (unsigned int)offset );
+            CLI_SPRINTF( offsetName, MAX_PATH, "%04zu",
+                offset );
 
             fileName += "_Offset_";
             fileName += offsetName;
@@ -6468,7 +6467,7 @@ void CLIntercept::checkEventList(
     if( numEvents != 0 && eventList == NULL )
     {
         std::lock_guard<std::mutex> lock(m_Mutex);
-        logf( "Check Events for %s: Num Events is %d, but Event List is NULL!\n",
+        logf( "Check Events for %s: Num Events is %u, but Event List is NULL!\n",
             functionName.c_str(),
             numEvents );
     }
@@ -12606,9 +12605,9 @@ cl_int CLIntercept::setUSMKernelExecInfo(
             {
                 size_t  count = usmContextInfo.HostAllocVector.size();
 
-                logf("Indirect USM Allocs for kernel %s: Fast path for %u host allocs\n",
+                logf("Indirect USM Allocs for kernel %s: Fast path for %zu host allocs\n",
                     getShortKernelName(kernel).c_str(),
-                    (cl_uint)count );
+                    count );
 
                 errorCode = dispatch().clSetKernelExecInfo(
                     kernel,
@@ -12620,9 +12619,9 @@ cl_int CLIntercept::setUSMKernelExecInfo(
             {
                 size_t  count = usmContextInfo.DeviceAllocVector.size();
 
-                logf("Indirect USM Allocs for kernel %s: Fast path for %u device allocs\n",
+                logf("Indirect USM Allocs for kernel %s: Fast path for %zu device allocs\n",
                     getShortKernelName(kernel).c_str(),
-                    (cl_uint)count );
+                    count );
 
                 errorCode = dispatch().clSetKernelExecInfo(
                     kernel,
@@ -12634,9 +12633,9 @@ cl_int CLIntercept::setUSMKernelExecInfo(
             {
                 size_t  count = usmContextInfo.SharedAllocVector.size();
 
-                logf("Indirect USM Allocs for kernel %s: Fast path for %u shared allocs\n",
+                logf("Indirect USM Allocs for kernel %s: Fast path for %zu shared allocs\n",
                     getShortKernelName(kernel).c_str(),
-                    (cl_uint)count );
+                    count );
 
                 errorCode = dispatch().clSetKernelExecInfo(
                     kernel,
@@ -12647,13 +12646,13 @@ cl_int CLIntercept::setUSMKernelExecInfo(
         }
         else
         {
-            logf("Indirect USM allocs for kernel %s: %u svm ptrs, %u usm ptrs, %u host allocs, %u device allocs, %u shared allocs\n",
+            logf("Indirect USM allocs for kernel %s: %zu svm ptrs, %zu usm ptrs, %zu host allocs, %zu device allocs, %zu shared allocs\n",
                 getShortKernelName(kernel).c_str(),
-                (cl_uint)usmKernelInfo.SVMPtrs.size(),
-                (cl_uint)usmKernelInfo.USMPtrs.size(),
-                setHostAllocs ? (cl_uint)usmContextInfo.HostAllocVector.size() : 0,
-                setDeviceAllocs ? (cl_uint)usmContextInfo.DeviceAllocVector.size() : 0,
-                setSharedAllocs ? (cl_uint)usmContextInfo.SharedAllocVector.size() : 0 );
+                usmKernelInfo.SVMPtrs.size(),
+                usmKernelInfo.USMPtrs.size(),
+                setHostAllocs ? usmContextInfo.HostAllocVector.size() : 0,
+                setDeviceAllocs ? usmContextInfo.DeviceAllocVector.size() : 0,
+                setSharedAllocs ? usmContextInfo.SharedAllocVector.size() : 0 );
 
             size_t  count =
                 usmKernelInfo.SVMPtrs.size() +

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -2535,11 +2535,11 @@ inline void CLIntercept::logCL_GLTextureDetails( cl_mem image, cl_GLenum target,
     CALL_LOGGING_INFO(
         "CL Channel Order = %s, "
         "CL Channel Data Type = %s, "
-        "CL Row Pitch = %d, "
-        "CL Slice Pitch = %d, "
-        "CL Width = %d, "
-        "CL Height = %d, "
-        "CL Depth = %d, ",
+        "CL Row Pitch = %zu, "
+        "CL Slice Pitch = %zu, "
+        "CL Width = %zu, "
+        "CL Height = %zu, "
+        "CL Depth = %zu, ",
         enumName().name( cl_format.image_channel_order ).c_str(),
         enumName().name( cl_format.image_channel_data_type ).c_str(),
         cl_rowPitch,


### PR DESCRIPTION
## Description of Changes

Fixes a number of incorrect logging formats specifiers, most notably when printing variables with type `size_t`.  The previous code was causing incorrect logging for very large memory allocations, among other problems.  These changes use `%zu` to print `size_t` variables, which seems to be fairly well-supported - if it isn't, we'll need to look for an alternative solution that is more portable.

## Testing Done

Examined call logging after executing several applications, including one that made very large (>4GB) allocations.  No issues observed.
