### PR TITLE
add an alternate CL_DEVICE_HANDLE_LIST_END_KHR

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -2293,15 +2293,23 @@ void CLIntercept::getMemPropertiesString(
                 {
                     ++properties;
                     str += "{ ";
-                    do
+                    while( true )
                     {
                         if( *properties == CL_DEVICE_HANDLE_LIST_END_KHR )
                         {
                             str += "CL_DEVICE_HANDLE_LIST_END_KHR";
+                            properties++;
+                            break;
+                        }
+                        else if( *properties == 0x2052 )
+                        {
+                            str += "CL_DEVICE_HANDLE_LIST_END_KHR_0x2502";
+                            properties++;
+                            break;
                         }
                         else
                         {
-                            auto pDevice = (const cl_device_id*)properties;
+                            auto pDevice = (const cl_device_id*)properties++;
                             std::string deviceInfo;
                             getDeviceInfoString(
                                 1,
@@ -2309,10 +2317,8 @@ void CLIntercept::getMemPropertiesString(
                                 deviceInfo );
                             str += deviceInfo;
                             str += ", ";
-
                         }
                     }
-                    while( *properties++ != CL_DEVICE_HANDLE_LIST_END_KHR );
                     str += " }";
                 }
                 break;
@@ -2392,15 +2398,23 @@ void CLIntercept::getSemaphorePropertiesString(
                 {
                     ++properties;
                     str += "{ ";
-                    do
+                    while( true )
                     {
                         if( *properties == CL_DEVICE_HANDLE_LIST_END_KHR )
                         {
                             str += "CL_DEVICE_HANDLE_LIST_END_KHR";
+                            properties++;
+                            break;
+                        }
+                        else if( *properties == 0x2052 )
+                        {
+                            str += "CL_DEVICE_HANDLE_LIST_END_KHR_0x2502";
+                            properties++;
+                            break;
                         }
                         else
                         {
-                            auto pDevice = (const cl_device_id*)properties;
+                            auto pDevice = (const cl_device_id*)properties++;
                             std::string deviceInfo;
                             getDeviceInfoString(
                                 1,
@@ -2408,10 +2422,8 @@ void CLIntercept::getSemaphorePropertiesString(
                                 deviceInfo );
                             str += deviceInfo;
                             str += ", ";
-
                         }
                     }
-                    while( *properties++ != CL_DEVICE_HANDLE_LIST_END_KHR );
                     str += " }";
                 }
                 break;


### PR DESCRIPTION
## Description of Changes

Drivers and sample code from a vendor that supports the provisional external memory sharing extension use a different value for CL_DEVICE_HANDLE_LIST_END_KHR from the one described by the spec.  While we figure out if this is a bug in the drivers or a bug in the spec, add the device handle list enum value used by these vendors so the sample applications can run and be traced without crashing.

## Testing Done

Ran sample apps from the vendor using the provisional external memory sharing extensions.  I'm also upgrading my Vulkan sharing sample to use the provisional external memory sharing extensions (not quite done yet though).
