### PR TITLE
add enum tracing for cl_intel_device_attribute_query

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -659,6 +659,21 @@ typedef struct _cl_queue_family_properties_intel {
 #define CL_QUEUE_CAPABILITY_KERNEL_INTEL                    (1 << 26)
 
 ///////////////////////////////////////////////////////////////////////////////
+// cl_intel_device_attribute_query
+typedef cl_bitfield         cl_device_feature_capabilities_intel;
+
+#define CL_DEVICE_FEATURE_FLAG_DP4A_INTEL                   (1 << 0)
+#define CL_DEVICE_FEATURE_FLAG_DPAS_INTEL                   (1 << 1)
+
+#define CL_DEVICE_IP_VERSION_INTEL                          0x4250
+#define CL_DEVICE_ID_INTEL                                  0x4251
+#define CL_DEVICE_NUM_SLICES_INTEL                          0x4252
+#define CL_DEVICE_NUM_SUB_SLICES_PER_SLICE_INTEL            0x4253
+#define CL_DEVICE_NUM_EUS_PER_SUB_SLICE_INTEL               0x4254
+#define CL_DEVICE_NUM_THREADS_PER_EU_INTEL                  0x4255
+#define CL_DEVICE_FEATURE_CAPABILITIES_INTEL                0x4256
+
+///////////////////////////////////////////////////////////////////////////////
 // cl_intel_driver_diagnostics
 
 #define CL_CONTEXT_SHOW_DIAGNOSTICS_INTEL           0x4106

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -854,6 +854,15 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_command_queue_capabilities_intel, CL_QUEUE_CAPABILITY_BARRIER_INTEL );
     ADD_ENUM_NAME( m_cl_command_queue_capabilities_intel, CL_QUEUE_CAPABILITY_KERNEL_INTEL );
 
+    // cl_intel_device_attribute_query
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_IP_VERSION_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_ID_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_NUM_SLICES_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_NUM_SUB_SLICES_PER_SLICE_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_NUM_EUS_PER_SUB_SLICE_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_NUM_THREADS_PER_EU_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_FEATURE_CAPABILITIES_INTEL );
+
     // cl_intel_driver_diagnostics
     ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_SHOW_DIAGNOSTICS_INTEL );
 


### PR DESCRIPTION
## Description of Changes

Adds enum tracing for the `cl_intel_device_attribute_query` extension.

## Testing Done

Tested with a simple app exercising the new queries.
