### PR TITLE
add enum tracing for cl_khr_integer_dot_product

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -383,6 +383,16 @@ cl_program CL_API_CALL clCreateProgramWithILKHR(
 #define CL_CONTEXT_MEMORY_INITIALIZE_KHR            0x2030
 
 ///////////////////////////////////////////////////////////////////////////////
+// cl_khr_integer_dot_product
+
+typedef cl_bitfield         cl_device_integer_dot_product_capabilities_khr;
+
+#define CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_PACKED_KHR (1 << 0)
+#define CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_KHR      (1 << 1)
+
+#define CL_DEVICE_INTEGER_DOT_PRODUCT_CAPABILITIES_KHR      0x1073
+
+///////////////////////////////////////////////////////////////////////////////
 // cl_khr_pci_bus_info
 
 typedef struct _cl_device_pci_bus_info_khr {

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -720,6 +720,9 @@ CEnumNameMap::CEnumNameMap()
     // cl_khr_initalize_memory
     ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_MEMORY_INITIALIZE_KHR );
 
+    // cl_khr_integer_dot_product
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_INTEGER_DOT_PRODUCT_CAPABILITIES_KHR );
+
     // cl_khr_pci_bus_info extension
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_PCI_BUS_INFO_KHR );
 
@@ -746,7 +749,6 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_MAX_ATOMIC_COUNTERS_EXT );
 
     // cl_ext_cxx_for_opencl
-
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT );
 
     // cl_ext_device_fission


### PR DESCRIPTION
## Description of Changes

Adds enum tracing for the `cl_khr_integer_dot_product` extensions.

## Testing Done

Tested with a simple app that uses this query and verified the call log looked correct.
