### PR TITLE
use map subscript operator instead of at

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -6459,7 +6459,7 @@ void CLIntercept::addKernelInfo(
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
 
-    m_KernelInfoMap[ kernel ] = m_KernelInfoMap.at( source_kernel );
+    m_KernelInfoMap[ kernel ] = m_KernelInfoMap[ source_kernel ];
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description of Changes

This is a minor update to PR https://github.com/intel/opencl-intercept-layer/pull/255.

Instead of calling `at()` when looking up the cloned kernel in the kernel info map, instead call `operator[]`.

The `at()` function will throw an exception if the key is not found in the map, whereas `operator[]` will insert an element with the key if it doesn't exist.  Although the key should always be found, if something happens and it isn't, we'd rather insert a default element and attempt to continue executing vs. throwing an exception.

## Testing Done

Tested with the clone_kernel CTS test.
