### PR TITLE
Map timing tags

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -4417,8 +4417,8 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapBuffer)(
                 event,
                 errcode_ret );
 
-            HOST_PERFORMANCE_TIMING_END_BLOCKING( blocking_map );
-            DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
+            HOST_PERFORMANCE_TIMING_END_MAP( blocking_map, map_flags );
+            DEVICE_PERFORMANCE_TIMING_END_MAP( command_queue, event, map_flags );
             DUMP_BUFFER_AFTER_MAP( command_queue, buffer, blocking_map, map_flags, retVal, offset, cb );
             CHECK_ERROR( errcode_ret[0] );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
@@ -4432,7 +4432,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapBuffer)(
                     &map_count,
                     NULL );
             }
-            CALL_LOGGING_EXIT_BLOCKING_EVENT( errcode_ret[0], blocking_map, event,
+            CALL_LOGGING_EXIT_MAP_EVENT( errcode_ret[0], blocking_map, map_flags, event,
                 "[ map count = %d ] returned %p",
                 map_count,
                 retVal );
@@ -4544,8 +4544,8 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapImage)(
                 event,
                 errcode_ret );
 
-            HOST_PERFORMANCE_TIMING_END_BLOCKING( blocking_map );
-            DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
+            HOST_PERFORMANCE_TIMING_END_MAP( blocking_map, map_flags );
+            DEVICE_PERFORMANCE_TIMING_END_MAP( command_queue, event, map_flags );
             CHECK_ERROR( errcode_ret[0] );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
             if( pIntercept->config().CallLogging )
@@ -4558,7 +4558,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapImage)(
                     &map_count,
                     NULL );
             }
-            CALL_LOGGING_EXIT_BLOCKING_EVENT( errcode_ret[0], blocking_map, event,
+            CALL_LOGGING_EXIT_MAP_EVENT( errcode_ret[0], blocking_map, map_flags, event,
                 "[ map count = %d ] returned %p",
                 map_count,
                 retVal );
@@ -6513,11 +6513,11 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMMap) (
                 event_wait_list,
                 event );
 
-            HOST_PERFORMANCE_TIMING_END_BLOCKING( blocking_map );
-            DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
+            HOST_PERFORMANCE_TIMING_END_MAP( blocking_map, map_flags );
+            DEVICE_PERFORMANCE_TIMING_END_MAP( command_queue, event, map_flags );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_BLOCKING_EVENT( retVal, blocking_map, event );
+            CALL_LOGGING_EXIT_MAP_EVENT( retVal, blocking_map, map_flags, event );
             ADD_EVENT( event ? event[0] : NULL );
 
             if( blocking_map )

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -9997,6 +9997,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemcpyINTEL(
                     size,
                     eventWaitListString.c_str() );
                 CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                GET_TIMING_TAGS_MEMCPY( queue, blocking, dst_ptr, src_ptr );
                 DEVICE_PERFORMANCE_TIMING_START( event );
                 HOST_PERFORMANCE_TIMING_START();
 
@@ -10010,11 +10011,11 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemcpyINTEL(
                     event_wait_list,
                     event );
 
-                HOST_PERFORMANCE_TIMING_END_MEMCPY( queue, blocking, dst_ptr, src_ptr );
-                DEVICE_PERFORMANCE_TIMING_END_MEMCPY( queue, event, dst_ptr, src_ptr );
+                HOST_PERFORMANCE_TIMING_END_WITH_TAG();
+                DEVICE_PERFORMANCE_TIMING_END_WITH_TAG( queue, event );
                 CHECK_ERROR( retVal );
                 ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-                CALL_LOGGING_EXIT_MEMCPY_EVENT( retVal, queue, blocking, dst_ptr, src_ptr, event );
+                CALL_LOGGING_EXIT_EVENT_WITH_TAG( retVal, event );
                 ADD_EVENT( event ? event[0] : NULL );
 
                 if( blocking )

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -3265,6 +3265,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReadBuffer)(
                 ptr,
                 eventWaitListString.c_str() );
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+            GET_TIMING_TAG_BLOCKING( blocking_read );
             DEVICE_PERFORMANCE_TIMING_START( event );
             HOST_PERFORMANCE_TIMING_START();
 
