### PR TITLE
fix a copy-paste error causing the queue family to be overwritten

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -12885,8 +12885,8 @@ void CLIntercept::chromeRegisterCommandQueue(
             testError |= dispatch().clGetCommandQueueInfo(
                 queue,
                 CL_QUEUE_INDEX_INTEL,
-                sizeof(queueFamily),
-                &queueFamily,
+                sizeof(queueIndex),
+                &queueIndex,
                 NULL );
             if( testError == CL_SUCCESS )
             {


### PR DESCRIPTION
## Description of Changes

Fix a copy-paste error causing the queue family to be overwritten with the queue index.

## Testing Done

Found while running tests on a system with multiple queue families.
