### PR TITLE
add enum map information for CL_DEVICE_PCI_DOMAIN_ID_NV

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -1084,6 +1084,7 @@ clCreateBufferNV(
 #define CL_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT_NV   0x4007
 #define CL_DEVICE_PCI_BUS_ID_NV                     0x4008
 #define CL_DEVICE_PCI_SLOT_ID_NV                    0x4009
+#define CL_DEVICE_PCI_DOMAIN_ID_NV                  0x400A
 
 ///////////////////////////////////////////////////////////////////////////////
 // cl_qcom_ext_host_ptr

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -1020,6 +1020,7 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT_NV );
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PCI_BUS_ID_NV );
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PCI_SLOT_ID_NV );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PCI_DOMAIN_ID_NV );
 
     // cl_qcom_ext_host_ptr extension
     ADD_ENUM_NAME( m_cl_mem_flags, CL_MEM_EXT_HOST_PTR_QCOM );


### PR DESCRIPTION
## Description of Changes

Adds a missing enum for `CL_DEVICE_PCI_DOMAIN_ID_NV`.

This enum can be queried using PyOpenCL.

## Testing Done

Ran the `dump-properties.py` app from https://github.com/KhronosGroup/OpenCL-SDK/pull/31.
