### PR TITLE
remove unnecessary critical section

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -9840,10 +9840,8 @@ bool CLIntercept::overrideGetPlatformInfo(
     size_t param_value_size,
     void* param_value,
     size_t* param_value_size_ret,
-    cl_int& errorCode )
+    cl_int& errorCode ) const
 {
-    std::lock_guard<std::mutex> lock(m_Mutex);
-
     bool    override = false;
 
     switch( param_name )
@@ -9987,10 +9985,8 @@ bool CLIntercept::overrideGetDeviceInfo(
     size_t param_value_size,
     void* param_value,
     size_t* param_value_size_ret,
-    cl_int& errorCode )
+    cl_int& errorCode ) const
 {
-    std::lock_guard<std::mutex> lock(m_Mutex);
-
     bool    override = false;
 
     switch( param_name )

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -603,14 +603,14 @@ public:
                 size_t param_value_size,
                 void* param_value,
                 size_t* param_value_size_ret,
-                cl_int& errorCode );
+                cl_int& errorCode ) const;
     bool    overrideGetDeviceInfo(
                 cl_device_id device,
                 cl_platform_info param_name,
                 size_t param_value_size,
                 void* param_value,
                 size_t* param_value_size_ret,
-                cl_int& errorCode );
+                cl_int& errorCode ) const;
 
     cl_int  ReadBuffer(
                 cl_command_queue commandQueue,


### PR DESCRIPTION
## Description of Changes

There does not need to be a critical section for the override functions called from clGetDeviceInfo or clGetPlatformInfo, which are called by default.  Removing the critical section reduces overhead when intercepting these functions.  Made these functions const to catch issues in the future if these functions do modify state.

## Testing Done

Ran low-level API microbenchmarks to verify reduced overhead when removing the critical section.