@@ -3297,11 +3298,11 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReadBuffer)(
                     event );
             }
 
-            HOST_PERFORMANCE_TIMING_END_BLOCKING( blocking_read );
+            HOST_PERFORMANCE_TIMING_END_WITH_TAG();
             DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_BLOCKING_EVENT( retVal, blocking_read, event );
+            CALL_LOGGING_EXIT_EVENT_WITH_TAG( retVal, event );
             ADD_EVENT( event ? event[0] : NULL );
 
             if( blocking_read )
@@ -3377,6 +3378,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReadBufferRect)(
                     eventWaitListString.c_str() );
             }
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+            GET_TIMING_TAG_BLOCKING( blocking_read );
             DEVICE_PERFORMANCE_TIMING_START( event );
             HOST_PERFORMANCE_TIMING_START();
 
@@ -3398,11 +3400,11 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReadBufferRect)(
                 event_wait_list,
                 event );
 
-            HOST_PERFORMANCE_TIMING_END_BLOCKING( blocking_read );
+            HOST_PERFORMANCE_TIMING_END_WITH_TAG();
             DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_BLOCKING_EVENT( retVal, blocking_read, event );
+            CALL_LOGGING_EXIT_EVENT_WITH_TAG( retVal, event );
             ADD_EVENT( event ? event[0] : NULL );
 
             if( blocking_read )
@@ -3459,6 +3461,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueWriteBuffer)(
                 ptr,
                 eventWaitListString.c_str() );
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+            GET_TIMING_TAG_BLOCKING( blocking_write );
             DEVICE_PERFORMANCE_TIMING_START( event );
             HOST_PERFORMANCE_TIMING_START();
 
@@ -3491,11 +3494,11 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueWriteBuffer)(
                     event );
             }
 
-            HOST_PERFORMANCE_TIMING_END_BLOCKING( blocking_write );
+            HOST_PERFORMANCE_TIMING_END_WITH_TAG();
             DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_BLOCKING_EVENT( retVal, blocking_write, event );
+            CALL_LOGGING_EXIT_EVENT_WITH_TAG( retVal, event );
             ADD_EVENT( event ? event[0] : NULL );
 
             if( blocking_write )
@@ -3571,6 +3574,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueWriteBufferRect)(
                     eventWaitListString.c_str() );
             }
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+            GET_TIMING_TAG_BLOCKING( blocking_write );
             DEVICE_PERFORMANCE_TIMING_START( event );
             HOST_PERFORMANCE_TIMING_START();
 
@@ -3592,11 +3596,11 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueWriteBufferRect)(
                 event_wait_list,
                 event );
 
-            HOST_PERFORMANCE_TIMING_END_BLOCKING( blocking_write );
+            HOST_PERFORMANCE_TIMING_END_WITH_TAG();
             DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_BLOCKING_EVENT( retVal, blocking_write, event );
+            CALL_LOGGING_EXIT_EVENT_WITH_TAG( retVal, event );
             ADD_EVENT( event ? event[0] : NULL );
 
             if( blocking_write )
@@ -3913,6 +3917,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReadImage)(
                     eventWaitListString.c_str() );
             }
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+            GET_TIMING_TAG_BLOCKING( blocking_read );
             DEVICE_PERFORMANCE_TIMING_START( event );
             HOST_PERFORMANCE_TIMING_START();
 
@@ -3949,11 +3954,11 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueReadImage)(
                     event );
             }
 
-            HOST_PERFORMANCE_TIMING_END_BLOCKING( blocking_read );
+            HOST_PERFORMANCE_TIMING_END_WITH_TAG();
             DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_BLOCKING_EVENT( retVal, blocking_read, event );
+            CALL_LOGGING_EXIT_EVENT_WITH_TAG( retVal, event );
             ADD_EVENT( event ? event[0] : NULL );
 
             if( blocking_read )
@@ -4010,6 +4015,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueWriteImage)(
                 ptr,
                 eventWaitListString.c_str() );
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+            GET_TIMING_TAG_BLOCKING( blocking_write );
             DEVICE_PERFORMANCE_TIMING_START( event );
             HOST_PERFORMANCE_TIMING_START();
 
@@ -4046,11 +4052,11 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueWriteImage)(
                     event );
             }
 
