### PR TITLE
multi-threading fixes

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -5302,6 +5302,8 @@ void CLIntercept::addTimingEvent(
     // the device name and other device properties as part of the report.
     cacheDeviceInfo( device );
 
+    dispatch().clRetainEvent( event );
+
     node.Device = device;
     node.QueueNumber = m_QueueNumberMap[ queue ];
     node.FunctionName = functionName;

--- a/intercept/src/objtracker.cpp
+++ b/intercept/src/objtracker.cpp
@@ -38,8 +38,10 @@ void CObjectTracker::ReportHelper(
     }
 }
 
-void CObjectTracker::writeReport( std::ostream& os ) const
+void CObjectTracker::writeReport( std::ostream& os )
 {
+    std::lock_guard<std::mutex> lock(m_Mutex);
+
     os << std::endl;
     ReportHelper( "cl_device_id",       m_Devices,          os );
     ReportHelper( "cl_context",         m_Contexts,         os );

--- a/intercept/src/objtracker.h
+++ b/intercept/src/objtracker.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "common.h"
 
 class CObjectTracker
@@ -13,14 +15,15 @@ class CObjectTracker
 public:
     CObjectTracker() {}
 
-    void    writeReport( std::ostream& os ) const;
+    void    writeReport( std::ostream& os );
 
     template<class T>
     void    AddAllocation( T obj )
     {
         if( obj )
         {
-            GetTracker(obj).NumAllocations++;   // todo: atomic?
+            std::lock_guard<std::mutex> lock(m_Mutex);
+            GetTracker(obj).NumAllocations++;
         }
     }
 
@@ -29,6 +32,7 @@ public:
     {
         if( obj )
         {
+            std::lock_guard<std::mutex> lock(m_Mutex);
             GetTracker(obj).NumRetains++;
         }
     }
@@ -38,6 +42,7 @@ public:
     {
         if( obj )
         {
+            std::lock_guard<std::mutex> lock(m_Mutex);
             GetTracker(obj).NumReleases++;
         }
     }
@@ -54,6 +59,8 @@ private:
         size_t  NumRetains;
         size_t  NumReleases;
     };
+
+    std::mutex  m_Mutex;
 
     CTracker    m_Devices;
     CTracker    m_Contexts;


### PR DESCRIPTION
This is a possible fix for #243.

## Description of Changes

This change fixes a couple of possible multi-threading race conditions:

* In some cases a device timing event could be added to the timing event list in one thread then checked and released in a different thread before being retained.  Fixed by retaining the event before it is added to the timing event wait list.
* Because the leak checking counters were not updated atomically they could be incorrect if multiple threads are allocating, retaining, or releasing objects.  Fixed by protecting the updates with a mutex.  I can investigate using std::atomics if this turns out to be a performance problem.

## Testing Done

Ran the math bruteforce conformance test several times to completion (in "wimpy" mode).  Did not observe any failures after this change and no leaks are reported.