### PR TITLE
do not check timing events for clFlush

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -3173,8 +3173,6 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clFlush)(
         CHECK_ERROR( retVal );
         CALL_LOGGING_EXIT( retVal );
 
-        DEVICE_PERFORMANCE_TIMING_CHECK();
-
         return retVal;
     }
 


### PR DESCRIPTION
## Description of Changes

For device timing, we don't want to wait too long to check if timing events have progressed (to minimize outstanding events), but we don't want to check too frequently either (to minimize overhead).  The current policy is to check device events on calls that block, such as clFinish, blocking reads and writes, waiting for an event, etc, though there are a few exceptions.

One of the current exceptions is clFlush, though we have found that events frequently are not complete after a call to clFlush, so this isn't a good place to check for timing events.  This change eliminates the call to check for timing events on a call to clFlush.

For record keeping, most of the remaining exceptions are after calls to release external objects for interop, such as clEnqueueReleaseExternalMemObjectsKHR.  Perhaps this isn't the best place to check timing events either?  Would it make more sense to check after acquiring memory objects for interop, instead?

I also see that we don't check device timings when we signal or wait on a semaphore object.  Would it make sense to add a check in either of these scenarios (or both)?

## Testing Done

Basic device performance timing touch-testing on an application that calls clFlush.
