### PR TITLE
Small edits to combine_chrome_traces.py

### DIFF
--- a/scripts/combine_chrome_traces.py
+++ b/scripts/combine_chrome_traces.py
@@ -86,7 +86,7 @@ def main():
     for j in range(numFiles):
         for k in range(len(inputFiles[j])):
             if (inputFiles[j][k].find("start_time") != -1):
-                start_times.append(int(inputFiles[j][2].split(":")[-1].split("}")[0]))
+                start_times.append(int(inputFiles[j][2].split(":")[-1].split("}")[0].strip('"')))
                 break
         if(len(start_times) != j+1):
             print("ERROR: start_time not found in trace file "+sys.argv[j+2]+". Please check if the trace is valid.")
@@ -111,7 +111,9 @@ def main():
             if (filteredFiles[j][k].find("\"ts\"") != -1):
                 ts = int(filteredFiles[j][k].split("\"ts\":")[-1].split(",")[0]) + offset
                 filteredFiles[j][k] = re.sub("\"ts\":\d+", "\"ts\":"+str(ts), filteredFiles[j][k])
-
+            elif (filteredFiles[j][k].find("start_time") != -1):
+                filteredFiles[j][k] = re.sub('\"start_time\":["]?\d+["]?', "\"start_time\":"+str(epoch), filteredFiles[j][k])
+    
     # Write to output file
     tstamp = datetime.datetime.now()
     fName = "merged_" + str(tstamp.year) + '-' + str(tstamp.month) + '-' + str(tstamp.day) \


### PR DESCRIPTION
## Description of Changes

1. Modified the combine_chrome_traces.py script so that it can merge traces captured with cl_tracer or ze_tracer from https://github.com/intel/pti-gpu as well (these tools enclose start_time within double quotes and opencl-intercept-layer doesn't). 
2. In the combined trace file, the start_time for all processes is now set to the normalized epoch instead of retaining the individual start_time. This makes records in the merged json file consistent as all ts values are relative to a common start_time. There is no impact on timeline visualization from this change.

## Testing Done

Tested with multiple example traces on a Linux system.
