### PR TITLE
add command queue property tracing for queue families

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -2086,6 +2086,8 @@ void CLIntercept::getCommandQueuePropertiesString(
                 }
                 break;
             case CL_QUEUE_SIZE:
+            case CL_QUEUE_FAMILY_INTEL:
+            case CL_QUEUE_INDEX_INTEL:
                 {
                     const cl_uint*  pu = (const cl_uint*)( properties + 1);
                     CLI_SPRINTF( s, 256, "%u", pu[0] );


### PR DESCRIPTION
## Description of Changes

Adds tracing for the `cl_intel_command_queue_families` queue properties.

## Testing Done

Tested with an application that creates different queues and specifies the queue family and queue index.
