### PR TITLE
add a cliloader option to print all controls

### DIFF
--- a/cliconfig/envVars.h
+++ b/cliconfig/envVars.h
@@ -85,7 +85,7 @@ static const VarDescription cVars[] =
 {
     { CONTROL_TYPE_BOOL, "BreakOnLoad", "", 0, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will break into the debugger when the DLL is loaded." },
     { CONTROL_TYPE_STRING, "OpenCLFileName", "", 0, "Used to control the DLL or Shared Library that the Intercept Layer for OpenCL Applications loads to make real OpenCL calls. If present, only this file name is loaded. If omitted, the Intercept Layer for OpenCL Applications will search a default set of real OpenCL file names." },
-#include "src\controls.h"
+#include "src/controls.h"
 };
 
 const int cNumVars = sizeof(cVars) / sizeof(cVars[0]);

--- a/cliloader/CMakeLists.txt
+++ b/cliloader/CMakeLists.txt
@@ -9,6 +9,7 @@ configure_file(git_version.h.in "${CMAKE_CURRENT_BINARY_DIR}/git_version.h" @ONL
 
 set( CLILOADER_SOURCE_FILES
     cliloader.cpp
+    printcontrols.h
     "${CMAKE_CURRENT_BINARY_DIR}/git_version.h"
 )
 source_group( Source FILES
@@ -19,9 +20,8 @@ add_executable(cliloader
     ${CLILOADER_SOURCE_FILES}
 )
 add_dependencies(cliloader OpenCL)
-target_include_directories(cliloader PRIVATE
-    ${CMAKE_CURRENT_BINARY_DIR}
-)
+target_include_directories(cliloader PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../intercept)
+target_include_directories(cliloader PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     foreach( OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES} )

--- a/cliloader/cliloader.cpp
+++ b/cliloader/cliloader.cpp
@@ -7,6 +7,8 @@
 #include "git_version.h"
 #include <string>
 
+#include "printcontrols.h"
+
 #if defined(_WIN32)
 
 #include <windows.h>
@@ -230,6 +232,11 @@ static bool parseArguments(int argc, char *argv[])
         {
             debug = true;
         }
+        else if (!strcmp(argv[i], "--controls") )
+        {
+            printControls();
+            return false;
+        }
 #if !defined(_WIN32)
         else if( !strcmp(argv[i], "--no-LD_PRELOAD") )
         {
@@ -373,6 +380,7 @@ static bool parseArguments(int argc, char *argv[])
             "\n"
             "Options:\n"
             "  --debug                          Enable cliloader Debug Messages\n"
+            "  --controls                       Print All Controls and Exit\n"
 #if !defined(_WIN32)
             "  --no-LD_PRELOAD                  Do not set LD_PRELOAD\n"
             "  --no-LD_LIBRARY_PATH             Do not set LD_LIBRARY_PATH\n"

--- a/cliloader/printcontrols.h
+++ b/cliloader/printcontrols.h
@@ -1,0 +1,63 @@
+/*
+// Copyright (c) 2018-2022 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+*/
+
+#pragma once
+
+#include <vector>
+
+#include <stdio.h>
+
+struct cliControl
+{
+    bool    IsSeparator;
+    const char* Name;
+    const char* Type;
+    const char* Description;
+};
+
+#define CLI_CONTROL( _type, _name, _init, _desc )           \
+{                                                           \
+    false,                                                  \
+    #_name,                                                 \
+    #_type,                                                 \
+    _desc,                                                  \
+},
+
+#define CLI_CONTROL_SEPARATOR( _name )                      \
+{                                                           \
+    true,                                                   \
+    #_name,                                                 \
+    "",                                                     \
+    "",                                                     \
+},
+
+static const std::vector<cliControl> controls =
+{
+    { true, "Startup Controls:", "", ""},
+    { false, "BreakOnLoad", "bool", "If set to a nonzero value, the Intercept Layer for OpenCL Applications will break into the debugger when the DLL is loaded." },
+    { false, "std::string", "OpenCLFileName", "Used to control the DLL or Shared Library that the Intercept Layer for OpenCL Applications loads to make real OpenCL calls. If present, only this file name is loaded. If omitted, the Intercept Layer for OpenCL Applications will search a default set of real OpenCL file names." },
+#include "src/controls.h"
+};
+
+#undef CLI_CONTROL
+#undef CLI_CONTROL_SEPARATOR
+
+void printControls()
+{
+    for (const auto& control : controls )
+    {
+        if (control.IsSeparator)
+        {
+            fprintf(stdout, "%s\n", control.Name);
+            fprintf(stdout, "========================================\n\n");
+        }
+        else
+        {
+            fprintf(stdout, "%s (%s):\n", control.Name, control.Type);
+            fprintf(stdout, "%s\n\n", control.Description);
+        }
+    }
+}


### PR DESCRIPTION
## Description of Changes

Added a cliloader option to dump all controls and their description.  This can make it much easier to find the name of a control and its exact spelling on systems without a GUI or an external internet connection.

## Testing Done

Tested the new cliloader option and observed that the controls were dumped properly.