### PR TITLE
add support for enabling a MDAPI queue via queue properties

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -1542,6 +1542,11 @@ cl_int CL_API_CALL clSetPerformanceConfigurationINTEL(
     cl_uint*        offsets,
     cl_uint*        values );
 
+#define CL_QUEUE_MDAPI_PROPERTIES_INTEL             0x425E
+#define CL_QUEUE_MDAPI_CONFIGURATION_INTEL          0x425F
+
+#define CL_QUEUE_MDAPI_ENABLE_INTEL                 (1 << 0)
+
 ///////////////////////////////////////////////////////////////////////////////
 // Unofficial kernel profiling extension:
 

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -1130,6 +1130,10 @@ CEnumNameMap::CEnumNameMap()
     // cl_qcom_ion_host_ptr extension
     ADD_ENUM_NAME( m_cl_int, CL_MEM_ION_HOST_PTR_QCOM );
 
+    // Unofficial MDAPI extension:
+    ADD_ENUM_NAME( m_cl_int, CL_QUEUE_MDAPI_PROPERTIES_INTEL );
+    ADD_ENUM_NAME( m_cl_int, CL_QUEUE_MDAPI_CONFIGURATION_INTEL );
+
     // Unofficial kernel profiling extension:
     ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_KERNEL_PROFILING_MODES_COUNT_INTEL );
     ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_KERNEL_PROFILING_MODE_INFO_INTEL );

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -2210,6 +2210,8 @@ void CLIntercept::getCommandQueuePropertiesString(
             case CL_QUEUE_SIZE:
             case CL_QUEUE_FAMILY_INTEL:
             case CL_QUEUE_INDEX_INTEL:
+            case CL_QUEUE_MDAPI_PROPERTIES_INTEL:
+            case CL_QUEUE_MDAPI_CONFIGURATION_INTEL:
                 {
                     const cl_uint*  pu = (const cl_uint*)( properties + 1);
                     CLI_SPRINTF( s, 256, "%u", pu[0] );
@@ -3457,7 +3459,7 @@ void CLIntercept::contextCallbackOverrideInit(
         // the context properties for the performance hint enum.  We need to
         // do this anyways to count the number of property pairs.
         bool    foundPerformanceHintEnum = false;
-        int     numProperties = 0;
+        size_t  numProperties = 0;
         if( properties )
         {
             while( properties[ numProperties ] != 0 )
@@ -5321,7 +5323,7 @@ void CLIntercept::createCommandQueueProperties(
                 config().DefaultQueueThrottleHint != 0 &&
                 checkDeviceForExtension( device, "cl_khr_throttle_hints" );
 
-    int numProperties = 0;
+    size_t  numProperties = 0;
     if( addCommandQueuePropertiesEnum )
     {
         numProperties += 2;
@@ -5394,7 +5396,7 @@ void CLIntercept::createCommandQueuePropertiesOverride(
                 config().DefaultQueueThrottleHint != 0 &&
                 checkDeviceForExtension( device, "cl_khr_throttle_hints" );
 
-    int     numProperties = 0;
+    size_t  numProperties = 0;
     if( properties )
     {
         while( properties[ numProperties ] != 0 )
@@ -8001,7 +8003,7 @@ void CLIntercept::usmAllocPropertiesOverride(
 
     bool    addMemFlagsEnum = config().RelaxAllocationLimits != 0;
 
-    int     numProperties = 0;
+    size_t  numProperties = 0;
     if( properties )
     {
         while( properties[ numProperties ] != 0 )


### PR DESCRIPTION
## Description of Changes

Adds the ability to create an MDAPI command queue with properties instead of clCreatePerfCountersCommandQueueINTEL().  This means that an MDAPI command queue can be created for a specific queue in a queue family, or for a high priority queue, or for any other queue properties.

## Testing Done

Tested with an application that creates a command queue with properties and specifies a queue family.
