### PR TITLE
add a cliloader option for ErrorLogging

### DIFF
--- a/cliloader/cliloader.cpp
+++ b/cliloader/cliloader.cpp
@@ -255,6 +255,10 @@ static bool parseArguments(int argc, char *argv[])
         {
             SETENV("CLI_CallLogging", "1");
         }
+        else if( !strcmp(argv[i], "-e") || !strcmp(argv[i], "--error-logging") )
+        {
+            SETENV("CLI_ErrorLogging", "1");
+        }
         else if( !strcmp(argv[i], "--tid") )
         {
             SETENV("CLI_CallLoggingThreadId", "1");
@@ -388,6 +392,7 @@ static bool parseArguments(int argc, char *argv[])
             "\n"
             "  --quiet [-q]                     Disable Logging\n"
             "  --call-logging [-c]              Trace Host API Calls\n"
+            "  --error-logging [-e]             Detect and Log API Errors\n"
             "  --tid                            Include Thread ID in the API Call Log\n"
             "  --appendpid                      Include Process ID in the Dump Directory\n"
             "  --dump-source [-dsrc]            Dump Input Program Source\n"


### PR DESCRIPTION
## Description of Changes

Adds a cliloader option to easily enable ErrorLogging, to simplify identifying OpenCL API errors without the verbosity of CallLogging.

## Testing Done

Tested with an application that generated an error and verified that error logging was enabled and that the error was properly reported.