-            HOST_PERFORMANCE_TIMING_END_BLOCKING( blocking_write );
+            HOST_PERFORMANCE_TIMING_END_WITH_TAG();
             DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_BLOCKING_EVENT( retVal, blocking_write, event );
+            CALL_LOGGING_EXIT_EVENT_WITH_TAG( retVal, event );
             ADD_EVENT( event ? event[0] : NULL );
 
             if( blocking_write )
@@ -4790,6 +4796,13 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueNDRangeKernel)(
                 argsString.c_str() );
 
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+            GET_TIMING_TAGS_KERNEL(
+                command_queue,
+                kernel,
+                work_dim,
+                global_work_offset,
+                global_work_size,
+                local_work_size );
             DEVICE_PERFORMANCE_TIMING_START( event );
             HOST_PERFORMANCE_TIMING_START();
 
@@ -4840,18 +4853,11 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueNDRangeKernel)(
                     event );
             }
 
-            HOST_PERFORMANCE_TIMING_END_KERNEL(kernel);
-            DEVICE_PERFORMANCE_TIMING_END_KERNEL(
-                command_queue,
-                event,
-                kernel,
-                work_dim,
-                global_work_offset,
-                global_work_size,
-                local_work_size );
+            HOST_PERFORMANCE_TIMING_END_WITH_TAG();
+            DEVICE_PERFORMANCE_TIMING_END_WITH_TAG( command_queue, event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_KERNEL_EVENT( retVal, kernel, event );
+            CALL_LOGGING_EXIT_EVENT_WITH_TAG( retVal, event );
             ADD_EVENT( event ? event[0] : NULL );
         }
 
@@ -4898,6 +4904,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueTask)(
                 kernel,
                 eventWaitListString.c_str());
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+            GET_TIMING_TAGS_KERNEL( command_queue, kernel, 0, NULL, NULL, NULL );
             DEVICE_PERFORMANCE_TIMING_START( event );
             HOST_PERFORMANCE_TIMING_START();
 
@@ -4908,18 +4915,11 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueTask)(
                 event_wait_list,
                 event );
 
-            HOST_PERFORMANCE_TIMING_END_KERNEL(kernel);
-            DEVICE_PERFORMANCE_TIMING_END_KERNEL(
-                command_queue,
-                event,
-                kernel,
-                0,
-                NULL,
-                NULL,
-                NULL );
+            HOST_PERFORMANCE_TIMING_END_WITH_TAG();
+            DEVICE_PERFORMANCE_TIMING_END_WITH_TAG( command_queue, event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_KERNEL_EVENT( retVal, kernel, event );
+            CALL_LOGGING_EXIT_EVENT_WITH_TAG( retVal, event );
             ADD_EVENT( event ? event[0] : NULL );
         }
 
@@ -6363,6 +6363,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMMemcpy) (
                 size,
                 eventWaitListString.c_str() );
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+            GET_TIMING_TAG_BLOCKING( blocking_copy );
             DEVICE_PERFORMANCE_TIMING_START( event );
             HOST_PERFORMANCE_TIMING_START();
 
@@ -6376,11 +6377,11 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMMemcpy) (
                 event_wait_list,
                 event );
 
-            HOST_PERFORMANCE_TIMING_END_BLOCKING( blocking_copy );
+            HOST_PERFORMANCE_TIMING_END_WITH_TAG();
             DEVICE_PERFORMANCE_TIMING_END( command_queue, event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_BLOCKING_EVENT( retVal, blocking_copy, event );
+            CALL_LOGGING_EXIT_EVENT_WITH_TAG( retVal, event );
             ADD_EVENT( event ? event[0] : NULL );
 
             if( blocking_copy )

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -4399,9 +4399,9 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapBuffer)(
                 cb,
                 eventWaitListString.c_str() );
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
             CHECK_ERROR_INIT( errcode_ret );
             GET_TIMING_TAGS_MAP( blocking_map, map_flags );
+            DEVICE_PERFORMANCE_TIMING_START( event );
             HOST_PERFORMANCE_TIMING_START();
 
             ITT_ADD_PARAM_AS_METADATA( blocking_map );
@@ -4433,7 +4433,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapBuffer)(
                     &map_count,
                     NULL );
             }
