### PR TITLE
add text tracing for the flags for cl_nv_create_buffer

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -1049,10 +1049,11 @@ CL_API_ENTRY cl_mem CL_API_CALL clCreateBufferNV(
         if( dispatchX.clCreateBufferNV )
         {
             GET_ENQUEUE_COUNTER();
-            CALL_LOGGING_ENTER( "context = %p, flags = %s (%llX), flags_NV = %llX, size = %zu, host_ptr = %p",
+            CALL_LOGGING_ENTER( "context = %p, flags = %s (%llX), flags_NV = %s (%llX), size = %zu, host_ptr = %p",
                 context,
                 pIntercept->enumName().name_mem_flags( flags ).c_str(),
                 flags,
+                pIntercept->enumName().name_mem_flags_NV( flags_NV ).c_str(),
                 flags_NV,
                 size,
                 host_ptr );

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -1025,6 +1025,10 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_int, CL_VA_API_MEDIA_SURFACE_ALREADY_ACQUIRED_INTEL );
     ADD_ENUM_NAME( m_cl_int, CL_VA_API_MEDIA_SURFACE_NOT_ACQUIRED_INTEL );
 
+    // cl_nv_create_buffer
+    ADD_ENUM_NAME( m_cl_mem_flags_NV, CL_MEM_LOCATION_HOST_NV );
+    ADD_ENUM_NAME( m_cl_mem_flags_NV, CL_MEM_PINNED_NV );
+
     // cl_nv_device_attribute_query
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV );
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_COMPUTE_CAPABILITY_MINOR_NV );

--- a/intercept/src/enummap.h
+++ b/intercept/src/enummap.h
@@ -119,6 +119,7 @@ public:
     GENERATE_MAP_AND_BITFIELD_FUNC( name_kernel_arg_type_qualifier,  cl_kernel_arg_type_qualifier    );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_map_flags,                  cl_map_flags                    );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_mem_flags,                  cl_mem_flags                    );
+    GENERATE_MAP_AND_BITFIELD_FUNC( name_mem_flags_NV,               cl_mem_flags_NV                 );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_mem_migration_flags,        cl_mem_migration_flags          );
     GENERATE_MAP_AND_FUNC(          name_program_binary_type,        cl_program_binary_type          );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_svm_mem_flags,              cl_svm_mem_flags                );


### PR DESCRIPTION
## Description of Changes

This is a minor update to decode the flags passed to clCreateBufferNV vs. printing the numerical value.

## Testing Done

Tested call logging with an application that uses cl_nv_create_buffer.
