### PR TITLE
add tracing and enum map support for cl_khr_pci_bus_info and cl_khr_suggested_local_work_size

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -383,6 +383,18 @@ cl_program CL_API_CALL clCreateProgramWithILKHR(
 #define CL_CONTEXT_MEMORY_INITIALIZE_KHR            0x2030
 
 ///////////////////////////////////////////////////////////////////////////////
+// cl_khr_pci_bus_info
+
+typedef struct _cl_device_pci_bus_info_khr {
+    cl_uint pci_domain;
+    cl_uint pci_bus;
+    cl_uint pci_device;
+    cl_uint pci_function;
+} cl_device_pci_bus_info_khr;
+
+#define CL_DEVICE_PCI_BUS_INFO_KHR                  0x410F
+
+///////////////////////////////////////////////////////////////////////////////
 // cl_khr_priority_hints
 
 #define CL_QUEUE_PRIORITY_KHR 0x1096
@@ -413,6 +425,19 @@ cl_int CL_API_CALL clGetKernelSubGroupInfoKHR(
     size_t param_value_size,
     void* param_value,
     size_t* param_value_size_ret);
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_suggested_local_work_size
+
+extern CL_API_ENTRY
+cl_int CL_API_CALL
+clGetKernelSuggestedLocalWorkSizeKHR(
+    cl_command_queue command_queue,
+    cl_kernel kernel,
+    cl_uint work_dim,
+    const size_t* global_work_offset,
+    const size_t* global_work_size,
+    size_t* suggested_local_work_size);
 
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_terminate_context

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -7974,7 +7974,53 @@ CL_API_ENTRY cl_int CL_API_CALL clSetPerformanceConfigurationINTEL(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+// cl_khr_suggested_local_work_size
+CL_API_ENTRY cl_int CL_API_CALL clGetKernelSuggestedLocalWorkSizeKHR(
+    cl_command_queue commandQueue,
+    cl_kernel kernel,
+    cl_uint workDim,
+    const size_t *globalWorkOffset,
+    const size_t *globalWorkSize,
+    size_t *suggestedLocalWorkSize)
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept )
+    {
+        auto dispatchX = pIntercept->dispatchX(commandQueue);
+        if( dispatchX.clGetKernelSuggestedLocalWorkSizeKHR )
+        {
+            GET_ENQUEUE_COUNTER();
+            CALL_LOGGING_ENTER_KERNEL(
+                kernel,
+                "queue = %p, kernel = %p",
+                commandQueue,
+                kernel );
+            CPU_PERFORMANCE_TIMING_START();
+
+            cl_int retVal = dispatchX.clGetKernelSuggestedLocalWorkSizeKHR(
+                commandQueue,
+                kernel,
+                workDim,
+                globalWorkOffset,
+                globalWorkSize,
+                suggestedLocalWorkSize );
+
+            CPU_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
+
+            return retVal;
+        }
+    }
+
+    NULL_FUNCTION_POINTER_RETURN_ERROR();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
 // Unofficial cl_get_kernel_suggested_local_work_size extension:
+// This function should stay in sync with clGetKernelSuggestedLocalWorkSizeKHR, above.
 CL_API_ENTRY cl_int CL_API_CALL clGetKernelSuggestedLocalWorkSizeINTEL(
     cl_command_queue commandQueue,
     cl_kernel kernel,

--- a/intercept/src/dispatch.h
+++ b/intercept/src/dispatch.h
@@ -197,6 +197,15 @@ struct CLdispatchX
                 void* param_value,
                 size_t* param_value_size_ret);
 
+    // cl_khr_suggested_local_work_size
+    cl_int  (CL_API_CALL *clGetKernelSuggestedLocalWorkSizeKHR) (
+                cl_command_queue command_queue,
+                cl_kernel kernel,
+                cl_uint work_dim,
+                const size_t* global_work_offset,
+                const size_t* global_work_size,
+                size_t* suggested_local_work_size);
+
     // cl_khr_create_command_queue
     cl_command_queue    (CL_API_CALL *clCreateCommandQueueWithPropertiesKHR) (
             cl_context context,

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -720,6 +720,9 @@ CEnumNameMap::CEnumNameMap()
     // cl_khr_initalize_memory
     ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_MEMORY_INITIALIZE_KHR );
 
+    // cl_khr_pci_bus_info extension
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PCI_BUS_INFO_KHR );
+
     // cl_khr_priority_hints extension
     ADD_ENUM_NAME( m_cl_int, CL_QUEUE_PRIORITY_KHR );
 

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -5083,6 +5083,9 @@ void CLIntercept::addTimingEvent(
             {
                 cl_platform_id  platform = getPlatform(device);
 
+                // TODO: Switch to or add support for clGetKernelSuggestedLocalWorkSizeKHR
+                // support is available.
+
                 if( dispatchX(platform).clGetKernelSuggestedLocalWorkSizeINTEL == NULL )
                 {
                     getExtensionFunctionAddress(
@@ -10813,6 +10816,8 @@ void* CLIntercept::getExtensionFunctionAddress(
     CHECK_RETURN_EXTENSION_FUNCTION( clCreateProgramWithILKHR );
     // cl_khr_subgroups
     CHECK_RETURN_EXTENSION_FUNCTION( clGetKernelSubGroupInfoKHR );
+    // cl_khr_suggested_local_work_size
+    CHECK_RETURN_EXTENSION_FUNCTION( clGetKernelSuggestedLocalWorkSizeKHR );
     // cl_khr_create_command_queue
     CHECK_RETURN_EXTENSION_FUNCTION( clCreateCommandQueueWithPropertiesKHR );
 


### PR DESCRIPTION
## Description of Changes

Adds tracing and enum map support for two new KHR extensions: `cl_khr_pci_bus_info` and `cl_khr_suggested_local_work_size`.

## Testing Done

Basic call logging testing with a tester app.