-            CALL_LOGGING_EXIT_MAP_EVENT( errcode_ret[0], blocking_map, map_flags, event,
+            CALL_LOGGING_EXIT_EVENT_WITH_TAG( errcode_ret[0], event,
                 "[ map count = %d ] returned %p",
                 map_count,
                 retVal );
@@ -4525,9 +4525,9 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapImage)(
                     eventWaitListString.c_str() );
             }
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
             CHECK_ERROR_INIT( errcode_ret );
             GET_TIMING_TAGS_MAP( blocking_map, map_flags );
+            DEVICE_PERFORMANCE_TIMING_START( event );
             HOST_PERFORMANCE_TIMING_START();
 
             ITT_ADD_PARAM_AS_METADATA( blocking_map );
@@ -4560,7 +4560,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapImage)(
                     &map_count,
                     NULL );
             }
-            CALL_LOGGING_EXIT_MAP_EVENT( errcode_ret[0], blocking_map, map_flags, event,
+            CALL_LOGGING_EXIT_EVENT_WITH_TAG( errcode_ret[0], event,
                 "[ map count = %d ] returned %p",
                 map_count,
                 retVal );
@@ -6502,8 +6502,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMMap) (
                 size,
                 eventWaitListString.c_str() );
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
-            DEVICE_PERFORMANCE_TIMING_START( event );
             GET_TIMING_TAGS_MAP( blocking_map, map_flags );
+            DEVICE_PERFORMANCE_TIMING_START( event );
             HOST_PERFORMANCE_TIMING_START();
 
             retVal = pIntercept->dispatch().clEnqueueSVMMap(
@@ -6520,7 +6520,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMMap) (
             DEVICE_PERFORMANCE_TIMING_END_WITH_TAG( command_queue, event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-            CALL_LOGGING_EXIT_MAP_EVENT( retVal, blocking_map, map_flags, event );
+            CALL_LOGGING_EXIT_EVENT_WITH_TAG( retVal, event );
             ADD_EVENT( event ? event[0] : NULL );
 
             if( blocking_map )
@@ -9855,6 +9855,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemsetINTEL(   // Deprecated
                     size,
                     eventWaitListString.c_str() );
                 CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                GET_TIMING_TAGS_MEMFILL( queue, dst_ptr );
                 DEVICE_PERFORMANCE_TIMING_START( event );
                 HOST_PERFORMANCE_TIMING_START();
 
@@ -9867,11 +9868,11 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemsetINTEL(   // Deprecated
                     event_wait_list,
                     event );
 
-                HOST_PERFORMANCE_TIMING_END_MEMFILL( queue, dst_ptr );
-                DEVICE_PERFORMANCE_TIMING_END_MEMFILL( queue, event, dst_ptr );
+                HOST_PERFORMANCE_TIMING_END_WITH_TAG();
+                DEVICE_PERFORMANCE_TIMING_END_WITH_TAG( queue, event );
                 CHECK_ERROR( retVal );
                 ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-                CALL_LOGGING_EXIT_MEMFILL_EVENT( retVal, queue, dst_ptr, event );
+                CALL_LOGGING_EXIT_EVENT_WITH_TAG( retVal, event );
                 ADD_EVENT( event ? event[0] : NULL );
             }
 
@@ -9924,6 +9925,7 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemFillINTEL(
                     size,
                     eventWaitListString.c_str() );
                 CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
+                GET_TIMING_TAGS_MEMFILL( queue, dst_ptr );
                 DEVICE_PERFORMANCE_TIMING_START( event );
                 HOST_PERFORMANCE_TIMING_START();
 
@@ -9937,11 +9939,11 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueMemFillINTEL(
                     event_wait_list,
                     event );
 
-                HOST_PERFORMANCE_TIMING_END_MEMFILL( queue, dst_ptr );
-                DEVICE_PERFORMANCE_TIMING_END_MEMFILL( queue, event, dst_ptr );
+                HOST_PERFORMANCE_TIMING_END_WITH_TAG();
+                DEVICE_PERFORMANCE_TIMING_END_WITH_TAG( queue, event );
                 CHECK_ERROR( retVal );
                 ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
-                CALL_LOGGING_EXIT_MEMFILL_EVENT( retVal, queue, dst_ptr, event );
+                CALL_LOGGING_EXIT_EVENT_WITH_TAG( retVal, event );
                 ADD_EVENT( event ? event[0] : NULL );
             }
 

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -4401,6 +4401,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapBuffer)(
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
             DEVICE_PERFORMANCE_TIMING_START( event );
             CHECK_ERROR_INIT( errcode_ret );
+            GET_TIMING_TAGS_MAP( blocking_map, map_flags );
             HOST_PERFORMANCE_TIMING_START();
 
             ITT_ADD_PARAM_AS_METADATA( blocking_map );
@@ -4417,8 +4418,8 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapBuffer)(
                 event,
                 errcode_ret );
 
