### PR TITLE
improve chrome tracing accuracy with device and host timer

### DIFF
--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -802,7 +802,8 @@ public:
                 uint64_t enqueueCounter,
                 unsigned int queueNumber,
                 cl_event event,
-                clock::time_point queuedTime );
+                clock::time_point queuedTime,
+                int64_t profilingDeltaNS );
 
     // USM Emulation:
     void*   emulatedHostMemAlloc(
@@ -970,6 +971,8 @@ private:
 
         cl_uint     NumComputeUnits;
         cl_uint     MaxClockFrequency;
+
+        int64_t     ProfilingDeltaNS;
 
         bool        Supports_cl_khr_create_command_queue;
         bool        Supports_cl_khr_subgroups;

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -799,12 +799,12 @@ public:
                 cl_command_queue queue );
     void    chromeTraceEvent(
                 const std::string& name,
+                bool useProfilingDelta,
+                int64_t profilingDeltaNS,
                 uint64_t enqueueCounter,
                 unsigned int queueNumber,
                 cl_event event,
-                clock::time_point queuedTime,
-                bool useProfilingDelta,
-                int64_t profilingDeltaNS );
+                clock::time_point queuedTime );
 
     // USM Emulation:
     void*   emulatedHostMemAlloc(

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -803,6 +803,7 @@ public:
                 unsigned int queueNumber,
                 cl_event event,
                 clock::time_point queuedTime,
+                bool useProfilingDelta,
                 int64_t profilingDeltaNS );
 
     // USM Emulation:
@@ -972,6 +973,7 @@ private:
         cl_uint     NumComputeUnits;
         cl_uint     MaxClockFrequency;
 
+        bool        UseProfilingDelta;
         int64_t     ProfilingDeltaNS;
 
         bool        Supports_cl_khr_create_command_queue;


### PR DESCRIPTION
## Description of Changes

This PR improves the accuracy of chrome tracing reports by using the "device and host timer" to more accurately align the intercept layer timeline with the event profiling timeline.

Before this change ther intercept layer recorded its estimated "queued time" at the start of an OpenCL enqueue API and aligned the event profiling "queued time" to it.  This is fairly accurate, but if the event profiling queued time were actually towards end end of the enqueue API it could have a maximum error approximately equal to the duration of the enqueue API.  In some cases this innacuracy was enough to incorrectly indicate that commands were overlapping in execution when they weren't in reality.

After this change a "profiling delta" is computed from the device and host timers and is used to compute an aligned queued time directly from the event profiling data.  If the computed queued time is close to the measured queued time (mostly done to filter out buggy device and host timers) then the computed queued time is used instead.  This improves the accuracy of the chrome tracing report.

## Testing Done

Tested on devices that do and do not support device and host timers on both Windows and Linux.  Also, tested behavior with a simulated buggy device and host timer by forcing the device timer to zero and verified that the measured queued time was used instead.
