### PR TITLE
track queues and call finish to emulate a blocking free

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -778,7 +778,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL CLIRN(clCreateCommandQueue)(
         ITT_REGISTER_COMMAND_QUEUE( retVal, false );
         ADD_OBJECT_ALLOCATION( retVal );
         CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
-        ADD_QUEUE( retVal );
+        ADD_QUEUE( context, retVal );
 
         return retVal;
     }
@@ -6335,7 +6335,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL CLIRN(clCreateCommandQueueWithProperti
         CHECK_ERROR( errcode_ret[0] );
         ADD_OBJECT_ALLOCATION( retVal );
         CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
-        ADD_QUEUE( retVal );
+        ADD_QUEUE( context, retVal );
 
         return retVal;
     }
@@ -6427,7 +6427,7 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithPropertiesKHR(
             CHECK_ERROR( errcode_ret[0] );
             ADD_OBJECT_ALLOCATION( retVal );
             CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
-            ADD_QUEUE( retVal );
+            ADD_QUEUE( context, retVal );
 
             return retVal;
         }

--- a/intercept/src/emulate.cpp
+++ b/intercept/src/emulate.cpp
@@ -133,7 +133,8 @@ cl_int CL_API_CALL clMemBlockingFreeINTEL_EMU(
 
     if( pIntercept && pIntercept->config().Emulate_cl_intel_unified_shared_memory )
     {
-        // TODO: Track queues and block all.
+        pIntercept->finishAll( context );
+
         return pIntercept->emulatedMemFree(
             context,
             ptr );


### PR DESCRIPTION
## Description of Changes

Adds an emulated version of the USM blocking free call, by tracking oustanding queues for a context and calling `clFinish` on all of them before freeing the USM allocation.

## Testing Done

Created a dedicated test app with multiple contexts and multiple queues to verify that the proper queues are synchronized before freeing memory.