-            HOST_PERFORMANCE_TIMING_END_MAP( blocking_map, map_flags );
-            DEVICE_PERFORMANCE_TIMING_END_MAP( command_queue, event, map_flags );
+            HOST_PERFORMANCE_TIMING_END_WITH_TAG();
+            DEVICE_PERFORMANCE_TIMING_END_WITH_TAG( command_queue, event );
             DUMP_BUFFER_AFTER_MAP( command_queue, buffer, blocking_map, map_flags, retVal, offset, cb );
             CHECK_ERROR( errcode_ret[0] );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
@@ -4526,6 +4527,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapImage)(
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
             DEVICE_PERFORMANCE_TIMING_START( event );
             CHECK_ERROR_INIT( errcode_ret );
+            GET_TIMING_TAGS_MAP( blocking_map, map_flags );
             HOST_PERFORMANCE_TIMING_START();
 
             ITT_ADD_PARAM_AS_METADATA( blocking_map );
@@ -4544,8 +4546,8 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clEnqueueMapImage)(
                 event,
                 errcode_ret );
 
-            HOST_PERFORMANCE_TIMING_END_MAP( blocking_map, map_flags );
-            DEVICE_PERFORMANCE_TIMING_END_MAP( command_queue, event, map_flags );
+            HOST_PERFORMANCE_TIMING_END_WITH_TAG();
+            DEVICE_PERFORMANCE_TIMING_END_WITH_TAG( command_queue, event );
             CHECK_ERROR( errcode_ret[0] );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
             if( pIntercept->config().CallLogging )
@@ -6501,6 +6503,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMMap) (
                 eventWaitListString.c_str() );
             CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
             DEVICE_PERFORMANCE_TIMING_START( event );
+            GET_TIMING_TAGS_MAP( blocking_map, map_flags );
             HOST_PERFORMANCE_TIMING_START();
 
             retVal = pIntercept->dispatch().clEnqueueSVMMap(
@@ -6513,8 +6516,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueSVMMap) (
                 event_wait_list,
                 event );
 
