### PR TITLE
Add Call Logging for Device Partition Properties

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -453,7 +453,6 @@ clGetKernelSuggestedLocalWorkSizeKHR(
 #define CL_QUEUE_THROTTLE_MED_KHR (1<<1)
 #define CL_QUEUE_THROTTLE_LOW_KHR (1<<2)
 
-
 ///////////////////////////////////////////////////////////////////////////////
 // cl_ext_atomic_counters
 
@@ -481,6 +480,15 @@ clGetKernelSuggestedLocalWorkSizeKHR(
 #define CL_INVALID_PARTITION_COUNT_EXT              -1058
 #define CL_INVALID_PARTITION_NAME_EXT               -1059
 
+#define CL_AFFINITY_DOMAIN_L1_CACHE_EXT             0x1
+#define CL_AFFINITY_DOMAIN_L2_CACHE_EXT             0x2
+#define CL_AFFINITY_DOMAIN_L3_CACHE_EXT             0x3
+#define CL_AFFINITY_DOMAIN_L4_CACHE_EXT             0x4
+#define CL_AFFINITY_DOMAIN_NUMA_EXT                 0x10
+#define CL_AFFINITY_DOMAIN_NEXT_FISSIONABLE_EXT     0x100
+
+#define CL_PARTITION_BY_COUNTS_LIST_END_EXT         0x0
+#define CL_PARTITION_BY_NAMES_LIST_END_EXT          -1
 
 ///////////////////////////////////////////////////////////////////////////////
 // cl_altera_compiler_mode

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -267,7 +267,22 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clCreateSubDevices)(
     if( pIntercept && pIntercept->dispatch().clCreateSubDevices )
     {
         GET_ENQUEUE_COUNTER();
-        CALL_LOGGING_ENTER();
+
+        std::string deviceInfo;
+        std::string propsStr;
+        if( pIntercept->config().CallLogging )
+        {
+            pIntercept->getDeviceInfoString(
+                1,
+                &in_device,
+                deviceInfo );
+            pIntercept->getDevicePartitionPropertiesString(
+                properties,
+                propsStr );
+        }
+        CALL_LOGGING_ENTER( "in_device = %s, properties = [ %s ], num_devices = %u",
+            deviceInfo.c_str(),
+            propsStr.c_str() );
         CPU_PERFORMANCE_TIMING_START();
 
         cl_int  retVal = pIntercept->dispatch().clCreateSubDevices(

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -282,7 +282,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clCreateSubDevices)(
         }
         CALL_LOGGING_ENTER( "in_device = %s, properties = [ %s ], num_devices = %u",
             deviceInfo.c_str(),
-            propsStr.c_str() );
+            propsStr.c_str(),
+            num_devices );
         CPU_PERFORMANCE_TIMING_START();
 
         cl_int  retVal = pIntercept->dispatch().clCreateSubDevices(

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -1802,10 +1802,10 @@ void CLIntercept::getDevicePartitionPropertiesString(
             case CL_DEVICE_PARTITION_BY_COUNTS:
             case CL_DEVICE_PARTITION_BY_COUNTS_EXT:
                 {
+                    ++properties;
                     str += "{ ";
                     do
                     {
-                        ++properties;
                         auto pu = (const cl_uint*)properties;
                         if( pu[0] == CL_DEVICE_PARTITION_BY_COUNTS_LIST_END )
                         {
@@ -1817,10 +1817,8 @@ void CLIntercept::getDevicePartitionPropertiesString(
                             str += s;
                         }
                     }
-                    while( *properties != CL_DEVICE_PARTITION_BY_COUNTS_LIST_END );
+                    while( *properties++ != CL_DEVICE_PARTITION_BY_COUNTS_LIST_END );
                     str += " }";
-
-                    ++properties;
                 }
                 break;
             case CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN:
@@ -1833,10 +1831,10 @@ void CLIntercept::getDevicePartitionPropertiesString(
                 break;
             case CL_DEVICE_PARTITION_BY_NAMES_EXT:
                 {
+                    ++properties;
                     str += "{ ";
                     do
                     {
-                        ++properties;
                         auto pu = (const cl_uint*)properties;
                         if( pu[0] == CL_PARTITION_BY_NAMES_LIST_END_EXT )
                         {
@@ -1848,44 +1846,19 @@ void CLIntercept::getDevicePartitionPropertiesString(
                             str += s;
                         }
                     }
-                    while( *properties != CL_PARTITION_BY_NAMES_LIST_END_EXT );
+                    while( *properties++ != CL_PARTITION_BY_NAMES_LIST_END_EXT );
                     str += " }";
-
-                    ++properties;
                 }
                 break;
             case CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_EXT:
                 // The extension uses different enums than the OpenCL 1.2
                 // feature, and we don't have an enum map for them (yet).
-                switch( properties[1] )
                 {
-                case CL_AFFINITY_DOMAIN_L1_CACHE_EXT:
-                    str += "CL_AFFINITY_DOMAIN_L1_CACHE_EXT";
-                    break;
-                case CL_AFFINITY_DOMAIN_L2_CACHE_EXT:
-                    str += "CL_AFFINITY_DOMAIN_L2_CACHE_EXT";
-                    break;
-                case CL_AFFINITY_DOMAIN_L3_CACHE_EXT:
-                    str += "CL_AFFINITY_DOMAIN_L3_CACHE_EXT";
-                    break;
-                case CL_AFFINITY_DOMAIN_L4_CACHE_EXT:
-                    str += "CL_AFFINITY_DOMAIN_L4_CACHE_EXT";
-                    break;
-                case CL_AFFINITY_DOMAIN_NUMA_EXT:
-                    str += "CL_AFFINITY_DOMAIN_NUMA_EXT";
-                    break;
-                case CL_AFFINITY_DOMAIN_NEXT_FISSIONABLE_EXT:
-                    str += "CL_AFFINITY_DOMAIN_NEXT_FISSIONABLE_EXT";
-                    break;
-                default:
-                    {
-                        CLI_SPRINTF( s, 256, "<Unknown %08X!>", (cl_uint)properties[1] );
-                        str += s;
-                    }
-                    break;
-                }
+                    CLI_SPRINTF( s, 256, "%04X", (cl_uint)properties[1] );
+                    str += s;
 
-                properties += 2;
+                    properties += 2;
+                }
                 break;
             default:
                 {

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -1772,6 +1772,84 @@ void CLIntercept::getDeviceInfoString(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+void CLIntercept::getDevicePartitionPropertiesString(
+    const cl_device_partition_property* properties,
+    std::string& str ) const
+{
+    str = "";
+
+    if( properties )
+    {
+        char    s[256];
+
+        while( properties[0] != 0 )
+        {
+            cl_int  property = (cl_int)properties[0];
+            str += enumName().name( property ) + " = ";
+
+            switch( property )
+            {
+            case CL_DEVICE_PARTITION_EQUALLY:
+                {
+                    auto pu = (const cl_uint*)( properties + 1 );
+                    CLI_SPRINTF( s, 256, "%u", pu[0] );
+                    str += s;
+
+                    properties += 2;
+                }
+                break;
+            case CL_DEVICE_PARTITION_BY_COUNTS:
+                {
+                    str += "{ ";
+                    do
+                    {
+                        ++properties;
+                        auto pu = (const cl_uint*)properties;
+                        if( pu[0] == CL_DEVICE_PARTITION_BY_COUNTS_LIST_END )
+                        {
+                            str += "CL_DEVICE_PARTITION_BY_COUNTS_LIST_END";
+                        }
+                        else
+                        {
+                            CLI_SPRINTF( s, 256, "%u, ", pu[0] );
+                            str += s;
+                        }
+                    }
+                    while( *properties != CL_DEVICE_PARTITION_BY_COUNTS_LIST_END );
+                    str += " }";
+                }
+                break;
+            case CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN:
+                {
+                    auto pd = (const cl_device_affinity_domain*)( properties + 1 );
+                    str += enumName().name_device_affinity_domain(pd[0]);
+
+                    properties += 2;
+                }
+                break;
+            default:
+                {
+                    CLI_SPRINTF( s, 256, "<Unknown %08X!>", (cl_uint)property );
+                    str += s;
+                    // Advance by two properties.  This may not be correct,
+                    // but it's the best we can do when the property is
+                    // unknown.
+                    properties += 2;
+                }
+                break;
+            }
+
+            if( properties[0] != 0 )
+            {
+                str += ", ";
+            }
+        }
+    }
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
 void CLIntercept::getEventListString(
     cl_uint numEvents,
     const cl_event* eventList,

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -1790,6 +1790,7 @@ void CLIntercept::getDevicePartitionPropertiesString(
             switch( property )
             {
             case CL_DEVICE_PARTITION_EQUALLY:
+            case CL_DEVICE_PARTITION_EQUALLY_EXT:
                 {
                     auto pu = (const cl_uint*)( properties + 1 );
                     CLI_SPRINTF( s, 256, "%u", pu[0] );
@@ -1799,6 +1800,7 @@ void CLIntercept::getDevicePartitionPropertiesString(
                 }
                 break;
             case CL_DEVICE_PARTITION_BY_COUNTS:
+            case CL_DEVICE_PARTITION_BY_COUNTS_EXT:
                 {
                     str += "{ ";
                     do
@@ -1817,6 +1819,8 @@ void CLIntercept::getDevicePartitionPropertiesString(
                     }
                     while( *properties != CL_DEVICE_PARTITION_BY_COUNTS_LIST_END );
                     str += " }";
+
+                    ++properties;
                 }
                 break;
             case CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN:
@@ -1826,6 +1830,62 @@ void CLIntercept::getDevicePartitionPropertiesString(
 
                     properties += 2;
                 }
+                break;
+            case CL_DEVICE_PARTITION_BY_NAMES_EXT:
+                {
+                    str += "{ ";
+                    do
+                    {
+                        ++properties;
+                        auto pu = (const cl_uint*)properties;
+                        if( pu[0] == CL_PARTITION_BY_NAMES_LIST_END_EXT )
+                        {
+                            str += "CL_PARTITION_BY_NAMES_LIST_END_EXT";
+                        }
+                        else
+                        {
+                            CLI_SPRINTF( s, 256, "%u, ", pu[0] );
+                            str += s;
+                        }
+                    }
+                    while( *properties != CL_PARTITION_BY_NAMES_LIST_END_EXT );
+                    str += " }";
+
+                    ++properties;
+                }
+                break;
+            case CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_EXT:
+                // The extension uses different enums than the OpenCL 1.2
+                // feature, and we don't have an enum map for them (yet).
+                switch( properties[1] )
+                {
+                case CL_AFFINITY_DOMAIN_L1_CACHE_EXT:
+                    str += "CL_AFFINITY_DOMAIN_L1_CACHE_EXT";
+                    break;
+                case CL_AFFINITY_DOMAIN_L2_CACHE_EXT:
+                    str += "CL_AFFINITY_DOMAIN_L2_CACHE_EXT";
+                    break;
+                case CL_AFFINITY_DOMAIN_L3_CACHE_EXT:
+                    str += "CL_AFFINITY_DOMAIN_L3_CACHE_EXT";
+                    break;
+                case CL_AFFINITY_DOMAIN_L4_CACHE_EXT:
+                    str += "CL_AFFINITY_DOMAIN_L4_CACHE_EXT";
+                    break;
+                case CL_AFFINITY_DOMAIN_NUMA_EXT:
+                    str += "CL_AFFINITY_DOMAIN_NUMA_EXT";
+                    break;
+                case CL_AFFINITY_DOMAIN_NEXT_FISSIONABLE_EXT:
+                    str += "CL_AFFINITY_DOMAIN_NEXT_FISSIONABLE_EXT";
+                    break;
+                default:
+                    {
+                        CLI_SPRINTF( s, 256, "<Unknown %08X!>", (cl_uint)properties[1] );
+                        str += s;
+                    }
+                    break;
+                }
+
+                properties += 2;
                 break;
             default:
                 {

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -145,6 +145,9 @@ public:
                 cl_uint num_devices,
                 const cl_device_id* devices,
                 std::string& str ) const;
+    void    getDevicePartitionPropertiesString(
+                const cl_device_partition_property* properties,
+                std::string& str ) const;
     void    getEventListString(
                 cl_uint num_events,
                 const cl_event* event_list,


### PR DESCRIPTION
## Description of Changes

Adds call logging for device partition properties, both for the OpenCL 1.2 feature and for the `cl_ext_device_fission` extension.

## Testing Done

Tried various partitioning types and verified that call logging worked correctly even if my device didn't support the partitioning type.
