### PR TITLE
chrome tracing event id

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -2766,11 +2766,6 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetKernelArg)(
             kernel,
             argsString.c_str() );
 
-        if ( pIntercept->config().DumpArgumentsOnSet )
-        {
-            pIntercept->dumpArgument( kernel, arg_index, arg_size, arg_value );
-        }
-
         SET_KERNEL_ARG( kernel, arg_index, arg_size, arg_value );
         CPU_PERFORMANCE_TIMING_START();
 

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -289,17 +289,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainDevice)(
     {
         GET_ENQUEUE_COUNTER();
 
-        cl_uint ref_count = 0;
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetDeviceInfo(
-                device,
-                CL_DEVICE_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        cl_uint ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( device ) : 0;
         CALL_LOGGING_ENTER( "[ ref count = %d ] device = %p",
             ref_count,
             device );
@@ -311,16 +303,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainDevice)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
         ADD_OBJECT_RETAIN( device );
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetDeviceInfo(
-                device,
-                CL_DEVICE_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( device ) : 0;
         CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
@@ -341,17 +326,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseDevice)(
     {
         GET_ENQUEUE_COUNTER();
 
-        cl_uint ref_count = 0;
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetDeviceInfo(
-                device,
-                CL_DEVICE_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        cl_uint ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( device ) : 0;
         CALL_LOGGING_ENTER( "[ ref count = %d ] device = %p",
             ref_count,
             device );
@@ -363,13 +340,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseDevice)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
         ADD_OBJECT_RELEASE( device );
-        if( pIntercept->config().CallLogging && ref_count != 0 )
-        {
-            // This isn't strictly correct, but it's pretty close, and it
-            // avoids crashes in some cases for bad implementations.
-            --ref_count;
-        }
-        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", --ref_count );
 
         return retVal;
     }
@@ -552,17 +523,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainContext)(
     {
         GET_ENQUEUE_COUNTER();
 
-        cl_uint ref_count = 0;
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetContextInfo(
-                context,
-                CL_CONTEXT_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        cl_uint ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( context ) : 0;
         CALL_LOGGING_ENTER( "[ ref count = %d ] context = %p",
             ref_count,
             context );
@@ -574,16 +537,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainContext)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
         ADD_OBJECT_RETAIN( context );
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetContextInfo(
-                context,
-                CL_CONTEXT_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( context ) : 0;
         CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
@@ -603,17 +559,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseContext)(
     {
         GET_ENQUEUE_COUNTER();
 
-        cl_uint ref_count = 0;
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetContextInfo(
-                context,
-                CL_CONTEXT_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        cl_uint ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( context ) : 0;
         CALL_LOGGING_ENTER( "[ ref count = %d ] context = %p",
             ref_count,
             context );
@@ -625,13 +573,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseContext)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
         ADD_OBJECT_RELEASE( context );
-        if( pIntercept->config().CallLogging && ref_count != 0 )
-        {
-            // This isn't strictly correct, but it's pretty close, and it
-            // avoids crashes in some cases for bad implementations.
-            --ref_count;
-        }
-        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", --ref_count );
 
 #if 0
         pIntercept->report();
@@ -821,17 +763,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainCommandQueue)(
     {
         GET_ENQUEUE_COUNTER();
 
-        cl_uint ref_count = 0;
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetCommandQueueInfo(
-                command_queue,
-                CL_QUEUE_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        cl_uint ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( command_queue ) : 0;
         CALL_LOGGING_ENTER( "[ ref count = %d ] command_queue = %p",
             ref_count,
             command_queue );
@@ -843,16 +777,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainCommandQueue)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
         ADD_OBJECT_RETAIN( command_queue );
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetCommandQueueInfo(
-                command_queue,
-                CL_QUEUE_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( command_queue ) : 0;
         CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
@@ -873,17 +800,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseCommandQueue)(
         GET_ENQUEUE_COUNTER();
         REMOVE_QUEUE( command_queue );
 
-        cl_uint ref_count = 0;
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetCommandQueueInfo(
-                command_queue,
-                CL_QUEUE_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        cl_uint ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( command_queue ) : 0;
         CALL_LOGGING_ENTER( "[ ref count = %d ] command_queue = %p",
             ref_count,
             command_queue );
@@ -896,13 +815,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseCommandQueue)(
         CHECK_ERROR( retVal );
         ITT_RELEASE_COMMAND_QUEUE( command_queue );
         ADD_OBJECT_RELEASE( command_queue );
-        if( pIntercept->config().CallLogging && ref_count != 0 )
-        {
-            // This isn't strictly correct, but it's pretty close, and it
-            // avoids crashes in some cases for bad implementations.
-            --ref_count;
-        }
-        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", --ref_count );
 
         return retVal;
     }
@@ -1513,17 +1426,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainMemObject)(
     {
         GET_ENQUEUE_COUNTER();
 
-        cl_uint ref_count = 0;
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetMemObjectInfo(
-                memobj,
-                CL_MEM_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        cl_uint ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( memobj ) : 0;
         CALL_LOGGING_ENTER( "[ ref count = %d ] mem = %p",
             ref_count,
             memobj );
@@ -1535,16 +1440,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainMemObject)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
         ADD_OBJECT_RETAIN( memobj );
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetMemObjectInfo(
-                memobj,
-                CL_MEM_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( memobj ) : 0;
         CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
@@ -1565,17 +1463,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseMemObject)(
         GET_ENQUEUE_COUNTER();
         REMOVE_MEMOBJ( memobj );
 
-        cl_uint ref_count = 0;
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetMemObjectInfo(
-                memobj,
-                CL_MEM_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        cl_uint ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( memobj ) : 0;
         CALL_LOGGING_ENTER( "[ ref count = %d ] mem = %p",
             ref_count,
             memobj );
@@ -1587,13 +1477,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseMemObject)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
         ADD_OBJECT_RELEASE( memobj );
-        if( pIntercept->config().CallLogging && ref_count != 0 )
-        {
-            // This isn't strictly correct, but it's pretty close, and it
-            // avoids crashes in some cases for bad implementations.
-            --ref_count;
-        }
-        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", --ref_count );
 
         return retVal;
     }
@@ -1811,17 +1695,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainSampler)(
     {
         GET_ENQUEUE_COUNTER();
 
-        cl_uint ref_count = 0;
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetSamplerInfo(
-                sampler,
-                CL_SAMPLER_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        cl_uint ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( sampler ) : 0;
         CALL_LOGGING_ENTER( "[ ref count = %d ] sampler = %p",
             ref_count,
             sampler );
@@ -1833,16 +1709,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainSampler)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
         ADD_OBJECT_RETAIN( sampler );
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetSamplerInfo(
-                sampler,
-                CL_SAMPLER_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( sampler ) : 0;
         CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
@@ -1863,16 +1732,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseSampler)(
         GET_ENQUEUE_COUNTER();
         REMOVE_SAMPLER( sampler );
 
-        cl_uint ref_count = 0;
-        if( pIntercept->config().CallLogging )
-        {
-            pIntercept->dispatch().clGetSamplerInfo(
-                sampler,
-                CL_SAMPLER_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        cl_uint ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( sampler ) : 0;
         CALL_LOGGING_ENTER( "[ ref count = %d ] sampler = %p",
             ref_count,
             sampler );
@@ -1884,13 +1746,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseSampler)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
         ADD_OBJECT_RELEASE( sampler );
-        if( pIntercept->config().CallLogging && ref_count != 0 )
-        {
-            // This isn't strictly correct, but it's pretty close, and it
-            // avoids crashes in some cases for bad implementations.
-            --ref_count;
-        }
-        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", --ref_count );
 
         return retVal;
     }
@@ -2139,17 +1995,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainProgram)(
     {
         GET_ENQUEUE_COUNTER();
 
-        cl_uint ref_count = 0;
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetProgramInfo(
-                program,
-                CL_PROGRAM_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        cl_uint ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( program ) : 0;
         CALL_LOGGING_ENTER( "[ ref count = %d ] program = %p",
             ref_count,
             program );
@@ -2161,16 +2009,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainProgram)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
         ADD_OBJECT_RETAIN( program );
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetProgramInfo(
-                program,
-                CL_PROGRAM_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( program ) : 0;
         CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
@@ -2190,17 +2031,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseProgram)(
     {
         GET_ENQUEUE_COUNTER();
 
-        cl_uint ref_count = 0;
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetProgramInfo(
-                program,
-                CL_PROGRAM_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        cl_uint ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( program ) : 0;
         CALL_LOGGING_ENTER( "[ ref count = %d ] program = %p",
             ref_count,
             program );
@@ -2212,13 +2045,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseProgram)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
         ADD_OBJECT_RELEASE( program );
-        if( pIntercept->config().CallLogging && ref_count != 0 )
-        {
-            // This isn't strictly correct, but it's pretty close, and it
-            // avoids crashes in some cases for bad implementations.
-            --ref_count;
-        }
-        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", --ref_count );
 
         return retVal;
     }
@@ -2732,17 +2559,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainKernel)(
     {
         GET_ENQUEUE_COUNTER();
 
-        cl_uint ref_count = 0;
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetKernelInfo(
-                kernel,
-                CL_KERNEL_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        cl_uint ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( kernel ) : 0;
         CALL_LOGGING_ENTER( "[ ref count = %d ] kernel = %p",
             ref_count,
             kernel );
@@ -2754,16 +2573,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainKernel)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
         ADD_OBJECT_RETAIN( kernel );
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetKernelInfo(
-                kernel,
-                CL_KERNEL_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( kernel ) : 0;
         CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
@@ -2785,17 +2597,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseKernel)(
 
         pIntercept->checkRemoveKernelInfo( kernel );
 
-        cl_uint ref_count = 0;
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetKernelInfo(
-                kernel,
-                CL_KERNEL_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        cl_uint ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( kernel ) : 0;
         CALL_LOGGING_ENTER( "[ ref count = %d ] kernel = %p",
             ref_count,
             kernel );
@@ -2807,13 +2611,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseKernel)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
         ADD_OBJECT_RELEASE( kernel );
-        if( pIntercept->config().CallLogging && ref_count != 0 )
-        {
-            // This isn't strictly correct, but it's pretty close, and it
-            // avoids crashes in some cases for bad implementations.
-            --ref_count;
-        }
-        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", --ref_count );
 
         return retVal;
     }
@@ -2994,33 +2792,28 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clWaitForEvents)(
     {
         GET_ENQUEUE_COUNTER();
 
-        cl_int  retVal = CL_SUCCESS;
-
-        if( pIntercept->config().NullEnqueue == false )
+        std::string eventList;
+        if( pIntercept->config().CallLogging )
         {
-            std::string eventList;
-            if( pIntercept->config().CallLogging )
-            {
-                pIntercept->getEventListString(
-                    num_events,
-                    event_list,
-                    eventList );
-            }
-            CALL_LOGGING_ENTER( "event_list = %s",
-                eventList.c_str() );
-            CHECK_EVENT_LIST( num_events, event_list, NULL );
-            CPU_PERFORMANCE_TIMING_START();
-
-            retVal = pIntercept->dispatch().clWaitForEvents(
+            pIntercept->getEventListString(
                 num_events,
-                event_list );
-
-            CPU_PERFORMANCE_TIMING_END();
-            CHECK_ERROR( retVal );
-            CALL_LOGGING_EXIT( retVal );
-
-            DEVICE_PERFORMANCE_TIMING_CHECK();
+                event_list,
+                eventList );
         }
+        CALL_LOGGING_ENTER( "event_list = %s",
+            eventList.c_str() );
+        CHECK_EVENT_LIST( num_events, event_list, NULL );
+        CPU_PERFORMANCE_TIMING_START();
+
+        cl_int  retVal = pIntercept->dispatch().clWaitForEvents(
+            num_events,
+            event_list );
+
+        CPU_PERFORMANCE_TIMING_END();
+        CHECK_ERROR( retVal );
+        CALL_LOGGING_EXIT( retVal );
+
+        DEVICE_PERFORMANCE_TIMING_CHECK();
 
         return retVal;
     }
@@ -3042,28 +2835,22 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetEventInfo)(
     if( pIntercept && pIntercept->dispatch().clGetEventInfo )
     {
         GET_ENQUEUE_COUNTER();
+        CALL_LOGGING_ENTER( "event = %p, param_name = %s (%08X)",
+            event,
+            pIntercept->enumName().name( param_name ).c_str(),
+            param_name );
+        CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = CL_SUCCESS;
+        cl_int  retVal = pIntercept->dispatch().clGetEventInfo(
+            event,
+            param_name,
+            param_value_size,
+            param_value,
+            param_value_size_ret );
 
-        if( pIntercept->config().NullEnqueue == false )
-        {
-            CALL_LOGGING_ENTER( "event = %p, param_name = %s (%08X)",
-                event,
-                pIntercept->enumName().name( param_name ).c_str(),
-                param_name );
-            CPU_PERFORMANCE_TIMING_START();
-
-            retVal = pIntercept->dispatch().clGetEventInfo(
-                event,
-                param_name,
-                param_value_size,
-                param_value,
-                param_value_size_ret );
-
-            CPU_PERFORMANCE_TIMING_END();
-            CHECK_ERROR( retVal );
-            CALL_LOGGING_EXIT( retVal );
-        }
+        CPU_PERFORMANCE_TIMING_END();
+        CHECK_ERROR( retVal );
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -3083,25 +2870,19 @@ CL_API_ENTRY cl_event CL_API_CALL CLIRN(clCreateUserEvent)(
     if( pIntercept && pIntercept->dispatch().clCreateUserEvent )
     {
         GET_ENQUEUE_COUNTER();
+        CALL_LOGGING_ENTER( "context = %p",
+            context );
+        CHECK_ERROR_INIT( errcode_ret );
+        CPU_PERFORMANCE_TIMING_START();
 
-        cl_event    retVal = NULL;
+        cl_event    retVal = pIntercept->dispatch().clCreateUserEvent(
+            context,
+            errcode_ret );
 
-        if( pIntercept->config().NullEnqueue == false )
-        {
-            CALL_LOGGING_ENTER( "context = %p",
-                context );
-            CHECK_ERROR_INIT( errcode_ret );
-            CPU_PERFORMANCE_TIMING_START();
-
-            retVal = pIntercept->dispatch().clCreateUserEvent(
-                context,
-                errcode_ret );
-
-            CPU_PERFORMANCE_TIMING_END();
-            CHECK_ERROR( errcode_ret[0] );
-            ADD_OBJECT_ALLOCATION( retVal );
-            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
-        }
+        CPU_PERFORMANCE_TIMING_END();
+        CHECK_ERROR( errcode_ret[0] );
+        ADD_OBJECT_ALLOCATION( retVal );
+        CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         return retVal;
     }
@@ -3120,17 +2901,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainEvent)(
     {
         GET_ENQUEUE_COUNTER();
 
-        cl_uint ref_count = 0;
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetEventInfo(
-                event,
-                CL_EVENT_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        cl_uint ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( event ) : 0;
         CALL_LOGGING_ENTER( "[ ref count = %d ] event = %p",
             ref_count,
             event );
@@ -3142,16 +2915,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainEvent)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
         ADD_OBJECT_RETAIN( event );
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetEventInfo(
-                event,
-                CL_EVENT_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( event ) : 0;
         CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
 
         return retVal;
@@ -3171,17 +2937,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseEvent)(
     {
         GET_ENQUEUE_COUNTER();
 
-        cl_uint ref_count = 0;
-        if( pIntercept->config().CallLogging )
-        {
-            ref_count = 0;
-            pIntercept->dispatch().clGetEventInfo(
-                event,
-                CL_EVENT_REFERENCE_COUNT,
-                sizeof( ref_count ),
-                &ref_count,
-                NULL );
-        }
+        cl_uint ref_count =
+            pIntercept->config().CallLogging ?
+            pIntercept->getRefCount( event ) : 0;
         CALL_LOGGING_ENTER( "[ ref count = %d ] event = %p",
             ref_count,
             event );
@@ -3193,13 +2951,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseEvent)(
         CPU_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
         ADD_OBJECT_RELEASE( event );
-        if( pIntercept->config().CallLogging && ref_count != 0 )
-        {
-            // This isn't strictly correct, but it's pretty close, and it
-            // avoids crashes in some cases for bad implementations.
-            --ref_count;
-        }
-        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", --ref_count );
 
         return retVal;
     }
@@ -3291,27 +3043,21 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetEventProfilingInfo)(
     if( pIntercept && pIntercept->dispatch().clGetEventProfilingInfo )
     {
         GET_ENQUEUE_COUNTER();
+        CALL_LOGGING_ENTER( "param_name = %s (%08X)",
+            pIntercept->enumName().name( param_name ).c_str(),
+            param_name );
+        CPU_PERFORMANCE_TIMING_START();
 
-        cl_int  retVal = CL_SUCCESS;
+        cl_int  retVal = pIntercept->dispatch().clGetEventProfilingInfo(
+            event,
+            param_name,
+            param_value_size,
+            param_value,
+            param_value_size_ret );
 
-        if( pIntercept->config().NullEnqueue == false )
-        {
-            CALL_LOGGING_ENTER( "param_name = %s (%08X)",
-                pIntercept->enumName().name( param_name ).c_str(),
-                param_name );
-            CPU_PERFORMANCE_TIMING_START();
-
-            retVal = pIntercept->dispatch().clGetEventProfilingInfo(
-                event,
-                param_name,
-                param_value_size,
-                param_value,
-                param_value_size_ret );
-
-            CPU_PERFORMANCE_TIMING_END();
-            CHECK_ERROR( retVal );
-            CALL_LOGGING_EXIT( retVal );
-        }
+        CPU_PERFORMANCE_TIMING_END();
+        CHECK_ERROR( retVal );
+        CALL_LOGGING_EXIT( retVal );
 
         return retVal;
     }
@@ -8414,13 +8160,7 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseAcceleratorINTEL(
 
             CPU_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            if( pIntercept->config().CallLogging && ref_count != 0 )
-            {
-                // This isn't strictly correct, but it's pretty close, and it
-                // avoids crashes in some cases for bad implementations.
-                --ref_count;
-            }
-            CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
+            CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", --ref_count );
 
             return retVal;
         }

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -37,6 +37,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetPlatformIDs)(
     {
         LOG_CLINFO();
 
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
@@ -68,6 +69,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetPlatformInfo)(
 
     if( pIntercept && pIntercept->dispatch().clGetPlatformInfo )
     {
+        GET_ENQUEUE_COUNTER();
+
         std::string platformInfo;
         if( pIntercept->config().CallLogging )
         {
@@ -122,6 +125,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetDeviceIDs)(
 
     if( pIntercept && pIntercept->dispatch().clGetDeviceIDs )
     {
+        GET_ENQUEUE_COUNTER();
+
         std::string platformInfo;
         if( pIntercept->config().CallLogging )
         {
@@ -184,6 +189,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetDeviceInfo)(
 
     if( pIntercept && pIntercept->dispatch().clGetDeviceInfo )
     {
+        GET_ENQUEUE_COUNTER();
+
         std::string deviceInfo;
         if( pIntercept->config().CallLogging )
         {
@@ -240,6 +247,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clCreateSubDevices)(
 
     if( pIntercept && pIntercept->dispatch().clCreateSubDevices )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
@@ -279,6 +287,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainDevice)(
 
     if( pIntercept && pIntercept->dispatch().clRetainDevice )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_uint ref_count = 0;
         if( pIntercept->config().CallLogging )
         {
@@ -329,6 +339,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseDevice)(
 
     if( pIntercept && pIntercept->dispatch().clReleaseDevice )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_uint ref_count = 0;
         if( pIntercept->config().CallLogging )
         {
@@ -385,6 +397,8 @@ CL_API_ENTRY cl_context CL_API_CALL CLIRN(clCreateContext)(
 
     if( pIntercept && pIntercept->dispatch().clCreateContext )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_context_properties*  newProperties = NULL;
         cl_context  retVal = NULL;
 
@@ -464,6 +478,8 @@ CL_API_ENTRY cl_context CL_API_CALL CLIRN(clCreateContextFromType)(
 
     if( pIntercept && pIntercept->dispatch().clCreateContextFromType )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_context_properties*  newProperties = NULL;
         cl_context  retVal = NULL;
 
@@ -534,6 +550,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainContext)(
 
     if( pIntercept && pIntercept->dispatch().clRetainContext )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_uint ref_count = 0;
         if( pIntercept->config().CallLogging )
         {
@@ -583,6 +601,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseContext)(
 
     if( pIntercept && pIntercept->dispatch().clReleaseContext )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_uint ref_count = 0;
         if( pIntercept->config().CallLogging )
         {
@@ -646,6 +666,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetContextInfo)(
 
     if( pIntercept && pIntercept->dispatch().clGetContextInfo )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "param_name = %s (%08X)",
             pIntercept->enumName().name( param_name ).c_str(),
             param_name );
@@ -680,6 +701,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetContextDestructorCallback(
 
     if( pIntercept && pIntercept->dispatch().clSetContextDestructorCallback )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
@@ -710,6 +732,8 @@ CL_API_ENTRY cl_command_queue CL_API_CALL CLIRN(clCreateCommandQueue)(
 
     if( pIntercept && pIntercept->dispatch().clCreateCommandQueue )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_queue_properties*    newProperties = NULL;
         cl_command_queue    retVal = NULL;
 
@@ -795,6 +819,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainCommandQueue)(
 
     if( pIntercept && pIntercept->dispatch().clRetainCommandQueue )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_uint ref_count = 0;
         if( pIntercept->config().CallLogging )
         {
@@ -844,6 +870,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseCommandQueue)(
 
     if( pIntercept && pIntercept->dispatch().clReleaseCommandQueue )
     {
+        GET_ENQUEUE_COUNTER();
         REMOVE_QUEUE( command_queue );
 
         cl_uint ref_count = 0;
@@ -896,6 +923,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetCommandQueueInfo)(
 
     if( pIntercept && pIntercept->dispatch().clGetCommandQueueInfo )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "command_queue = %p, param_name = %s (%08X)",
             command_queue,
             pIntercept->enumName().name( param_name ).c_str(),
@@ -931,6 +959,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetCommandQueueProperty)(
 
     if( pIntercept && pIntercept->dispatch().clSetCommandQueueProperty )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
@@ -963,6 +992,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateBuffer)(
 
     if( pIntercept && pIntercept->dispatch().clCreateBuffer )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "context = %p, flags = %s (%llX), size = %zu, host_ptr = %p",
             context,
             pIntercept->enumName().name_mem_flags( flags ).c_str(),
@@ -1009,6 +1039,8 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateBufferWithProperties)(
 
     if( pIntercept && pIntercept->dispatch().clCreateBufferWithProperties )
     {
+        GET_ENQUEUE_COUNTER();
+
         std::string propsStr;
         if( pIntercept->config().CallLogging )
         {
@@ -1067,6 +1099,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateBufferNV(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clCreateBufferNV )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER( "context = %p, flags = %s (%llX), flags_NV = %llX, size = %zu, host_ptr = %p",
                 context,
                 pIntercept->enumName().name_mem_flags( flags ).c_str(),
@@ -1115,6 +1148,8 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateSubBuffer)(
 
     if( pIntercept && pIntercept->dispatch().clCreateSubBuffer )
     {
+        GET_ENQUEUE_COUNTER();
+
         std::string argsString;
         if( pIntercept->config().CallLogging )
         {
@@ -1165,6 +1200,8 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateImage)(
 
     if( pIntercept && pIntercept->dispatch().clCreateImage )
     {
+        GET_ENQUEUE_COUNTER();
+
         if( image_desc && image_format )
         {
             CALL_LOGGING_ENTER(
@@ -1244,6 +1281,8 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateImageWithProperties)(
 
     if( pIntercept && pIntercept->dispatch().clCreateImageWithProperties )
     {
+        GET_ENQUEUE_COUNTER();
+
         if( image_desc && image_format )
         {
             std::string propsStr;
@@ -1333,6 +1372,8 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateImage2D)(
 
     if( pIntercept && pIntercept->dispatch().clCreateImage2D )
     {
+        GET_ENQUEUE_COUNTER();
+
         if( image_format )
         {
             CALL_LOGGING_ENTER(
@@ -1402,6 +1443,8 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateImage3D)(
 
     if( pIntercept && pIntercept->dispatch().clCreateImage3D )
     {
+        GET_ENQUEUE_COUNTER();
+
         if( image_format )
         {
             CALL_LOGGING_ENTER(
@@ -1468,6 +1511,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainMemObject)(
 
     if( pIntercept && pIntercept->dispatch().clRetainMemObject )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_uint ref_count = 0;
         if( pIntercept->config().CallLogging )
         {
@@ -1517,6 +1562,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseMemObject)(
 
     if( pIntercept && pIntercept->dispatch().clReleaseMemObject )
     {
+        GET_ENQUEUE_COUNTER();
         REMOVE_MEMOBJ( memobj );
 
         cl_uint ref_count = 0;
@@ -1569,6 +1615,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetSupportedImageFormats)(
 
     if( pIntercept && pIntercept->dispatch().clGetSupportedImageFormats )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "flags = %s (%llX), image_type = %s (%X)",
             pIntercept->enumName().name_mem_flags( flags ).c_str(),
             flags,
@@ -1607,6 +1654,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetMemObjectInfo)(
 
     if( pIntercept && pIntercept->dispatch().clGetMemObjectInfo )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "mem = %p, param_name = %s (%08X)",
             memobj,
             pIntercept->enumName().name( param_name ).c_str(),
@@ -1643,6 +1691,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetImageInfo)(
 
     if( pIntercept && pIntercept->dispatch().clGetImageInfo )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "mem = %p, param_name = %s (%08X)",
             image,
             pIntercept->enumName().name( param_name ).c_str(),
@@ -1678,6 +1727,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetMemObjectDestructorCallback)(
 
     if( pIntercept && pIntercept->dispatch().clSetMemObjectDestructorCallback )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
@@ -1709,6 +1759,8 @@ CL_API_ENTRY cl_sampler CL_API_CALL CLIRN(clCreateSampler)(
 
     if( pIntercept && pIntercept->dispatch().clCreateSampler )
     {
+        GET_ENQUEUE_COUNTER();
+
         std::string propsStr;
         if( pIntercept->config().CallLogging )
         {
@@ -1757,6 +1809,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainSampler)(
 
     if( pIntercept && pIntercept->dispatch().clRetainSampler )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_uint ref_count = 0;
         if( pIntercept->config().CallLogging )
         {
@@ -1806,6 +1860,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseSampler)(
 
     if( pIntercept && pIntercept->dispatch().clReleaseSampler )
     {
+        GET_ENQUEUE_COUNTER();
         REMOVE_SAMPLER( sampler );
 
         cl_uint ref_count = 0;
@@ -1856,6 +1911,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetSamplerInfo)(
 
     if( pIntercept && pIntercept->dispatch().clGetSamplerInfo )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "param_name = %s (%08X)",
             pIntercept->enumName().name( param_name ).c_str(),
             param_name );
@@ -1891,6 +1947,8 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clCreateProgramWithSource)(
 
     if( pIntercept && pIntercept->dispatch().clCreateProgramWithSource )
     {
+        GET_ENQUEUE_COUNTER();
+
         char*       singleString = NULL;
         uint64_t    hash = 0;
 
@@ -1966,8 +2024,9 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clCreateProgramWithBinary)(
 
     if( pIntercept && pIntercept->dispatch().clCreateProgramWithBinary )
     {
-        uint64_t    hash = 0;
+        GET_ENQUEUE_COUNTER();
 
+        uint64_t    hash = 0;
         COMPUTE_BINARY_HASH( num_devices, lengths, binaries, hash );
 
         CALL_LOGGING_ENTER( "context = %p, num_devices = %u",
@@ -2031,6 +2090,7 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clCreateProgramWithBuiltInKernels)(
 
     if( pIntercept && pIntercept->dispatch().clCreateProgramWithBuiltInKernels )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "context = %p, num_devices = %u, kernel_names = [ %s ]",
             context,
             num_devices,
@@ -2077,6 +2137,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainProgram)(
 
     if( pIntercept && pIntercept->dispatch().clRetainProgram )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_uint ref_count = 0;
         if( pIntercept->config().CallLogging )
         {
@@ -2126,6 +2188,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseProgram)(
 
     if( pIntercept && pIntercept->dispatch().clReleaseProgram )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_uint ref_count = 0;
         if( pIntercept->config().CallLogging )
         {
@@ -2176,6 +2240,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clBuildProgram)(
 
     if( pIntercept && pIntercept->dispatch().clBuildProgram )
     {
+        GET_ENQUEUE_COUNTER();
+
         char*   newOptions = NULL;
 
         SAVE_PROGRAM_OPTIONS_HASH( program, options );
@@ -2229,6 +2295,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clCompileProgram)(
 
     if( pIntercept && pIntercept->dispatch().clCompileProgram )
     {
+        GET_ENQUEUE_COUNTER();
+
         const bool  modified = false;
 
         DUMP_PROGRAM_OPTIONS( program, options );
@@ -2279,6 +2347,8 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clLinkProgram)(
 
     if( pIntercept && pIntercept->dispatch().clLinkProgram )
     {
+        GET_ENQUEUE_COUNTER();
+
         const bool  modified = false;
 
         CALL_LOGGING_ENTER( "context = %p, num_input_programs = %u, pfn_notify = %p",
@@ -2333,6 +2403,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetProgramReleaseCallback)(
 
     if( pIntercept && pIntercept->dispatch().clSetProgramReleaseCallback )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "program = %p", program );
         CPU_PERFORMANCE_TIMING_START();
 
@@ -2364,6 +2435,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetProgramSpecializationConstant)(
 
     if( pIntercept && pIntercept->dispatch().clSetProgramSpecializationConstant )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "program = %p, spec_id = %u, spec_size = %zu",
             program,
             spec_id,
@@ -2396,6 +2468,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clUnloadPlatformCompiler)(
 
     if( pIntercept && pIntercept->dispatch().clUnloadPlatformCompiler )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
@@ -2420,6 +2493,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clUnloadCompiler)( void )
 
     if( pIntercept && pIntercept->dispatch().clUnloadCompiler )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
@@ -2448,6 +2522,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetProgramInfo)(
 
     if( pIntercept && pIntercept->dispatch().clGetProgramInfo )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "param_name = %s (%08X)",
             pIntercept->enumName().name( param_name ).c_str(),
             param_name );
@@ -2484,6 +2559,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetProgramBuildInfo)(
 
     if( pIntercept && pIntercept->dispatch().clGetProgramBuildInfo )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "param_name = %s (%08X)",
             pIntercept->enumName().name( param_name ).c_str(),
             param_name );
@@ -2519,6 +2595,7 @@ CL_API_ENTRY cl_kernel CL_API_CALL CLIRN(clCreateKernel)(
 
     if( pIntercept && pIntercept->dispatch().clCreateKernel )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "program = %p, kernel_name = %s",
             program,
             kernel_name );
@@ -2582,8 +2659,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clCreateKernelsInProgram)(
 
     if( pIntercept && pIntercept->dispatch().clCreateKernelsInProgram )
     {
-        cl_uint local_num_kernels_ret = 0;
+        GET_ENQUEUE_COUNTER();
 
+        cl_uint local_num_kernels_ret = 0;
         if( num_kernels_ret == NULL )
         {
             num_kernels_ret = &local_num_kernels_ret;
@@ -2652,6 +2730,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainKernel)(
 
     if( pIntercept && pIntercept->dispatch().clRetainKernel )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_uint ref_count = 0;
         if( pIntercept->config().CallLogging )
         {
@@ -2701,6 +2781,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseKernel)(
 
     if( pIntercept && pIntercept->dispatch().clReleaseKernel )
     {
+        GET_ENQUEUE_COUNTER();
+
         pIntercept->checkRemoveKernelInfo( kernel );
 
         cl_uint ref_count = 0;
@@ -2751,6 +2833,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetKernelArg)(
 
     if( pIntercept && pIntercept->dispatch().clSetKernelArg )
     {
+        GET_ENQUEUE_COUNTER();
+
         std::string argsString;
         if( pIntercept->config().CallLogging )
         {
@@ -2798,6 +2882,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetKernelInfo)(
 
     if( pIntercept && pIntercept->dispatch().clGetKernelInfo )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER_KERNEL( kernel, "param_name = %s (%X)",
             pIntercept->enumName().name( param_name ).c_str(),
             param_name );
@@ -2835,6 +2920,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetKernelArgInfo)(
 
     if( pIntercept && pIntercept->dispatch().clGetKernelArgInfo )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER_KERNEL( kernel, "param_name = %s (%X)",
             pIntercept->enumName().name( param_name ).c_str(),
             param_name );
@@ -2872,6 +2958,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetKernelWorkGroupInfo)(
 
     if( pIntercept && pIntercept->dispatch().clGetKernelWorkGroupInfo )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER_KERNEL( kernel, "param_name = %s (%X)",
             pIntercept->enumName().name( param_name ).c_str(),
             param_name );
@@ -2905,6 +2992,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clWaitForEvents)(
 
     if( pIntercept && pIntercept->dispatch().clWaitForEvents )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_int  retVal = CL_SUCCESS;
 
         if( pIntercept->config().NullEnqueue == false )
@@ -2952,6 +3041,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetEventInfo)(
 
     if( pIntercept && pIntercept->dispatch().clGetEventInfo )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_int  retVal = CL_SUCCESS;
 
         if( pIntercept->config().NullEnqueue == false )
@@ -2991,6 +3082,8 @@ CL_API_ENTRY cl_event CL_API_CALL CLIRN(clCreateUserEvent)(
 
     if( pIntercept && pIntercept->dispatch().clCreateUserEvent )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_event    retVal = NULL;
 
         if( pIntercept->config().NullEnqueue == false )
@@ -3025,6 +3118,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clRetainEvent)(
 
     if( pIntercept && pIntercept->dispatch().clRetainEvent )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_uint ref_count = 0;
         if( pIntercept->config().CallLogging )
         {
@@ -3074,6 +3169,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseEvent)(
 
     if( pIntercept && pIntercept->dispatch().clReleaseEvent )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_uint ref_count = 0;
         if( pIntercept->config().CallLogging )
         {
@@ -3121,6 +3218,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetUserEventStatus)(
 
     if( pIntercept && pIntercept->dispatch().clSetUserEventStatus )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "event = %p, status = %s (%d)",
             event,
             pIntercept->enumName().name_command_exec_status( execution_status ).c_str(),
@@ -3154,6 +3252,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetEventCallback)(
 
     if( pIntercept && pIntercept->dispatch().clSetEventCallback )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "event = %p, callback_type = %s (%d)",
             event,
             pIntercept->enumName().name_command_exec_status( command_exec_callback_type ).c_str(),
@@ -3191,6 +3290,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetEventProfilingInfo)(
 
     if( pIntercept && pIntercept->dispatch().clGetEventProfilingInfo )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_int  retVal = CL_SUCCESS;
 
         if( pIntercept->config().NullEnqueue == false )
@@ -3227,6 +3328,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clFlush)(
 
     if( pIntercept && pIntercept->dispatch().clFlush )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "queue = %p", command_queue );
         CPU_PERFORMANCE_TIMING_START();
 
@@ -3254,6 +3356,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clFinish)(
 
     if( pIntercept && pIntercept->dispatch().clFinish )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "queue = %p", command_queue );
         CPU_PERFORMANCE_TIMING_START();
 
@@ -3291,6 +3394,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReadBuffer)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -3382,6 +3486,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReadBufferRect)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -3471,6 +3576,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueWriteBuffer)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -3562,6 +3668,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueWriteBufferRect)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -3652,6 +3759,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueFillBuffer)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -3712,6 +3820,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueCopyBuffer)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -3794,6 +3903,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueCopyBufferRect)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -3875,6 +3985,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReadImage)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -3979,6 +4090,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueWriteImage)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -4066,6 +4178,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueFillImage)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -4122,6 +4235,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueCopyImage)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -4196,6 +4310,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueCopyImageToBuffer)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -4254,6 +4369,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueCopyBufferToImage)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -4313,6 +4429,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapBuffer)(
     {
         void*   retVal = NULL;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -4425,6 +4542,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapImage)(
     {
         void*   retVal = NULL;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -4535,6 +4653,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueUnmapMemObject)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         DUMP_BUFFER_BEFORE_UNMAP( memobj, command_queue );
         CHECK_AUBCAPTURE_START( command_queue );
 
@@ -4625,6 +4744,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueMigrateMemObjects)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -4678,6 +4798,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueNDRangeKernel)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         DUMP_BUFFERS_BEFORE_ENQUEUE( kernel, command_queue );
         DUMP_IMAGES_BEFORE_ENQUEUE( kernel, command_queue );
         CHECK_AUBCAPTURE_START_KERNEL(
@@ -4816,6 +4937,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueTask)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START_KERNEL( kernel, 0, NULL, NULL, command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -4879,6 +5001,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueNativeKernel)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -4929,6 +5052,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueMarker)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -4971,6 +5095,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueWaitForEvents)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -5025,6 +5150,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueBarrier)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -5066,6 +5192,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueMarkerWithWaitList)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -5124,6 +5251,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueBarrierWithWaitList)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -5177,6 +5305,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clGetExtensionFunctionAddress)(
 
     if( pIntercept && pIntercept->dispatch().clGetExtensionFunctionAddress )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "func_name = %s", func_name ? func_name : "(NULL)" );
         CPU_PERFORMANCE_TIMING_START();
 
@@ -5221,6 +5350,8 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clGetExtensionFunctionAddressForPlatform)(
 
     if( pIntercept && pIntercept->dispatch().clGetExtensionFunctionAddressForPlatform )
     {
+        GET_ENQUEUE_COUNTER();
+
         std::string platformInfo;
         if( pIntercept->config().CallLogging )
         {
@@ -5286,6 +5417,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLBuffer)(
 
     if( pIntercept && pIntercept->dispatch().clCreateFromGLBuffer )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER(
             "context = %p, "
             "flags = %s (%llX)",
@@ -5335,6 +5467,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture)(
 
     if( pIntercept && pIntercept->dispatch().clCreateFromGLTexture )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER(
             "context = %p, "
             "flags = %s (%llX), "
@@ -5397,6 +5530,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture2D)(
 
     if( pIntercept && pIntercept->dispatch().clCreateFromGLTexture2D )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER(
             "context = %p, "
             "flags = %s (%llX), "
@@ -5459,6 +5593,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLTexture3D)(
 
     if( pIntercept && pIntercept->dispatch().clCreateFromGLTexture3D )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER(
             "context = %p, "
             "flags = %s (%llX), "
@@ -5519,6 +5654,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateFromGLRenderbuffer)(
 
     if( pIntercept && pIntercept->dispatch().clCreateFromGLRenderbuffer )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER(
             "context = %p, "
             "flags = %s (%llX)",
@@ -5565,6 +5701,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetGLObjectInfo)(
 
     if( pIntercept && pIntercept->dispatch().clGetGLObjectInfo )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
@@ -5604,6 +5741,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetGLTextureInfo)(
 
     if( pIntercept && pIntercept->dispatch().clGetGLTextureInfo )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
@@ -5648,6 +5786,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueAcquireGLObjects)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -5706,6 +5845,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReleaseGLObjects)(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -5755,6 +5895,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clSVMAlloc) (
 
     if( pIntercept && pIntercept->dispatch().clSVMAlloc )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "flags = %s (%llX), size = %zu, alignment = %u",
             pIntercept->enumName().name_svm_mem_flags( flags ).c_str(),
             flags,
@@ -5796,6 +5937,7 @@ CL_API_ENTRY void CL_API_CALL CLIRN(clSVMFree) (
 
     if( pIntercept && pIntercept->dispatch().clSVMFree )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "svm_pointer = %p",
             svm_pointer );
         CPU_PERFORMANCE_TIMING_START();
@@ -5833,6 +5975,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMFree) (
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -5888,6 +6031,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMMemcpy) (
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -5943,6 +6087,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMMemFill) (
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -6001,6 +6146,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMMap) (
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -6053,6 +6199,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMUnmap) (
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -6098,6 +6245,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetKernelArgSVMPointer) (
 
     if( pIntercept && pIntercept->dispatch().clSetKernelArgSVMPointer )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER_KERNEL(
             kernel,
             "kernel = %p, index = %u, value = %p",
@@ -6135,6 +6283,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetKernelExecInfo) (
 
     if( pIntercept && pIntercept->dispatch().clSetKernelExecInfo )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER_KERNEL( kernel, "param_name = %s (%08X)",
             pIntercept->enumName().name( param_name ).c_str(),
             param_name );
@@ -6185,6 +6334,7 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreatePipe) (
 
     if( pIntercept && pIntercept->dispatch().clCreatePipe )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "context = %p, flags = %s (%llX), pipe_packet_size = %u, pipe_max_packets = %u",
             context,
             pIntercept->enumName().name_mem_flags( flags ).c_str(),
@@ -6227,6 +6377,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetPipeInfo) (
 
     if( pIntercept && pIntercept->dispatch().clGetPipeInfo )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER( "mem = %p, param_name = %s (%08X)",
             pipe,
             pIntercept->enumName().name( param_name ).c_str(),
@@ -6263,6 +6414,8 @@ CL_API_ENTRY cl_command_queue CL_API_CALL CLIRN(clCreateCommandQueueWithProperti
 
     if( pIntercept && pIntercept->dispatch().clCreateCommandQueueWithProperties )
     {
+        GET_ENQUEUE_COUNTER();
+
         cl_queue_properties*    newProperties = NULL;
         cl_command_queue    retVal = NULL;
 
@@ -6355,6 +6508,8 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithPropertiesKHR(
         auto dispatchX = pIntercept->dispatchX(device);
         if( dispatchX.clCreateCommandQueueWithPropertiesKHR )
         {
+            GET_ENQUEUE_COUNTER();
+
             cl_queue_properties*    newProperties = NULL;
             cl_command_queue    retVal = NULL;
 
@@ -6443,6 +6598,8 @@ CL_API_ENTRY cl_sampler CL_API_CALL CLIRN(clCreateSamplerWithProperties) (
 
     if( pIntercept && pIntercept->dispatch().clCreateSamplerWithProperties )
     {
+        GET_ENQUEUE_COUNTER();
+
         std::string propsStr;
         if( pIntercept->config().CallLogging )
         {
@@ -6485,6 +6642,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetDefaultDeviceCommandQueue) (
 
     if( pIntercept && pIntercept->dispatch().clSetDefaultDeviceCommandQueue )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
@@ -6515,6 +6673,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetDeviceAndHostTimer) (
 
     if( pIntercept && pIntercept->dispatch().clGetDeviceAndHostTimer )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
@@ -6544,6 +6703,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetHostTimer) (
 
     if( pIntercept && pIntercept->dispatch().clGetHostTimer )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
@@ -6574,6 +6734,8 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clCreateProgramWithIL) (
 
     if( pIntercept && pIntercept->dispatch().clCreateProgramWithIL )
     {
+        GET_ENQUEUE_COUNTER();
+
         char*       injectedSPIRV = NULL;
         uint64_t    hash = 0;
 
@@ -6624,6 +6786,8 @@ CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithILKHR(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clCreateProgramWithILKHR )
         {
+            GET_ENQUEUE_COUNTER();
+
             char*       injectedSPIRV = NULL;
             uint64_t    hash = 0;
 
@@ -6669,6 +6833,7 @@ CL_API_ENTRY cl_kernel CL_API_CALL CLIRN(clCloneKernel) (
 
     if( pIntercept && pIntercept->dispatch().clCloneKernel )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER();
         CHECK_ERROR_INIT( errcode_ret );
         CPU_PERFORMANCE_TIMING_START();
@@ -6704,12 +6869,11 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clGetKernelSubGroupInfo) (
 
     if( pIntercept && pIntercept->dispatch().clGetKernelSubGroupInfo )
     {
-        cl_int  retVal = CL_SUCCESS;
-
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
-        retVal = pIntercept->dispatch().clGetKernelSubGroupInfo(
+        cl_int retVal = pIntercept->dispatch().clGetKernelSubGroupInfo(
             kernel,
             device,
             param_name,
@@ -6750,12 +6914,11 @@ CL_API_ENTRY cl_int CL_API_CALL clGetKernelSubGroupInfoKHR(
         auto dispatchX = pIntercept->dispatchX(kernel);
         if( dispatchX.clGetKernelSubGroupInfoKHR )
         {
-            cl_int  retVal = CL_SUCCESS;
-
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER();
             CPU_PERFORMANCE_TIMING_START();
 
-            retVal = dispatchX.clGetKernelSubGroupInfoKHR(
+            cl_int retVal = dispatchX.clGetKernelSubGroupInfoKHR(
                 kernel,
                 device,
                 param_name,
@@ -6795,6 +6958,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueSVMMigrateMem(
     {
         cl_int  retVal = CL_SUCCESS;
 
+        INCREMENT_ENQUEUE_COUNTER();
         CHECK_AUBCAPTURE_START( command_queue );
 
         if( pIntercept->config().NullEnqueue == false )
@@ -6851,6 +7015,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetGLContextInfoKHR(
 
     if( pIntercept && pIntercept->dispatch().clGetGLContextInfoKHR )
     {
+        GET_ENQUEUE_COUNTER();
         CALL_LOGGING_ENTER();
         CPU_PERFORMANCE_TIMING_START();
 
@@ -6886,6 +7051,7 @@ CL_API_ENTRY cl_event CL_API_CALL clCreateEventFromGLsyncKHR(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clCreateEventFromGLsyncKHR )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER( "context = %p",
                 context );
             CHECK_ERROR_INIT( errcode_ret );
@@ -6929,6 +7095,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D10KHR(
         auto dispatchX = pIntercept->dispatchX(platform);
         if( dispatchX.clGetDeviceIDsFromD3D10KHR )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER();
             CPU_PERFORMANCE_TIMING_START();
 
@@ -6968,6 +7135,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10BufferKHR(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clCreateFromD3D10BufferKHR )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER(
                 "context = %p, "
                 "flags = %s (%llX)",
@@ -7013,6 +7181,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture2DKHR(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clCreateFromD3D10Texture2DKHR )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER(
                 "context = %p, "
                 "flags = %s (%llX)",
@@ -7059,6 +7228,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture3DKHR(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clCreateFromD3D10Texture3DKHR )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER(
                 "context = %p, "
                 "flags = %s (%llX)",
@@ -7108,6 +7278,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D10ObjectsKHR(
         {
             cl_int  retVal = CL_SUCCESS;
 
+            INCREMENT_ENQUEUE_COUNTER();
             CHECK_AUBCAPTURE_START( command_queue );
 
             if( pIntercept->config().NullEnqueue == false )
@@ -7162,6 +7333,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D10ObjectsKHR(
         {
             cl_int  retVal = CL_SUCCESS;
 
+            INCREMENT_ENQUEUE_COUNTER();
             CHECK_AUBCAPTURE_START( command_queue );
 
             if( pIntercept->config().NullEnqueue == false )
@@ -7217,6 +7389,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D11KHR(
         auto dispatchX = pIntercept->dispatchX(platform);
         if( dispatchX.clGetDeviceIDsFromD3D11KHR )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER();
             CPU_PERFORMANCE_TIMING_START();
 
@@ -7256,6 +7429,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11BufferKHR(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clCreateFromD3D11BufferKHR )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER(
                 "context = %p, "
                 "flags = %s (%llX)",
@@ -7301,6 +7475,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture2DKHR(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clCreateFromD3D11Texture2DKHR )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER(
                 "context = %p, "
                 "flags = %s (%llX)",
@@ -7347,6 +7522,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture3DKHR(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clCreateFromD3D11Texture3DKHR )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER(
                 "context = %p, "
                 "flags = %s (%llX)",
@@ -7396,6 +7572,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D11ObjectsKHR(
         {
             cl_int  retVal = CL_SUCCESS;
 
+            INCREMENT_ENQUEUE_COUNTER();
             CHECK_AUBCAPTURE_START( command_queue );
 
             if( pIntercept->config().NullEnqueue == false )
@@ -7450,6 +7627,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D11ObjectsKHR(
         {
             cl_int  retVal = CL_SUCCESS;
 
+            INCREMENT_ENQUEUE_COUNTER();
             CHECK_AUBCAPTURE_START( command_queue );
 
             if( pIntercept->config().NullEnqueue == false )
@@ -7506,6 +7684,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromDX9MediaAdapterKHR(
         auto dispatchX = pIntercept->dispatchX(platform);
         if( dispatchX.clGetDeviceIDsFromDX9MediaAdapterKHR )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER();
             CPU_PERFORMANCE_TIMING_START();
 
@@ -7548,6 +7727,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceKHR(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clCreateFromDX9MediaSurfaceKHR )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER(
                 "context = %p, "
                 "flags = %s (%llX)",
@@ -7598,6 +7778,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireDX9MediaSurfacesKHR(
         {
             cl_int  retVal = CL_SUCCESS;
 
+            INCREMENT_ENQUEUE_COUNTER();
             CHECK_AUBCAPTURE_START( command_queue );
 
             if( pIntercept->config().NullEnqueue == false )
@@ -7652,6 +7833,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseDX9MediaSurfacesKHR(
         {
             cl_int  retVal = CL_SUCCESS;
 
+            INCREMENT_ENQUEUE_COUNTER();
             CHECK_AUBCAPTURE_START( command_queue );
 
             if( pIntercept->config().NullEnqueue == false )
@@ -7709,6 +7891,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromDX9INTEL(
         auto dispatchX = pIntercept->dispatchX(platform);
         if( dispatchX.clGetDeviceIDsFromDX9INTEL )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER();
             CPU_PERFORMANCE_TIMING_START();
 
@@ -7750,6 +7933,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceINTEL(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clCreateFromDX9MediaSurfaceINTEL )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER(
                 "context = %p, "
                 "flags = %s (%llX)",
@@ -7800,6 +7984,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireDX9ObjectsINTEL(
         {
             cl_int  retVal = CL_SUCCESS;
 
+            INCREMENT_ENQUEUE_COUNTER();
             CHECK_AUBCAPTURE_START( command_queue );
 
             if( pIntercept->config().NullEnqueue == false )
@@ -7854,6 +8039,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseDX9ObjectsINTEL(
         {
             cl_int  retVal = CL_SUCCESS;
 
+            INCREMENT_ENQUEUE_COUNTER();
             CHECK_AUBCAPTURE_START( command_queue );
 
             if( pIntercept->config().NullEnqueue == false )
@@ -7908,6 +8094,8 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreatePerfCountersCommandQueueINTEL(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clCreatePerfCountersCommandQueueINTEL )
         {
+            GET_ENQUEUE_COUNTER();
+
             // We don't have to do this, since profiling must be enabled
             // for a perf counters command queue, but it doesn't hurt to
             // add it, either.
@@ -7960,6 +8148,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetPerformanceConfigurationINTEL(
         auto dispatchX = pIntercept->dispatchX(device);
         if( dispatchX.clSetPerformanceConfigurationINTEL )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER();
             CPU_PERFORMANCE_TIMING_START();
 
@@ -7998,6 +8187,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetKernelSuggestedLocalWorkSizeINTEL(
         auto dispatchX = pIntercept->dispatchX(commandQueue);
         if( dispatchX.clGetKernelSuggestedLocalWorkSizeINTEL )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER_KERNEL(
                 kernel,
                 "queue = %p, kernel = %p",
@@ -8041,6 +8231,8 @@ CL_API_ENTRY cl_accelerator_intel CL_API_CALL clCreateAcceleratorINTEL(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clCreateAcceleratorINTEL )
         {
+            GET_ENQUEUE_COUNTER();
+
             if( ( accelerator_type == CL_ACCELERATOR_TYPE_MOTION_ESTIMATION_INTEL ) &&
                 ( descriptor_size >= sizeof( cl_motion_estimation_desc_intel ) ) )
             {
@@ -8105,6 +8297,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetAcceleratorInfoINTEL(
         auto dispatchX = pIntercept->dispatchX(accelerator);
         if( dispatchX.clGetAcceleratorInfoINTEL )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER( "param_name = %s (%X)",
                 pIntercept->enumName().name( param_name ).c_str(),
                 param_name );
@@ -8141,6 +8334,8 @@ CL_API_ENTRY cl_int CL_API_CALL clRetainAcceleratorINTEL(
         auto dispatchX = pIntercept->dispatchX(accelerator);
         if( dispatchX.clRetainAcceleratorINTEL )
         {
+            GET_ENQUEUE_COUNTER();
+
             cl_uint ref_count = 0;
             if( pIntercept->config().CallLogging )
             {
@@ -8194,6 +8389,8 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseAcceleratorINTEL(
         auto dispatchX = pIntercept->dispatchX(accelerator);
         if( dispatchX.clReleaseAcceleratorINTEL )
         {
+            GET_ENQUEUE_COUNTER();
+
             pIntercept->checkRemoveAcceleratorInfo( accelerator );
 
             cl_uint ref_count = 0;
@@ -8251,6 +8448,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromVA_APIMediaAdapterINTEL(
         auto dispatchX = pIntercept->dispatchX(platform);
         if( dispatchX.clGetDeviceIDsFromVA_APIMediaAdapterINTEL )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER();
             CPU_PERFORMANCE_TIMING_START();
 
@@ -8291,6 +8489,7 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateFromVA_APIMediaSurfaceINTEL(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clCreateFromVA_APIMediaSurfaceINTEL )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER(
                 "context = %p, "
                 "flags = %s (%llX)",
@@ -8340,6 +8539,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireVA_APIMediaSurfacesINTEL(
         {
             cl_int  retVal = CL_SUCCESS;
 
+            INCREMENT_ENQUEUE_COUNTER();
             CHECK_AUBCAPTURE_START( command_queue );
 
             if( pIntercept->config().NullEnqueue == false )
@@ -8394,6 +8594,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseVA_APIMediaSurfacesINTEL(
         {
             cl_int  retVal = CL_SUCCESS;
 
+            INCREMENT_ENQUEUE_COUNTER();
             CHECK_AUBCAPTURE_START( command_queue );
 
             if( pIntercept->config().NullEnqueue == false )
@@ -8447,6 +8648,7 @@ CL_API_ENTRY void* CL_API_CALL clHostMemAllocINTEL(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clHostMemAllocINTEL )
         {
+            GET_ENQUEUE_COUNTER();
             // TODO: Make properties string.
             CALL_LOGGING_ENTER( "context = %p, properties = %p, size = %zu, alignment = %u",
                 context,
@@ -8492,6 +8694,8 @@ CL_API_ENTRY void* CL_API_CALL clDeviceMemAllocINTEL(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clDeviceMemAllocINTEL )
         {
+            GET_ENQUEUE_COUNTER();
+
             std::string deviceInfo;
             if( pIntercept->config().CallLogging )
             {
@@ -8547,6 +8751,8 @@ CL_API_ENTRY void* CL_API_CALL clSharedMemAllocINTEL(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clSharedMemAllocINTEL )
         {
+            GET_ENQUEUE_COUNTER();
+
             std::string deviceInfo;
             if( pIntercept->config().CallLogging )
             {
@@ -8598,6 +8804,7 @@ CL_API_ENTRY cl_int CL_API_CALL clMemFreeINTEL(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clMemFreeINTEL )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER( "context = %p, ptr = %p",
                 context,
                 ptr );
@@ -8633,6 +8840,7 @@ clMemBlockingFreeINTEL(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clMemBlockingFreeINTEL )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER( "context = %p, ptr = %p",
                 context,
                 ptr );
@@ -8671,6 +8879,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetMemAllocInfoINTEL(
         auto dispatchX = pIntercept->dispatchX(context);
         if( dispatchX.clGetMemAllocInfoINTEL )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER( "context = %p, ptr = %p, param_name = %s (%08X)",
                 context,
                 ptr,
@@ -8712,6 +8921,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgMemPointerINTEL(
         auto dispatchX = pIntercept->dispatchX(kernel);
         if( dispatchX.clSetKernelArgMemPointerINTEL )
         {
+            GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER_KERNEL(
                 kernel,
                 "kernel = %p, index = %u, value = %p",
@@ -8758,6 +8968,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemsetINTEL(   // Deprecated
         {
             cl_int  retVal = CL_SUCCESS;
 
+            INCREMENT_ENQUEUE_COUNTER();
             CHECK_AUBCAPTURE_START( queue );
 
             if( pIntercept->config().NullEnqueue == false )
@@ -8819,6 +9030,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemFillINTEL(
         {
             cl_int  retVal = CL_SUCCESS;
 
+            INCREMENT_ENQUEUE_COUNTER();
             CHECK_AUBCAPTURE_START( queue );
 
             if( pIntercept->config().NullEnqueue == false )
@@ -8881,6 +9093,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemcpyINTEL(
         {
             cl_int  retVal = CL_SUCCESS;
 
+            INCREMENT_ENQUEUE_COUNTER();
             CHECK_AUBCAPTURE_START( queue );
 
             if( pIntercept->config().NullEnqueue == false )
@@ -8943,6 +9156,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMigrateMemINTEL(
         {
             cl_int  retVal = CL_SUCCESS;
 
+            INCREMENT_ENQUEUE_COUNTER();
             CHECK_AUBCAPTURE_START( queue );
 
             if( pIntercept->config().NullEnqueue == false )
@@ -9004,6 +9218,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemAdviseINTEL(
         {
             cl_int  retVal = CL_SUCCESS;
 
+            INCREMENT_ENQUEUE_COUNTER();
             CHECK_AUBCAPTURE_START( queue );
 
             if( pIntercept->config().NullEnqueue == false )

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -4200,7 +4200,7 @@ void CLIntercept::dumpInputProgramBinaries(
         }
         if( deviceType & CL_DEVICE_TYPE_ACCELERATOR )
         {
-            outputFileName += "_ACCELERATOR";
+            outputFileName += "_ACC";
         }
         if( deviceType & CL_DEVICE_TYPE_CUSTOM )
         {
@@ -4592,7 +4592,7 @@ void CLIntercept::dumpProgramBuildLog(
     }
     if( deviceType & CL_DEVICE_TYPE_ACCELERATOR )
     {
-        fileName += "_ACCELERATOR";
+        fileName += "_ACC";
     }
     if( deviceType & CL_DEVICE_TYPE_CUSTOM )
     {
@@ -5339,6 +5339,7 @@ void CLIntercept::checkTimingEvents()
 
                     chromeTraceEvent(
                         name,
+                        node.EnqueueCounter,
                         node.QueueNumber,
                         node.Event,
                         node.QueuedTime );
@@ -7456,7 +7457,7 @@ cl_program CLIntercept::createProgramWithInjectionBinaries(
                 }
                 if( deviceType & CL_DEVICE_TYPE_ACCELERATOR )
                 {
-                    suffix += "_ACCELERATOR";
+                    suffix += "_ACC";
                 }
                 if( deviceType & CL_DEVICE_TYPE_CUSTOM )
                 {
@@ -7725,7 +7726,7 @@ void CLIntercept::dumpProgramBinary(
                 }
                 if( deviceType & CL_DEVICE_TYPE_ACCELERATOR )
                 {
-                    outputFileName += "_ACCELERATOR";
+                    outputFileName += "_ACC";
                 }
                 if( deviceType & CL_DEVICE_TYPE_CUSTOM )
                 {
@@ -7921,7 +7922,7 @@ void CLIntercept::dumpKernelISABinaries(
                     }
                     if( deviceType & CL_DEVICE_TYPE_ACCELERATOR )
                     {
-                        fileName += "ACCELERATOR_";
+                        fileName += "ACC_";
                     }
                     if( deviceType & CL_DEVICE_TYPE_CUSTOM )
                     {
@@ -11437,7 +11438,7 @@ void CLIntercept::ittRegisterCommandQueue(
         }
         if( deviceType & CL_DEVICE_TYPE_ACCELERATOR )
         {
-            trackName += " ACCELERATOR";
+            trackName += " ACC";
         }
         if( deviceType & CL_DEVICE_TYPE_CUSTOM )
         {
@@ -11694,7 +11695,8 @@ void CLIntercept::chromeCallLoggingExit(
         << ", \"name\":\"" << str
         << "\", \"ts\":" << usStart
         << ", \"dur\":" << usDelta
-        << "},\n";
+        << ", \"args\":{\"id\":" << m_EnqueueCounter
+        << "}},\n";
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11754,7 +11756,7 @@ void CLIntercept::chromeRegisterCommandQueue(
         }
         if( deviceType & CL_DEVICE_TYPE_ACCELERATOR )
         {
-            trackName += "ACCELERATOR";
+            trackName += "ACC";
         }
         if( deviceType & CL_DEVICE_TYPE_CUSTOM )
         {
@@ -11793,6 +11795,7 @@ void CLIntercept::chromeRegisterCommandQueue(
 //
 void CLIntercept::chromeTraceEvent(
     const std::string& name,
+    uint64_t enqueueCounter,
     unsigned int queueNumber,
     cl_event event,
     const clock::time_point queuedTime )
@@ -11887,7 +11890,8 @@ void CLIntercept::chromeTraceEvent(
                     << ", \"ts\":" << usStarts[state]
                     << ", \"dur\":" << usDeltas[state]
                     << ", \"cname\":\"" << colours[state]
-                    << "\"},\n";
+                    << "\", \"args\":{\"id\":" << enqueueCounter
+                    << "}},\n";
             }
             m_EventsChromeTraced++;
         }
@@ -11903,7 +11907,8 @@ void CLIntercept::chromeTraceEvent(
                 << ", \"name\":\"" << name
                 << "\", \"ts\":" << usStart
                 << ", \"dur\":" << usDelta
-                << "},\n";
+                << ", \"args\":{\"id\":" << enqueueCounter
+                << "}},\n";
         }
     }
     else

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -5526,16 +5526,8 @@ void CLIntercept::checkRemoveKernelInfo( cl_kernel kernel )
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
 
-    cl_uint refCount = 0;
-    cl_int  errorCode = CL_SUCCESS;
-
-    errorCode = dispatch().clGetKernelInfo(
-        kernel,
-        CL_KERNEL_REFERENCE_COUNT,
-        sizeof( refCount ),
-        &refCount,
-        NULL );
-    if( errorCode == CL_SUCCESS && refCount == 1 )
+    cl_uint refCount = getRefCount( kernel );
+    if( refCount == 1 )
     {
 #if 0
         // We shouldn't remove the kernel name from the local kernel name map
@@ -5611,16 +5603,8 @@ void CLIntercept::checkRemoveSamplerString(
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
 
-    cl_uint refCount = 0;
-    cl_int  errorCode = CL_SUCCESS;
-
-    errorCode = dispatch().clGetSamplerInfo(
-        sampler,
-        CL_SAMPLER_REFERENCE_COUNT,
-        sizeof( refCount ),
-        &refCount,
-        NULL );
-    if( errorCode == CL_SUCCESS && refCount == 1 )
+    cl_uint refCount = getRefCount( sampler );
+    if( refCount == 1 )
     {
         m_SamplerDataMap.erase( sampler );
     }
@@ -5674,22 +5658,14 @@ void CLIntercept::checkRemoveQueue(
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
 
-    cl_uint refCount = 0;
-    cl_int  errorCode = CL_SUCCESS;
-
-    errorCode = dispatch().clGetCommandQueueInfo(
-        queue,
-        CL_QUEUE_REFERENCE_COUNT,
-        sizeof( refCount ),
-        &refCount,
-        NULL );
-    if( errorCode == CL_SUCCESS && refCount == 1 )
+    cl_uint refCount = getRefCount( queue );
+    if( refCount == 1 )
     {
         m_QueueNumberMap.erase( queue );
 
         cl_context  context = NULL;
 
-        errorCode = dispatch().clGetCommandQueueInfo(
+        cl_int errorCode = dispatch().clGetCommandQueueInfo(
             queue,
             CL_QUEUE_CONTEXT,
             sizeof(context),
@@ -5837,16 +5813,8 @@ void CLIntercept::checkRemoveMemObj(
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
 
-    cl_uint refCount = 0;
-    cl_int  errorCode = CL_SUCCESS;
-
-    errorCode = dispatch().clGetMemObjectInfo(
-        memobj,
-        CL_MEM_REFERENCE_COUNT,
-        sizeof( refCount ),
-        &refCount,
-        NULL );
-    if( errorCode == CL_SUCCESS && refCount == 1 )
+    cl_uint refCount = getRefCount( memobj );
+    if( refCount == 1 )
     {
         m_MemAllocNumberMap.erase( memobj );
         m_BufferInfoMap.erase( memobj );
@@ -11478,20 +11446,10 @@ void CLIntercept::ittReleaseCommandQueue(
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
 
-    cl_int  errorCode = CL_SUCCESS;
-    cl_uint refCount = 0;
-
     if( m_ITTQueueInfoMap.find(queue) != m_ITTQueueInfoMap.end() )
     {
-        errorCode = dispatch().clGetCommandQueueInfo(
-            queue,
-            CL_QUEUE_REFERENCE_COUNT,
-            sizeof( refCount ),
-            &refCount,
-            NULL );
-
-        if( ( errorCode == CL_SUCCESS ) &&
-            ( refCount == 1 ) )
+        cl_uint refCount = getRefCount( queue );
+        if( refCount == 1 )
         {
             dispatch().clReleaseCommandQueue( queue );
             m_ITTQueueInfoMap.erase( queue );

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -1659,6 +1659,10 @@ inline bool CLIntercept::checkDumpImageEnqueueLimits() const
     }
 
 #define SET_KERNEL_ARG( kernel, arg_index, arg_size, arg_value )            \
+    if ( pIntercept->config().DumpArgumentsOnSet )                          \
+    {                                                                       \
+        pIntercept->dumpArgument( kernel, arg_index, arg_size, arg_value ); \
+    }                                                                       \
     if( ( pIntercept->config().DumpBuffersBeforeEnqueue ||                  \
           pIntercept->config().DumpBuffersAfterEnqueue ||                   \
           pIntercept->config().DumpImagesBeforeEnqueue ||                   \

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -660,6 +660,15 @@ public:
     cl_platform_id  getPlatform( cl_kernel kernel ) const;
     cl_platform_id  getPlatform( cl_mem memobj ) const;
 
+    cl_uint getRefCount( cl_command_queue queue ) const;
+    cl_uint getRefCount( cl_context conest ) const;
+    cl_uint getRefCount( cl_device_id device ) const;
+    cl_uint getRefCount( cl_event event ) const;
+    cl_uint getRefCount( cl_program program ) const;
+    cl_uint getRefCount( cl_kernel kernel ) const;
+    cl_uint getRefCount( cl_mem memobj ) const;
+    cl_uint getRefCount( cl_sampler sampler ) const;
+
     const OS::Services& OS() const;
 
     const CEnumNameMap& enumName() const;
@@ -1308,6 +1317,104 @@ inline cl_platform_id CLIntercept::getPlatform( cl_mem memobj ) const
         &context,
         NULL);
     return getPlatform(context);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+inline cl_uint CLIntercept::getRefCount( cl_command_queue queue ) const
+{
+    cl_uint refCount = 0;
+    dispatch().clGetCommandQueueInfo(
+        queue,
+        CL_QUEUE_REFERENCE_COUNT,
+        sizeof(refCount),
+        &refCount,
+        NULL);
+    return refCount;
+}
+
+inline cl_uint CLIntercept::getRefCount( cl_context context ) const
+{
+    cl_uint refCount = 0;
+    dispatch().clGetContextInfo(
+        context,
+        CL_CONTEXT_REFERENCE_COUNT,
+        sizeof(refCount),
+        &refCount,
+        NULL);
+    return refCount;
+}
+
+inline cl_uint CLIntercept::getRefCount( cl_device_id device ) const
+{
+    cl_uint refCount = 0;
+    dispatch().clGetDeviceInfo(
+        device,
+        CL_DEVICE_REFERENCE_COUNT,
+        sizeof(refCount),
+        &refCount,
+        NULL);
+    return refCount;
+}
+
+inline cl_uint CLIntercept::getRefCount( cl_event event ) const
+{
+    cl_uint refCount = 0;
+    dispatch().clGetEventInfo(
+        event,
+        CL_EVENT_REFERENCE_COUNT,
+        sizeof(refCount),
+        &refCount,
+        NULL);
+    return refCount;
+}
+
+inline cl_uint CLIntercept::getRefCount( cl_program program ) const
+{
+    cl_uint refCount = 0;
+    dispatch().clGetProgramInfo(
+        program,
+        CL_PROGRAM_REFERENCE_COUNT,
+        sizeof(refCount),
+        &refCount,
+        NULL);
+    return refCount;
+}
+
+inline cl_uint CLIntercept::getRefCount( cl_kernel kernel ) const
+{
+    cl_uint refCount = 0;
+    dispatch().clGetKernelInfo(
+        kernel,
+        CL_KERNEL_REFERENCE_COUNT,
+        sizeof(refCount),
+        &refCount,
+        NULL);
+    return refCount;
+}
+
+inline cl_uint CLIntercept::getRefCount( cl_mem memobj ) const
+{
+    cl_uint refCount = 0;
+    dispatch().clGetMemObjectInfo(
+        memobj,
+        CL_MEM_REFERENCE_COUNT,
+        sizeof(refCount),
+        &refCount,
+        NULL);
+    return refCount;
+}
+
+inline cl_uint CLIntercept::getRefCount( cl_sampler sampler ) const
+{
+    cl_uint refCount = 0;
+    dispatch().clGetSamplerInfo(
+        sampler,
+        CL_SAMPLER_REFERENCE_COUNT,
+        sizeof(refCount),
+        &refCount,
+        NULL);
+    return refCount;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -709,6 +709,7 @@ public:
                 cl_command_queue queue );
     void    chromeTraceEvent(
                 const std::string& name,
+                uint64_t enqueueCounter,
                 unsigned int queueNumber,
                 cl_event event,
                 clock::time_point queuedTime );

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -75,9 +75,11 @@ public:
 
     void    callLoggingEnter(
                 const std::string& functionName,
+                const uint64_t enqueueCounter,
                 const cl_kernel kernel );
     void    callLoggingEnter(
                 const std::string& functionName,
+                const uint64_t enqueueCounter,
                 const cl_kernel kernel,
                 const char* formatStr,
                 ... );
@@ -249,8 +251,6 @@ public:
                 cl_event event,
                 cl_int status );
 
-    void    incrementEnqueueCounter();
-
     void    overrideNullLocalWorkSize(
                 const cl_uint work_dim,
                 const size_t* global_work_size,
@@ -367,10 +367,13 @@ public:
                 cl_queue_properties*& pLocalQueueProperties ) const;
     void    createCommandQueuePropertiesCleanup(
                 cl_queue_properties*& pLocalQueueProperties ) const;
-    bool    checkHostPerformanceTimingEnqueueLimits() const;
-    bool    checkDevicePerformanceTimingEnqueueLimits() const;
+    bool    checkHostPerformanceTimingEnqueueLimits(
+                uint64_t enqueueCounter ) const;
+    bool    checkDevicePerformanceTimingEnqueueLimits(
+                uint64_t enqueueCounter ) const;
     void    addTimingEvent(
                 const std::string& functionName,
+                const uint64_t enqueueCounter,
                 const clock::time_point queuedTime,
                 const cl_kernel kernel,
                 const cl_uint workDim,
@@ -440,20 +443,24 @@ public:
                 const void* arg );
     void    dumpBuffersForKernel(
                 const std::string& name,
+                const uint64_t enqueueCounter,
                 cl_kernel kernel,
                 cl_command_queue command_queue );
     void    dumpImagesForKernel(
                 const std::string& name,
+                const uint64_t enqueueCounter,
                 cl_kernel kernel,
                 cl_command_queue command_queue );
 
     void    dumpArgument(
+                const uint64_t enqueueCounter,
                 cl_kernel kernel,
                 cl_int arg_index,
                 size_t size,
                 const void *pBuffer );
     void    dumpBuffer(
                 const std::string& name,
+                const uint64_t enqueueCounter,
                 cl_mem memobj,
                 cl_command_queue command_queue,
                 void* ptr,
@@ -471,6 +478,7 @@ public:
 
     void    startAubCapture(
                 const std::string& functionName,
+                const uint64_t enqueueCounter,
                 const cl_kernel kernel,
                 const cl_uint workDim,
                 const size_t* gws,
@@ -658,14 +666,17 @@ public:
 
     const Config&   config() const;
 
+    uint64_t    getEnqueueCounter() const;
+    uint64_t    incrementEnqueueCounter();
+
     CObjectTracker& objectTracker();
 
     bool    dumpBufferForKernel( const cl_kernel kernel );
     bool    dumpImagesForKernel( const cl_kernel kernel );
-    bool    checkDumpBufferEnqueueLimits() const;
-    bool    checkDumpImageEnqueueLimits() const;
+    bool    checkDumpBufferEnqueueLimits( uint64_t enqueueCounter ) const;
+    bool    checkDumpImageEnqueueLimits( uint64_t enqueueCounter ) const;
 
-    bool    checkAubCaptureEnqueueLimits() const;
+    bool    checkAubCaptureEnqueueLimits( uint64_t enqueueCounter ) const;
     bool    checkAubCaptureKernelSignature(
                 const cl_kernel kernel,
                 cl_uint workDim,
@@ -702,6 +713,7 @@ public:
 
     void    chromeCallLoggingExit(
                 const std::string& functionName,
+                const uint64_t enqueueCounter,
                 const cl_kernel kernel,
                 clock::time_point start,
                 clock::time_point end );
@@ -1321,6 +1333,25 @@ inline const CLIntercept::Config& CLIntercept::config() const
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+inline uint64_t CLIntercept::getEnqueueCounter() const
+{
+    return m_EnqueueCounter;
+}
+
+inline uint64_t CLIntercept::incrementEnqueueCounter()
+{
+    std::lock_guard<std::mutex> lock(m_Mutex);
+    return m_EnqueueCounter++;
+}
+
+#define GET_ENQUEUE_COUNTER()                                               \
+    uint64_t enqueueCounter = pIntercept->getEnqueueCounter();
+
+#define INCREMENT_ENQUEUE_COUNTER()                                         \
+    uint64_t enqueueCounter = pIntercept->incrementEnqueueCounter();
+
+///////////////////////////////////////////////////////////////////////////////
+//
 inline CObjectTracker& CLIntercept::objectTracker()
 {
     return m_ObjectTracker;
@@ -1376,14 +1407,16 @@ inline CObjectTracker& CLIntercept::objectTracker()
 #define CALL_LOGGING_ENTER(...)                                             \
     if( pIntercept->config().CallLogging )                                  \
     {                                                                       \
-        pIntercept->callLoggingEnter( __FUNCTION__, NULL, ##__VA_ARGS__ );  \
+        pIntercept->callLoggingEnter(                                       \
+            __FUNCTION__, enqueueCounter, NULL, ##__VA_ARGS__ );            \
     }                                                                       \
     ITT_CALL_LOGGING_ENTER( NULL );
 
 #define CALL_LOGGING_ENTER_KERNEL(kernel, ...)                              \
     if( pIntercept->config().CallLogging )                                  \
     {                                                                       \
-        pIntercept->callLoggingEnter( __FUNCTION__, kernel, ##__VA_ARGS__ );\
+        pIntercept->callLoggingEnter(                                       \
+            __FUNCTION__, enqueueCounter, kernel, ##__VA_ARGS__ );          \
     }                                                                       \
     ITT_CALL_LOGGING_ENTER( kernel );
 
@@ -1506,7 +1539,6 @@ inline CObjectTracker& CLIntercept::objectTracker()
 ///////////////////////////////////////////////////////////////////////////////
 //
 #define FINISH_OR_FLUSH_AFTER_ENQUEUE( _command_queue )                     \
-    pIntercept->incrementEnqueueCounter();                                  \
     if( pIntercept->config().FinishAfterEnqueue )                           \
     {                                                                       \
         pIntercept->logFlushOrFinishAfterEnqueueStart(                      \
@@ -1562,16 +1594,18 @@ inline bool CLIntercept::dumpImagesForKernel( const cl_kernel kernel )
         m_KernelInfoMap[ kernel ].KernelName == m_Config.DumpImagesForKernel;
 }
 
-inline bool CLIntercept::checkDumpBufferEnqueueLimits() const
+inline bool CLIntercept::checkDumpBufferEnqueueLimits(
+    uint64_t enqueueCounter ) const
 {
-    return ( m_EnqueueCounter >= m_Config.DumpBuffersMinEnqueue ) &&
-           ( m_EnqueueCounter <= m_Config.DumpBuffersMaxEnqueue );
+    return ( enqueueCounter >= m_Config.DumpBuffersMinEnqueue ) &&
+           ( enqueueCounter <= m_Config.DumpBuffersMaxEnqueue );
 }
 
-inline bool CLIntercept::checkDumpImageEnqueueLimits() const
+inline bool CLIntercept::checkDumpImageEnqueueLimits(
+    uint64_t enqueueCounter ) const
 {
-    return ( m_EnqueueCounter >= m_Config.DumpImagesMinEnqueue ) &&
-           ( m_EnqueueCounter <= m_Config.DumpImagesMaxEnqueue );
+    return ( enqueueCounter >= m_Config.DumpImagesMinEnqueue ) &&
+           ( enqueueCounter <= m_Config.DumpImagesMaxEnqueue );
 }
 
 #define ADD_QUEUE( context, queue )                                         \
@@ -1661,7 +1695,8 @@ inline bool CLIntercept::checkDumpImageEnqueueLimits() const
 #define SET_KERNEL_ARG( kernel, arg_index, arg_size, arg_value )            \
     if ( pIntercept->config().DumpArgumentsOnSet )                          \
     {                                                                       \
-        pIntercept->dumpArgument( kernel, arg_index, arg_size, arg_value ); \
+        pIntercept->dumpArgument(                                           \
+            enqueueCounter, kernel, arg_index, arg_size, arg_value );       \
     }                                                                       \
     if( ( pIntercept->config().DumpBuffersBeforeEnqueue ||                  \
           pIntercept->config().DumpBuffersAfterEnqueue ||                   \
@@ -1710,97 +1745,107 @@ inline bool CLIntercept::checkDumpImageEnqueueLimits() const
 #define DUMP_BUFFER_AFTER_CREATE( memobj, flags, ptr, size )                \
     if( memobj &&                                                           \
         ( flags & ( CL_MEM_COPY_HOST_PTR | CL_MEM_USE_HOST_PTR ) ) &&       \
-        pIntercept->checkDumpBufferEnqueueLimits() &&                       \
+        pIntercept->checkDumpBufferEnqueueLimits( enqueueCounter ) &&       \
         pIntercept->config().DumpBuffersAfterCreate )                       \
     {                                                                       \
-        pIntercept->dumpBuffer( "Create", memobj, NULL, ptr, 0, size );     \
+        pIntercept->dumpBuffer(                                             \
+            "Create", enqueueCounter, memobj, NULL, ptr, 0, size );         \
     }
 
 #define DUMP_BUFFER_AFTER_MAP( command_queue, memobj, blocking_map, flags, ptr, offset, size ) \
     if( memobj &&                                                           \
         !( flags & CL_MAP_WRITE_INVALIDATE_REGION ) &&                      \
-        pIntercept->checkDumpBufferEnqueueLimits() &&                       \
+        pIntercept->checkDumpBufferEnqueueLimits( enqueueCounter ) &&       \
         pIntercept->config().DumpBuffersAfterMap )                          \
     {                                                                       \
         if( blocking_map == false )                                         \
         {                                                                   \
             pIntercept->dispatch().clFinish( command_queue );               \
         }                                                                   \
-        pIntercept->dumpBuffer( "Map", memobj, NULL, ptr, offset, size );   \
+        pIntercept->dumpBuffer(                                             \
+            "Map", enqueueCounter, memobj, NULL, ptr, offset, size );       \
     }
 
 #define DUMP_BUFFER_BEFORE_UNMAP( memobj, command_queue)                    \
     if( memobj &&                                                           \
         command_queue &&                                                    \
-        pIntercept->checkDumpBufferEnqueueLimits() &&                       \
+        pIntercept->checkDumpBufferEnqueueLimits( enqueueCounter ) &&       \
         pIntercept->config().DumpBuffersBeforeUnmap )                       \
     {                                                                       \
-        pIntercept->dumpBuffer( "Unmap", memobj, command_queue, NULL, 0, 0 );\
+        pIntercept->dumpBuffer(                                             \
+            "Unmap", enqueueCounter, memobj, command_queue, NULL, 0, 0 );   \
     }
 
 #define DUMP_BUFFERS_BEFORE_ENQUEUE( kernel, command_queue )                \
-    if( pIntercept->checkDumpBufferEnqueueLimits() &&                       \
+    if( pIntercept->checkDumpBufferEnqueueLimits( enqueueCounter ) &&       \
         pIntercept->config().DumpBuffersBeforeEnqueue &&                    \
         pIntercept->dumpBufferForKernel( kernel ) )                         \
     {                                                                       \
-        pIntercept->dumpBuffersForKernel( "Pre", kernel, command_queue );   \
+        pIntercept->dumpBuffersForKernel(                                   \
+            "Pre", enqueueCounter, kernel, command_queue );                 \
     }
 
 #define DUMP_BUFFERS_AFTER_ENQUEUE( kernel, command_queue )                 \
-    if( pIntercept->checkDumpBufferEnqueueLimits() &&                       \
+    if( pIntercept->checkDumpBufferEnqueueLimits( enqueueCounter ) &&       \
         pIntercept->config().DumpBuffersAfterEnqueue &&                     \
         pIntercept->dumpBufferForKernel( kernel ) )                         \
     {                                                                       \
-        pIntercept->dumpBuffersForKernel( "Post", kernel, command_queue );  \
+        pIntercept->dumpBuffersForKernel(                                   \
+            "Post", enqueueCounter, kernel, command_queue );                \
     }
 
 #define DUMP_IMAGES_BEFORE_ENQUEUE( kernel, command_queue )                 \
-    if( pIntercept->checkDumpImageEnqueueLimits() &&                        \
+    if( pIntercept->checkDumpImageEnqueueLimits( enqueueCounter ) &&        \
         pIntercept->config().DumpImagesBeforeEnqueue &&                     \
         pIntercept->dumpImagesForKernel( kernel ) )                         \
     {                                                                       \
-        pIntercept->dumpImagesForKernel( "Pre", kernel, command_queue );    \
+        pIntercept->dumpImagesForKernel(                                    \
+            "Pre", enqueueCounter, kernel, command_queue );                 \
     }
 
 #define DUMP_IMAGES_AFTER_ENQUEUE( kernel, command_queue )                  \
-    if( pIntercept->checkDumpImageEnqueueLimits() &&                        \
+    if( pIntercept->checkDumpImageEnqueueLimits( enqueueCounter ) &&        \
         pIntercept->config().DumpImagesAfterEnqueue &&                      \
         pIntercept->dumpImagesForKernel( kernel ) )                         \
     {                                                                       \
-        pIntercept->dumpImagesForKernel( "Post", kernel, command_queue );   \
+        pIntercept->dumpImagesForKernel(                                    \
+            "Post", enqueueCounter, kernel, command_queue );                \
     }
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-inline bool CLIntercept::checkAubCaptureEnqueueLimits() const
+inline bool CLIntercept::checkAubCaptureEnqueueLimits(
+    uint64_t enqueueCounter ) const
 {
-    return ( m_EnqueueCounter >= m_Config.AubCaptureMinEnqueue ) &&
-           ( m_EnqueueCounter <= m_Config.AubCaptureMaxEnqueue );
+    return ( enqueueCounter >= m_Config.AubCaptureMinEnqueue ) &&
+           ( enqueueCounter <= m_Config.AubCaptureMaxEnqueue );
 }
 
 // Note: We do not individually aub capture non-kernel enqueues at the moment.
 #define CHECK_AUBCAPTURE_START( command_queue )                             \
     if( pIntercept->config().AubCapture &&                                  \
-        pIntercept->checkAubCaptureEnqueueLimits() &&                       \
+        pIntercept->checkAubCaptureEnqueueLimits( enqueueCounter ) &&       \
         !pIntercept->config().AubCaptureIndividualEnqueues )                \
     {                                                                       \
         pIntercept->startAubCapture(                                        \
-            __FUNCTION__, NULL, 0, NULL, NULL, command_queue );             \
+            __FUNCTION__, enqueueCounter,                                   \
+            NULL, 0, NULL, NULL, command_queue );                           \
     }
 
 #define CHECK_AUBCAPTURE_START_KERNEL( kernel, wd, gws, lws, command_queue )\
     if( pIntercept->config().AubCapture &&                                  \
-        pIntercept->checkAubCaptureEnqueueLimits() &&                       \
+        pIntercept->checkAubCaptureEnqueueLimits( enqueueCounter ) &&       \
         pIntercept->checkAubCaptureKernelSignature( kernel, wd, gws, lws ) )\
     {                                                                       \
         pIntercept->startAubCapture(                                        \
-            __FUNCTION__, kernel, wd, gws, lws, command_queue );            \
+            __FUNCTION__, enqueueCounter,                                   \
+            kernel, wd, gws, lws, command_queue );                          \
     }
 
 #define CHECK_AUBCAPTURE_STOP( command_queue )                              \
     if( pIntercept->config().AubCapture &&                                  \
         ( pIntercept->config().AubCaptureIndividualEnqueues ||              \
-          !pIntercept->checkAubCaptureEnqueueLimits() ) )                   \
+          !pIntercept->checkAubCaptureEnqueueLimits( enqueueCounter ) ) )   \
     {                                                                       \
         pIntercept->stopAubCapture( command_queue );                        \
     }
@@ -2081,17 +2126,18 @@ inline bool CLIntercept::checkAubCaptureEnqueueLimits() const
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-inline bool CLIntercept::checkHostPerformanceTimingEnqueueLimits() const
+inline bool CLIntercept::checkHostPerformanceTimingEnqueueLimits(
+    uint64_t enqueueCounter ) const
 {
-    return ( m_EnqueueCounter >= m_Config.HostPerformanceTimingMinEnqueue ) &&
-           ( m_EnqueueCounter <= m_Config.HostPerformanceTimingMaxEnqueue );
+    return ( enqueueCounter >= m_Config.HostPerformanceTimingMinEnqueue ) &&
+           ( enqueueCounter <= m_Config.HostPerformanceTimingMaxEnqueue );
 }
 
 #define CPU_PERFORMANCE_TIMING_START()                                      \
     CLIntercept::clock::time_point   cpuStart, cpuEnd;                      \
     if( ( pIntercept->config().HostPerformanceTiming ||                     \
           pIntercept->config().ChromeCallLogging ) &&                       \
-        pIntercept->checkHostPerformanceTimingEnqueueLimits() )             \
+        pIntercept->checkHostPerformanceTimingEnqueueLimits( enqueueCounter ) )\
     {                                                                       \
         cpuStart = CLIntercept::clock::now();                               \
     }
@@ -2099,7 +2145,7 @@ inline bool CLIntercept::checkHostPerformanceTimingEnqueueLimits() const
 #define CPU_PERFORMANCE_TIMING_END()                                        \
     if( ( pIntercept->config().HostPerformanceTiming ||                     \
           pIntercept->config().ChromeCallLogging ) &&                       \
-        pIntercept->checkHostPerformanceTimingEnqueueLimits() )             \
+        pIntercept->checkHostPerformanceTimingEnqueueLimits( enqueueCounter ) )\
     {                                                                       \
         cpuEnd = CLIntercept::clock::now();                                 \
         if( pIntercept->config().HostPerformanceTiming )                    \
@@ -2114,6 +2160,7 @@ inline bool CLIntercept::checkHostPerformanceTimingEnqueueLimits() const
         {                                                                   \
             pIntercept->chromeCallLoggingExit(                              \
                 __FUNCTION__,                                               \
+                enqueueCounter,                                             \
                 NULL,                                                       \
                 cpuStart,                                                   \
                 cpuEnd );                                                   \
@@ -2123,7 +2170,7 @@ inline bool CLIntercept::checkHostPerformanceTimingEnqueueLimits() const
 #define CPU_PERFORMANCE_TIMING_END_KERNEL( _kernel )                        \
     if( ( pIntercept->config().HostPerformanceTiming ||                     \
           pIntercept->config().ChromeCallLogging ) &&                       \
-        pIntercept->checkHostPerformanceTimingEnqueueLimits() )             \
+        pIntercept->checkHostPerformanceTimingEnqueueLimits( enqueueCounter ) )\
     {                                                                       \
         cpuEnd = CLIntercept::clock::now();                                 \
         if( pIntercept->config().HostPerformanceTiming )                    \
@@ -2138,6 +2185,7 @@ inline bool CLIntercept::checkHostPerformanceTimingEnqueueLimits() const
         {                                                                   \
             pIntercept->chromeCallLoggingExit(                              \
                 __FUNCTION__,                                               \
+                enqueueCounter,                                             \
                 _kernel,                                                    \
                 cpuStart,                                                   \
                 cpuEnd );                                                   \
@@ -2146,10 +2194,11 @@ inline bool CLIntercept::checkHostPerformanceTimingEnqueueLimits() const
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-inline bool CLIntercept::checkDevicePerformanceTimingEnqueueLimits() const
+inline bool CLIntercept::checkDevicePerformanceTimingEnqueueLimits(
+    uint64_t enqueueCounter ) const
 {
-    return ( m_EnqueueCounter >= m_Config.DevicePerformanceTimingMinEnqueue ) &&
-           ( m_EnqueueCounter <= m_Config.DevicePerformanceTimingMaxEnqueue );
+    return ( enqueueCounter >= m_Config.DevicePerformanceTimingMinEnqueue ) &&
+           ( enqueueCounter <= m_Config.DevicePerformanceTimingMaxEnqueue );
 }
 
 #define CREATE_COMMAND_QUEUE_OVERRIDE_INIT( _device, _props, _newprops )    \
@@ -2224,7 +2273,7 @@ inline bool CLIntercept::checkDevicePerformanceTimingEnqueueLimits() const
           pIntercept->config().DevicePerfCounterEventBasedSampling ) &&     \
         ( pEvent != NULL ) )                                                \
     {                                                                       \
-        if( !pIntercept->checkDevicePerformanceTimingEnqueueLimits() ||     \
+        if( !pIntercept->checkDevicePerformanceTimingEnqueueLimits( enqueueCounter ) ||\
             ( pIntercept->config().DevicePerformanceTimingSkipUnmap &&      \
               std::string(__FUNCTION__) == "clEnqueueUnmapMemObject" ) )    \
         {                                                                   \
@@ -2238,6 +2287,7 @@ inline bool CLIntercept::checkDevicePerformanceTimingEnqueueLimits() const
         {                                                                   \
             pIntercept->addTimingEvent(                                     \
                 __FUNCTION__,                                               \
+                enqueueCounter,                                             \
                 queuedTime,                                                 \
                 NULL,                                                       \
                 0, NULL, NULL, NULL,                                        \
@@ -2261,7 +2311,7 @@ inline bool CLIntercept::checkDevicePerformanceTimingEnqueueLimits() const
           pIntercept->config().DevicePerfCounterEventBasedSampling ) &&     \
         ( pEvent != NULL ) )                                                \
     {                                                                       \
-        if( !pIntercept->checkDevicePerformanceTimingEnqueueLimits() )      \
+        if( !pIntercept->checkDevicePerformanceTimingEnqueueLimits( enqueueCounter ) )\
         {                                                                   \
             if( retainAppEvent == false )                                   \
             {                                                               \
@@ -2273,6 +2323,7 @@ inline bool CLIntercept::checkDevicePerformanceTimingEnqueueLimits() const
         {                                                                   \
             pIntercept->addTimingEvent(                                     \
                 __FUNCTION__,                                               \
+                enqueueCounter,                                             \
                 queuedTime,                                                 \
                 kernel,                                                     \
                 wd, gwo, gws, lws,                                          \


### PR DESCRIPTION
## Description of Changes

The primary purpose of these changes is to add an "id" to chrome call logging and timing to associate an API call to an event on the device timeline.  This is done by using the "enqueue counter" as the "id".  The "id" is added as an "argument" to the chome events the colors for each event remain the same.

These changes also fix a few long-standing bugs relating to the enqueue counters, including the enqueue counter race condition.  The enqueue counter is still maintained globally, but it is acquired once per API call, so the enqueue counter will remain constant for the entire API call.  Fixes #42.

## Testing Done

Verified chrome tracing and call logging with the new enqueue counter tracking.