-            HOST_PERFORMANCE_TIMING_END_MAP( blocking_map, map_flags );
-            DEVICE_PERFORMANCE_TIMING_END_MAP( command_queue, event, map_flags );
+            HOST_PERFORMANCE_TIMING_END_WITH_TAG();
+            DEVICE_PERFORMANCE_TIMING_END_WITH_TAG( command_queue, event );
             CHECK_ERROR( retVal );
             ADD_OBJECT_ALLOCATION( event ? event[0] : NULL );
             CALL_LOGGING_EXIT_MAP_EVENT( retVal, blocking_map, map_flags, event );

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -5113,6 +5113,43 @@ void CLIntercept::getHostTimingTagBlocking(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+void CLIntercept::getHostTimingTagMap(
+    const cl_map_flags flags,
+    const cl_bool blocking,
+    std::string& str )
+{
+    std::lock_guard<std::mutex> lock(m_Mutex);
+
+    if( flags & CL_MAP_WRITE_INVALIDATE_REGION )
+    {
+        str += "WI";
+    }
+    else if( flags & CL_MAP_WRITE )
+    {
+        str += "RW";
+    }
+    else if( flags & CL_MAP_READ )
+    {
+        str += "R";
+    }
+
+    if( flags & ~(CL_MAP_READ | CL_MAP_WRITE | CL_MAP_WRITE_INVALIDATE_REGION) )
+    {
+        str += "?";
+    }
+
+    if( blocking == CL_TRUE )
+    {
+        if( !str.empty() )
+        {
+            str += ", ";
+        }
+        str += "blocking";
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
 void CLIntercept::getHostTimingTagMemfill(
     const cl_command_queue queue,
     const void* dst,
@@ -5545,6 +5582,40 @@ void CLIntercept::dummyCommandQueue(
                     errorCode );
             }
         }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+void CLIntercept::getDeviceTimingTagMap(
+    const std::string& functionName,
+    const cl_map_flags flags,
+    std::string& str )
+{
+    std::lock_guard<std::mutex> lock(m_Mutex);
+
+    str = functionName;
+
+    if( flags & CL_MAP_WRITE_INVALIDATE_REGION )
+    {
+        str += "( WI";
+    }
+    else if( flags & CL_MAP_WRITE )
+    {
+        str += "( RW";
+    }
+    else if( flags & CL_MAP_READ )
+    {
+        str += "( R";
+    }
+
+    if( flags & ~(CL_MAP_READ | CL_MAP_WRITE | CL_MAP_WRITE_INVALIDATE_REGION) )
+    {
+        str += "? )";
+    }
+    else
+    {
+        str += " )";
     }
 }
 

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -5113,40 +5113,48 @@ void CLIntercept::getHostTimingTagBlocking(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-void CLIntercept::getHostTimingTagMap(
+void CLIntercept::getTimingTagsMap(
+    const std::string& functionName,
     const cl_map_flags flags,
     const cl_bool blocking,
-    std::string& str )
+    std::string& hostTag,
+    std::string& deviceTag )
 {
-    std::lock_guard<std::mutex> lock(m_Mutex);
+    // Note: we do not currently need a lock for this function.
 
     if( flags & CL_MAP_WRITE_INVALIDATE_REGION )
     {
-        str += "WI";
+        hostTag += "WI";
     }
     else if( flags & CL_MAP_WRITE )
     {
-        str += "RW";
+        hostTag += "RW";
     }
     else if( flags & CL_MAP_READ )
     {
-        str += "R";
+        hostTag += "R";
     }
 
     if( flags & ~(CL_MAP_READ | CL_MAP_WRITE | CL_MAP_WRITE_INVALIDATE_REGION) )
     {
-        str += "?";
+        hostTag += "?";
     }
+
+    deviceTag = functionName;
+    deviceTag += "( ";
+    deviceTag += hostTag;
+    deviceTag += " )";
 
     if( blocking == CL_TRUE )
     {
-        if( !str.empty() )
+        if( !hostTag.empty() )
         {
-            str += ", ";
+            hostTag += ", ";
         }
-        str += "blocking";
+        hostTag += "blocking";
     }
 }
+
 
 ///////////////////////////////////////////////////////////////////////////////
 //
@@ -5582,40 +5590,6 @@ void CLIntercept::dummyCommandQueue(
                     errorCode );
             }
         }
-    }
-}
-
-///////////////////////////////////////////////////////////////////////////////
-//
-void CLIntercept::getDeviceTimingTagMap(
-    const std::string& functionName,
-    const cl_map_flags flags,
-    std::string& str )
-{
-    std::lock_guard<std::mutex> lock(m_Mutex);
-
-    str = functionName;
-
-    if( flags & CL_MAP_WRITE_INVALIDATE_REGION )
-    {
-        str += "( WI";
-    }
-    else if( flags & CL_MAP_WRITE )
-    {
-        str += "( RW";
-    }
-    else if( flags & CL_MAP_READ )
-    {
-        str += "( R";
-    }
-
-    if( flags & ~(CL_MAP_READ | CL_MAP_WRITE | CL_MAP_WRITE_INVALIDATE_REGION) )
-    {
-        str += "? )";
-    }
-    else
-    {
-        str += " )";
     }
 }
 

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -358,6 +358,10 @@ public:
     void    getHostTimingTagBlocking(
                 const cl_bool blocking,
                 std::string& str );
+    void    getHostTimingTagMap(
+                const cl_map_flags flags,
+                const cl_bool blocking,
+                std::string& str );
     void    getHostTimingTagMemfill(
                 const cl_command_queue queue,
                 const void* dst,
@@ -395,6 +399,10 @@ public:
                 cl_context context,
                 cl_device_id device );
 
