### PR TITLE
improved chrome tracing device queue name

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -12657,33 +12657,24 @@ void CLIntercept::chromeRegisterCommandQueue(
     cl_device_type              deviceType = 0;
     cl_command_queue_properties properties = 0;
 
-    if( errorCode == CL_SUCCESS )
-    {
-        errorCode = dispatch().clGetCommandQueueInfo(
-            queue,
-            CL_QUEUE_DEVICE,
-            sizeof(device),
-            &device,
-            NULL);
-    }
-    if( errorCode == CL_SUCCESS )
-    {
-        errorCode = dispatch().clGetDeviceInfo(
-            device,
-            CL_DEVICE_TYPE,
-            sizeof(deviceType),
-            &deviceType,
-            NULL );
-    }
-    if( errorCode == CL_SUCCESS )
-    {
-        errorCode = dispatch().clGetCommandQueueInfo(
-            queue,
-            CL_QUEUE_PROPERTIES,
-            sizeof(properties),
-            &properties,
-            NULL );
-    }
+    errorCode |= dispatch().clGetCommandQueueInfo(
+        queue,
+        CL_QUEUE_DEVICE,
+        sizeof(device),
+        &device,
+        NULL);
+    errorCode |= dispatch().clGetDeviceInfo(
+        device,
+        CL_DEVICE_TYPE,
+        sizeof(deviceType),
+        &deviceType,
+        NULL );
+    errorCode |= dispatch().clGetCommandQueueInfo(
+        queue,
+        CL_QUEUE_PROPERTIES,
+        sizeof(properties),
+        &properties,
+        NULL );
 
     if( errorCode == CL_SUCCESS )
     {
@@ -12691,42 +12682,31 @@ void CLIntercept::chromeRegisterCommandQueue(
 
         std::string trackName;
 
-        if( deviceType & CL_DEVICE_TYPE_CPU )
-        {
-            trackName += "CPU";
-        }
-        if( deviceType & CL_DEVICE_TYPE_GPU )
-        {
-            trackName += "GPU";
-        }
-        if( deviceType & CL_DEVICE_TYPE_ACCELERATOR )
-        {
-            trackName += "ACC";
-        }
-        if( deviceType & CL_DEVICE_TYPE_CUSTOM )
-        {
-            trackName += "CUSTOM";
-        }
-
         if( properties & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE )
         {
-            trackName += " OOQ";
+            trackName += "OOQ ";
         }
         else
         {
-            trackName += " IOQ";
+            trackName += "IOQ ";
         }
 
         {
-            CLI_SPRINTF( m_StringBuffer, CLI_STRING_BUFFER_SIZE, " %p", queue );
+            CLI_SPRINTF( m_StringBuffer, CLI_STRING_BUFFER_SIZE, "%p on ", queue );
             trackName = trackName + m_StringBuffer;
         }
+
+        std::string deviceInfo;
+        getDeviceInfoString(
+            1,
+            &device,
+            deviceInfo );
 
         uint64_t    processId = OS().GetProcessID();
         m_InterceptTrace
             << "{\"ph\":\"M\", \"name\":\"thread_name\", \"pid\":" << processId
             << ", \"tid\":-" << queueNumber
-            << ", \"args\":{\"name\":\"" << trackName
+            << ", \"args\":{\"name\":\"" << trackName << deviceInfo
             << "\"}},\n";
         m_InterceptTrace
             << "{\"ph\":\"M\", \"name\":\"thread_sort_index\", \"pid\":" << processId

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -99,6 +99,10 @@ public:
     bool    checkDeviceForExtension(
                 cl_device_id device,
                 const char* extensionName ) const;
+    bool    getDeviceIndexInPlatform(
+                cl_device_id device,
+                size_t& index,
+                size_t& count ) const;
 
     cl_int  allocateAndGetPlatformInfoString(
                 cl_platform_id platform,
@@ -393,6 +397,13 @@ public:
                 cl_device_id device,
                 const cl_queue_properties* properties,
                 cl_int* errcode_ret );
+
+    void    addSubDeviceInfo(
+                cl_device_id parentDevice,
+                const cl_device_id* subdevices,
+                cl_uint numSubDevices );
+    void    checkRemoveDeviceInfo(
+                cl_device_id device );
 
     void    addKernelInfo(
                 const cl_kernel kernel,
@@ -912,6 +923,18 @@ private:
 
     unsigned int    m_ProgramNumber;
 
+    // This defines a mapping between a sub-device handle and information
+    // about the sub-device.
+
+    struct SSubDeviceInfo
+    {
+        cl_device_id    ParentDevice;
+        cl_uint         SubDeviceIndex;
+    };
+
+    typedef std::map< const cl_device_id, SSubDeviceInfo >  CSubDeviceInfoMap;
+    CSubDeviceInfoMap   m_SubDeviceInfoMap;
+
     // This defines a mapping between the program handle and information
     // about the program.
 
@@ -924,7 +947,7 @@ private:
         uint64_t        OptionsHash;
     };
 
-    typedef std::map< const cl_program, SProgramInfo>   CProgramInfoMap;
+    typedef std::map< const cl_program, SProgramInfo >  CProgramInfoMap;
     CProgramInfoMap m_ProgramInfoMap;
 
     struct SHostTimingStats
@@ -949,6 +972,12 @@ private:
 
     struct SDeviceInfo
     {
+        cl_device_id    ParentDevice;   // null for root devices
+        size_t      DeviceIndex;        // sub-device index or index in platform
+        size_t      DeviceCountInPlatform;  // one for sub-devices
+
+        cl_device_type  Type;
+
         std::string Name;
         std::string NameForReport;
 


### PR DESCRIPTION
## Description of Changes

Adds more information about the device for chrome tracing.  Previously, the device queue name included the queue address, the type of device it was running on, and whether the queue was an in-order or out-of-order queue, but this isn't enough information for a system with multiple devices or for a device that was partitioned into sub-devices.  After this change, the device queue name will include:

* The name of the device.
* The device index, for a root device in a multi-device platform.
* The sub-device index, for a sub-device.

TODO: Consider including the device UUID?

## Testing Done

Tested chrome tracing for an application that partitioned a device into sub-devices and ran on each sub-device.
