### PR TITLE
add missing enum tracing

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -674,6 +674,13 @@ typedef cl_bitfield         cl_device_feature_capabilities_intel;
 #define CL_DEVICE_FEATURE_CAPABILITIES_INTEL                0x4256
 
 ///////////////////////////////////////////////////////////////////////////////
+// cl_intel_device_side_avc_motion_estimation (partial)
+
+#define CL_DEVICE_AVC_ME_VERSION_INTEL                      0x410B
+#define CL_DEVICE_AVC_ME_SUPPORTS_TEXTURE_SAMPLER_USE_INTEL 0x410C
+#define CL_DEVICE_AVC_ME_SUPPORTS_PREEMPTION_INTEL          0x410D
+
+///////////////////////////////////////////////////////////////////////////////
 // cl_intel_driver_diagnostics
 
 #define CL_CONTEXT_SHOW_DIAGNOSTICS_INTEL           0x4106

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -863,6 +863,11 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_NUM_THREADS_PER_EU_INTEL );
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_FEATURE_CAPABILITIES_INTEL );
 
+    // cl_intel_device_side_avc_motion_estimation (partial)
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_AVC_ME_VERSION_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_AVC_ME_SUPPORTS_TEXTURE_SAMPLER_USE_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_AVC_ME_SUPPORTS_PREEMPTION_INTEL );
+
     // cl_intel_driver_diagnostics
     ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_SHOW_DIAGNOSTICS_INTEL );
 


### PR DESCRIPTION
## Description of Changes

Adds missing enum tracing for cl_intel_device_side_avc_motion_estimation.

## Testing Done

Verified using call logging with an app using these queries.
