### PR TITLE
Fix missing names for cloned kernels

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -7210,6 +7210,11 @@ CL_API_ENTRY cl_kernel CL_API_CALL CLIRN(clCloneKernel) (
         CHECK_ERROR( errcode_ret[0] );
         CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
+        if( retVal != NULL )
+        {
+            pIntercept->addKernelInfo( retVal, source_kernel );
+        }
+
         return retVal;
     }
 

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -6534,6 +6534,17 @@ void CLIntercept::addKernelInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+void CLIntercept::addKernelInfo(
+    const cl_kernel kernel,
+    const cl_kernel source_kernel )
+{
+    std::lock_guard<std::mutex> lock(m_Mutex);
+
+    m_KernelInfoMap[ kernel ] = m_KernelInfoMap.at( source_kernel );
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
 void CLIntercept::checkRemoveKernelInfo( cl_kernel kernel )
 {
     std::lock_guard<std::mutex> lock(m_Mutex);

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -449,6 +449,9 @@ public:
                 const cl_kernel* kernels,
                 const cl_program program,
                 cl_uint numKernels );
+    void    addKernelInfo(
+                const cl_kernel kernel,
+                const cl_kernel source_kernel );
     void    checkRemoveKernelInfo(
                 const cl_kernel kernel );
 


### PR DESCRIPTION
PR fixes an issue with missing kernel names for kernel cloned via `clCloneKernel`. In output it looks like this:

```
>>>> clEnqueueNDRangeKernel(  ): queue = ...
```

I added a special version of `addKernelInfo()` copying the original entry in `m_KernelInfoMap`, please let me know if this breaks any underlying assumptions or feel free to adjust the fix as needed. Thanks.