### PR TITLE
improve tracing for perf counter command queues

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -7985,8 +7985,20 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreatePerfCountersCommandQueueINTEL(
                 properties |= (cl_command_queue_properties)CL_QUEUE_PROFILING_ENABLE;
             }
 
-            CALL_LOGGING_ENTER( "context = %p",
-                context );
+            std::string deviceInfo;
+            if( pIntercept->config().CallLogging )
+            {
+                pIntercept->getDeviceInfoString(
+                    1,
+                    &device,
+                    deviceInfo );
+            }
+            CALL_LOGGING_ENTER( "context = %p, device = %s, properties = %s (%llX), configuration = %u",
+                context,
+                deviceInfo.c_str(),
+                pIntercept->enumName().name_command_queue_properties( properties ).c_str(),
+                properties,
+                configuration );
             CHECK_ERROR_INIT( errcode_ret );
             CPU_PERFORMANCE_TIMING_START();
 


### PR DESCRIPTION
## Description of Changes

Adds more tracing for manual calls to clCreatePerfCountersCommandQueueINTEL.  This API is usually used internally and not called directly, but having improved tracing can help when debugging applications that do call this function directly.

## Testing Done

Tested with an application that creates a perf counters command queue directly.
