### PR TITLE
even more improvements to the chrome tracing device queue name

### DIFF
--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -87,6 +87,9 @@ public:
 
     void    cacheDeviceInfo(
                 cl_device_id device );
+    void    getDeviceIndexString(
+                cl_device_id device,
+                std::string& str );
     cl_int  getDeviceMajorMinorVersion(
                 cl_device_id device,
                 size_t& majorVersion,
@@ -96,13 +99,13 @@ public:
                 const char* str,
                 size_t& majorVersion,
                 size_t& minorVersion ) const;
+    bool    getDeviceIndex(
+                cl_device_id device,
+                cl_uint& platformIndex,
+                cl_uint& deviceIndex ) const;
     bool    checkDeviceForExtension(
                 cl_device_id device,
                 const char* extensionName ) const;
-    bool    getDeviceIndexInPlatform(
-                cl_device_id device,
-                size_t& index,
-                size_t& count ) const;
 
     cl_int  allocateAndGetPlatformInfoString(
                 cl_platform_id platform,
@@ -973,8 +976,8 @@ private:
     struct SDeviceInfo
     {
         cl_device_id    ParentDevice;   // null for root devices
-        size_t      DeviceIndex;        // sub-device index or index in platform
-        size_t      DeviceCountInPlatform;  // one for sub-devices
+        cl_uint     PlatformIndex;      // zero for sub-devices
+        cl_uint     DeviceIndex;
 
         cl_device_type  Type;
 


### PR DESCRIPTION
## Description of Changes

A few more improvements to the chrome tracing device queue name:

* Provide the full platform.device.subdevice "index" in the queue name.
* Move the "index" closer to the front of the queue name so it is visible without needing to hover over the queue name.
* Include the queue family and queue index for devices supporting cl_intel_command_queue_families.

## Testing Done

Tested with an application that creates sub-devices.  Also tested with a device supporting cl_intel_command_queue_families.
