### PR TITLE
add a check for NULL timing events

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -5296,6 +5296,13 @@ void CLIntercept::addTimingEvent(
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
 
+    if( event == NULL )
+    {
+        logf( "Unexpectedly got a NULL timing event for %s, check for OpenCL errors!\n",
+            functionName.c_str() );
+        return;
+    }
+
     m_EventList.emplace_back();
 
     SEventListNode& node = m_EventList.back();


### PR DESCRIPTION
## Description of Changes

Added a check for a NULL timing event.  This will most frequently happen if the command generating the timing event returned an error so no event was created.

The intercept layer worked fine without this check, but when this happened it generated a confusing error message, because the timing event was NULL and hence the query to determine the timing event status returned `CL_INVALID_EVENT`.  The check for the NULL timing event lets us generate a much better error message.

## Testing Done

Tested DevicePerformanceTiming with an app that made an incorrect call to `clEnqueueNDRangeKernel` that returned an error.  Observed a confusing error message prior to this change, and a much better error message after this change.