+    void    getDeviceTimingTagMap(
+                const std::string& functionName,
+                const cl_map_flags flags,
+                std::string& str );
     void    getDeviceTimingTagMemfill(
                 const std::string& functionName,
                 const cl_command_queue queue,
@@ -1910,6 +1918,32 @@ inline CObjectTracker& CLIntercept::objectTracker()
     }                                                                       \
     ITT_CALL_LOGGING_EXIT();
 
+#define CALL_LOGGING_EXIT_MAP_EVENT(errorCode, _blocking, _flags, _event, ...) \
+    if( pIntercept->config().CallLogging )                                  \
+    {                                                                       \
+        pIntercept->callLoggingExit(                                        \
+            __FUNCTION__,                                                   \
+            errorCode,                                                      \
+            _event,                                                         \
+            ##__VA_ARGS__ );                                                \
+    }                                                                       \
+    if( pIntercept->config().ChromeCallLogging )                            \
+    {                                                                       \
+        std::string tag;                                                    \
+        pIntercept->getHostTimingTagMap(                                    \
+            _flags,                                                         \
+            _blocking,                                                      \
+            tag );                                                          \
+        pIntercept->chromeCallLoggingExit(                                  \
+            __FUNCTION__,                                                   \
+            tag,                                                            \
+            true,                                                           \
+            enqueueCounter,                                                 \
+            cpuStart,                                                       \
+            cpuEnd );                                                       \
+    }                                                                       \
+    ITT_CALL_LOGGING_EXIT();
+
 #define CALL_LOGGING_EXIT_MEMFILL_EVENT(errorCode, _queue, _dst, _event, ...)\
     if( pIntercept->config().CallLogging )                                  \
     {                                                                       \
@@ -2797,6 +2831,27 @@ inline bool CLIntercept::checkHostPerformanceTimingEnqueueLimits(
         }                                                                   \
     }
 
+#define HOST_PERFORMANCE_TIMING_END_MAP( _blocking, _flags)                 \
+    if( pIntercept->config().HostPerformanceTiming ||                       \
+        pIntercept->config().ChromeCallLogging )                            \
+    {                                                                       \
+        cpuEnd = CLIntercept::clock::now();                                 \
+        if( pIntercept->config().HostPerformanceTiming &&                   \
+            pIntercept->checkHostPerformanceTimingEnqueueLimits( enqueueCounter ) )\
+        {                                                                   \
+            std::string tag;                                                \
+            pIntercept->getHostTimingTagMap(                                \
+                _flags,                                                     \
+                _blocking,                                                  \
+                tag );                                                      \
+            pIntercept->updateHostTimingStats(                              \
+                __FUNCTION__,                                               \
+                tag,                                                        \
+                cpuStart,                                                   \
+                cpuEnd );                                                   \
+        }                                                                   \
+    }
+
 #define HOST_PERFORMANCE_TIMING_END_MEMFILL( _queue, _dst )                 \
     if( pIntercept->config().HostPerformanceTiming ||                       \
         pIntercept->config().ChromeCallLogging )                            \
@@ -2984,6 +3039,37 @@ inline bool CLIntercept::checkDevicePerformanceTimingEnqueueLimits(
                 enqueueCounter,                                             \
                 queuedTime,                                                 \
                 "",                                                         \
+                queue,                                                      \
+                pEvent[0] );                                                \
+            TOOL_OVERHEAD_TIMING_END( "(timing event overhead)" );          \
+        }                                                                   \
+        if( isLocalEvent )                                                  \
+        {                                                                   \
+            pIntercept->dispatch().clReleaseEvent( pEvent[0] );             \
+            pEvent = NULL;                                                  \
+        }                                                                   \
+    }
+
+#define DEVICE_PERFORMANCE_TIMING_END_MAP( queue, pEvent, flags )           \
+    if( ( pIntercept->config().DevicePerformanceTiming ||                   \
+          pIntercept->config().ITTPerformanceTiming ||                      \
+          pIntercept->config().ChromePerformanceTiming ||                   \
+          pIntercept->config().DevicePerfCounterEventBasedSampling ) &&     \
+        ( pEvent != NULL ) )                                                \
+    {                                                                       \
+        if( pIntercept->checkDevicePerformanceTimingEnqueueLimits( enqueueCounter ) )\
+        {                                                                   \
+            TOOL_OVERHEAD_TIMING_START();                                   \
+            std::string tag;                                                \
+            pIntercept->getDeviceTimingTagMap(                              \
+                __FUNCTION__,                                               \
+                flags,                                                      \
+                tag );                                                      \
+            pIntercept->addTimingEvent(                                     \
+                __FUNCTION__,                                               \
+                enqueueCounter,                                             \
+                queuedTime,                                                 \
+                tag,                                                        \
                 queue,                                                      \
                 pEvent[0] );                                                \
             TOOL_OVERHEAD_TIMING_END( "(timing event overhead)" );          \

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -361,13 +361,15 @@ public:
                 const cl_bool blocking,
                 std::string& hostTag,
                 std::string& deviceTag );
+    void    getTimingTagsMemfill(
+                const std::string& functionName,
+                const cl_command_queue queue,
+                const void* dst,
+                std::string& hostTag,
+                std::string& deviceTag );
 
     void    getHostTimingTagBlocking(
                 const cl_bool blocking,
-                std::string& str );
-    void    getHostTimingTagMemfill(
-                const cl_command_queue queue,
-                const void* dst,
                 std::string& str );
     void    getHostTimingTagMemcpy(
                 const cl_command_queue queue,
@@ -402,11 +404,6 @@ public:
                 cl_context context,
                 cl_device_id device );
 
-    void    getDeviceTimingTagMemfill(
-                const std::string& functionName,
-                const cl_command_queue queue,
-                const void* dst,
-                std::string& str );
     void    getDeviceTimingTagMemcpy(
                 const std::string& functionName,
                 const cl_command_queue queue,
@@ -1917,7 +1914,7 @@ inline CObjectTracker& CLIntercept::objectTracker()
     }                                                                       \
     ITT_CALL_LOGGING_EXIT();
 
-#define CALL_LOGGING_EXIT_MAP_EVENT(errorCode, _blocking, _flags, _event, ...) \
+#define CALL_LOGGING_EXIT_EVENT_WITH_TAG(errorCode, _event, ...)            \
     if( pIntercept->config().CallLogging )                                  \
     {                                                                       \
         pIntercept->callLoggingExit(                                        \
@@ -2789,6 +2786,25 @@ inline bool CLIntercept::checkAubCaptureEnqueueLimits(
             __FUNCTION__,                                                   \
             _map_flags,                                                     \
             _blocking_map,                                                  \
+            hostTag,                                                        \
+            deviceTag );                                                    \
+    }                                                                       \
+
+#define GET_TIMING_TAGS_MEMFILL( _queue, _dst_ptr )                         \
+    std::string hostTag, deviceTag;                                         \
+    if( pIntercept->config().ChromeCallLogging ||                           \
+        ( pIntercept->config().HostPerformanceTiming &&                     \
+          pIntercept->checkHostPerformanceTimingEnqueueLimits( enqueueCounter ) ) ||\
+        ( ( pIntercept->config().DevicePerformanceTiming ||                   \
+            pIntercept->config().ITTPerformanceTiming ||                      \
+            pIntercept->config().ChromePerformanceTiming ||                   \
+            pIntercept->config().DevicePerfCounterEventBasedSampling ) &&     \
+          pIntercept->checkDevicePerformanceTimingEnqueueLimits( enqueueCounter ) ) )\
+    {                                                                       \
+        pIntercept->getTimingTagsMemfill(                                   \
+            __FUNCTION__,                                                   \
+            _queue,                                                         \
+            _dst_ptr,                                                       \
             hostTag,                                                        \
             deviceTag );                                                    \
     }                                                                       \


### PR DESCRIPTION
## Description of Changes

This PR adds several improvements to the previous "timing tags" for functionality, code maintainability, and performance:

* Adds timing tags for map operations, to different between mapping for reading, writing, etc.
* Unifies the functions to get host timing tags and device timing tags.  In many cases, both functions were very similar, so unifying the functions reduces the liklihood of bugs.  Unifying the functions also improves performance, because e.g. query results can be reused for both host and device functions.
* Eliminates a redundant call to get a host timing tag if the host timing tag is needed both for host performance timing and for chrome call logging.

## Testing Done

Various touch-testing to verify that the different APIs with host and device timing behave as expected.
