### PR TITLE
more overhead reductions

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -113,7 +113,7 @@ CLIntercept::CLIntercept( void* pGlobalData )
 
     m_LoggedCLInfo = false;
 
-    m_EnqueueCounter = 0;
+    m_EnqueueCounter.store(0, std::memory_order::memory_order_relaxed);
 
     m_EventsChromeTraced = 0;
     m_ProgramNumber = 0;
@@ -760,7 +760,7 @@ void CLIntercept::writeReport(
         os << "*** WARNING *** NullEnqueue Enabled!" << std::endl << std::endl;
     }
 
-    os << "Total Enqueues: " << m_EnqueueCounter << std::endl << std::endl;
+    os << "Total Enqueues: " << m_EnqueueCounter.load(std::memory_order_relaxed) << std::endl << std::endl;
 
     if( config().LeakChecking )
     {

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -5175,6 +5175,7 @@ void CLIntercept::getTimingTagsMap(
         hostTag += "?";
     }
 
+    deviceTag.reserve(128);
     deviceTag = functionName;
     deviceTag += "( ";
     deviceTag += hostTag;
@@ -5243,6 +5244,7 @@ void CLIntercept::getTimingTagsMemfill(
             default:                        hostTag += "M"; break;
             }
 
+            deviceTag.reserve(128);
             deviceTag = functionName;
             deviceTag += "( ";
             deviceTag += hostTag;
@@ -5321,6 +5323,7 @@ void CLIntercept::getTimingTagsMemcpy(
             default:                        hostTag += "M"; break;
             }
 
+            deviceTag.reserve(128);
             deviceTag = functionName;
             deviceTag += "( ";
             deviceTag += hostTag;
@@ -5990,7 +5993,7 @@ void CLIntercept::addTimingEvent(
 
     node.Device = device;
     node.QueueNumber = m_QueueNumberMap[ queue ];
-    node.Name = functionName;
+    node.Name = !tag.empty() ? tag : functionName;
     node.EnqueueCounter = enqueueCounter;
     node.QueuedTime = queuedTime;
     node.UseProfilingDelta = false;
@@ -6043,11 +6046,6 @@ void CLIntercept::addTimingEvent(
             //    interceptTimeStartNS, interceptTimeEndNS, interceptTimeEndNS - interceptTimeStartNS,
             //    hostTimeNS );
         }
-    }
-
-    if( !tag.empty() )
-    {
-        node.Name = tag;
     }
 }
 

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -791,6 +791,9 @@ void CLIntercept::writeReport(
     {
         os << std::endl << "Host Performance Timing Results:" << std::endl;
 
+        std::vector<std::string> keys;
+        keys.reserve(m_HostTimingStatsMap.size());
+
         uint64_t    totalTotalNS = 0;
         size_t      longestName = 32;
 
@@ -802,12 +805,15 @@ void CLIntercept::writeReport(
 
             if( !name.empty() )
             {
+                keys.push_back(name);
                 totalTotalNS += hostTimingStats.TotalNS;
                 longestName = std::max< size_t >( name.length(), longestName );
             }
 
             ++i;
         }
+
+        std::sort(keys.begin(), keys.end());
 
         os << std::endl << "Total Time (ns): " << totalTotalNS << std::endl;
 
@@ -820,24 +826,17 @@ void CLIntercept::writeReport(
             << std::right << std::setw(13) << "Min (ns)" << ", "
             << std::right << std::setw(13) << "Max (ns)" << std::endl;
 
-        i = m_HostTimingStatsMap.begin();
-        while( i != m_HostTimingStatsMap.end() )
+        for( const auto& name : keys )
         {
-            const std::string& name = (*i).first;
-            const SHostTimingStats& hostTimingStats = (*i).second;
+            const SHostTimingStats& hostTimingStats = m_HostTimingStatsMap.at(name);
 
-            if( !name.empty() )
-            {
-                os << std::right << std::setw(longestName) << name << ", "
-                    << std::right << std::setw( 6) << hostTimingStats.NumberOfCalls << ", "
-                    << std::right << std::setw(13) << hostTimingStats.TotalNS << ", "
-                    << std::right << std::setw( 7) << std::fixed << std::setprecision(2) << hostTimingStats.TotalNS * 100.0f / totalTotalNS << "%, "
-                    << std::right << std::setw(13) << hostTimingStats.TotalNS / hostTimingStats.NumberOfCalls << ", "
-                    << std::right << std::setw(13) << hostTimingStats.MinNS << ", "
-                    << std::right << std::setw(13) << hostTimingStats.MaxNS << std::endl;
-            }
-
-            ++i;
+            os << std::right << std::setw(longestName) << name << ", "
+                << std::right << std::setw( 6) << hostTimingStats.NumberOfCalls << ", "
+                << std::right << std::setw(13) << hostTimingStats.TotalNS << ", "
+                << std::right << std::setw( 7) << std::fixed << std::setprecision(2) << hostTimingStats.TotalNS * 100.0f / totalTotalNS << "%, "
+                << std::right << std::setw(13) << hostTimingStats.TotalNS / hostTimingStats.NumberOfCalls << ", "
+                << std::right << std::setw(13) << hostTimingStats.MinNS << ", "
+                << std::right << std::setw(13) << hostTimingStats.MaxNS << std::endl;
         }
     }
 
@@ -854,6 +853,9 @@ void CLIntercept::writeReport(
 
             os << std::endl << "Device Performance Timing Results for " << deviceInfo.NameForReport << ":" << std::endl;
 
+            std::vector<std::string> keys;
+            keys.reserve(dtsm.size());
+
             cl_ulong    totalTotalNS = 0;
             size_t      longestName = 32;
 
@@ -865,12 +867,15 @@ void CLIntercept::writeReport(
 
                 if( !name.empty() )
                 {
+                    keys.push_back(name);
                     totalTotalNS += deviceTimingStats.TotalNS;
                     longestName = std::max< size_t >( name.length(), longestName );
                 }
 
                 ++i;
             }
+
+            std::sort(keys.begin(), keys.end());
 
             os << std::endl << "Total Time (ns): " << totalTotalNS << std::endl;
 
@@ -883,24 +888,17 @@ void CLIntercept::writeReport(
                 << std::right << std::setw(13) << "Min (ns)" << ", "
                 << std::right << std::setw(13) << "Max (ns)" << std::endl;
 
-            i = dtsm.begin();
-            while( i != dtsm.end() )
+            for( const auto& name : keys )
             {
-                const std::string& name = (*i).first;
-                const SDeviceTimingStats& deviceTimingStats = (*i).second;
+                const SDeviceTimingStats& deviceTimingStats = dtsm.at(name);
 
-                if( !name.empty() )
-                {
-                    os << std::right << std::setw(longestName) << name << ", "
-                        << std::right << std::setw( 6) << deviceTimingStats.NumberOfCalls << ", "
-                        << std::right << std::setw(13) << deviceTimingStats.TotalNS << ", "
-                        << std::right << std::setw( 7) << std::fixed << std::setprecision(2) << deviceTimingStats.TotalNS * 100.0f / totalTotalNS << "%, "
-                        << std::right << std::setw(13) << deviceTimingStats.TotalNS / deviceTimingStats.NumberOfCalls << ", "
-                        << std::right << std::setw(13) << deviceTimingStats.MinNS << ", "
-                        << std::right << std::setw(13) << deviceTimingStats.MaxNS << std::endl;
-                }
-
-                ++i;
+                os << std::right << std::setw(longestName) << name << ", "
+                    << std::right << std::setw( 6) << deviceTimingStats.NumberOfCalls << ", "
+                    << std::right << std::setw(13) << deviceTimingStats.TotalNS << ", "
+                    << std::right << std::setw( 7) << std::fixed << std::setprecision(2) << deviceTimingStats.TotalNS * 100.0f / totalTotalNS << "%, "
+                    << std::right << std::setw(13) << deviceTimingStats.TotalNS / deviceTimingStats.NumberOfCalls << ", "
+                    << std::right << std::setw(13) << deviceTimingStats.MinNS << ", "
+                    << std::right << std::setw(13) << deviceTimingStats.MaxNS << std::endl;
             }
 
             ++id;

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -61,11 +61,11 @@ public:
     void    report();
 
     void    callLoggingEnter(
-                const std::string& functionName,
+                const char* functionName,
                 const uint64_t enqueueCounter,
                 const cl_kernel kernel );
     void    callLoggingEnter(
-                const std::string& functionName,
+                const char* functionName,
                 const uint64_t enqueueCounter,
                 const cl_kernel kernel,
                 const char* formatStr,
@@ -78,11 +78,11 @@ public:
                 ... );
 
     void    callLoggingExit(
-                const std::string& functionName,
+                const char* functionName,
                 const cl_int errorCode,
                 const cl_event* event );
     void    callLoggingExit(
-                const std::string& functionName,
+                const char* functionName,
                 const cl_int errorCode,
                 const cl_event* event,
                 const char* formatStr,
@@ -192,14 +192,14 @@ public:
                 cl_uint num_devices,
                 const cl_device_id* device_list );
     void    logError(
-                const std::string& functionName,
+                const char* functionName,
                 cl_int errorCode );
     void    logFlushOrFinishAfterEnqueueStart(
-                const std::string& flushOrFinish,
-                const std::string& functionName );
+                const char* flushOrFinish,
+                const char* functionName );
     void    logFlushOrFinishAfterEnqueueEnd(
-                const std::string& flushOrFinish,
-                const std::string& functionName,
+                const char* flushOrFinish,
+                const char* functionName,
                 cl_int errorCode );
     void    logKernelInfo(
                 const cl_kernel* kernels,
@@ -361,19 +361,19 @@ public:
                 const cl_bool blocking,
                 std::string& hostTag );
     void    getTimingTagsMap(
-                const std::string& functionName,
+                const char* functionName,
                 const cl_map_flags flags,
                 const cl_bool blocking,
                 std::string& hostTag,
                 std::string& deviceTag );
     void    getTimingTagsMemfill(
-                const std::string& functionName,
+                const char* functionName,
                 const cl_command_queue queue,
                 const void* dst,
                 std::string& hostTag,
                 std::string& deviceTag );
     void    getTimingTagsMemcpy(
-                const std::string& functionName,
+                const char* functionName,
                 const cl_command_queue queue,
                 const cl_bool blocking,
                 const void* dst,
@@ -391,7 +391,7 @@ public:
                 std::string& deviceTag );
 
     void    updateHostTimingStats(
-                const std::string& functionName,
+                const char* functionName,
                 const std::string& tag,
                 clock::time_point start,
                 clock::time_point end );
@@ -415,7 +415,7 @@ public:
                 cl_device_id device );
 
     void    addTimingEvent(
-                const std::string& functionName,
+                const char* functionName,
                 const uint64_t enqueueCounter,
                 const clock::time_point queuedTime,
                 const std::string& tag,
@@ -548,7 +548,7 @@ public:
                 size_t size );
 
     void    checkEventList(
-                const std::string& functionName,
+                const char* functionName,
                 cl_uint numEvents,
                 const cl_event* eventList,
                 cl_event* event );
@@ -566,7 +566,7 @@ public:
                 cl_mem_properties_intel*& pLocalAllocProperties ) const;
 
     void    startAubCapture(
-                const std::string& functionName,
+                const char* functionName,
                 const uint64_t enqueueCounter,
                 const cl_kernel kernel,
                 const cl_uint workDim,
@@ -807,7 +807,7 @@ public:
     void    ittInit();
 
     void    ittCallLoggingEnter(
-                const std::string& functionName,
+                const char* functionName,
                 const cl_kernel kernel );
     void    ittCallLoggingExit();
 
@@ -823,7 +823,7 @@ public:
 #endif
 
     void    chromeCallLoggingExit(
-                const std::string& functionName,
+                const char* functionName,
                 const std::string& tag,
                 bool includeId,
                 const uint64_t enqueueCounter,

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -13,9 +13,10 @@
 #include <vector>
 #include <map>
 #include <mutex>
+#include <queue>
 #include <set>
 #include <sstream>
-#include <queue>
+#include <unordered_map>
 
 #include <stdint.h>
 
@@ -971,7 +972,7 @@ private:
         cl_uint         SubDeviceIndex;
     };
 
-    typedef std::map< const cl_device_id, SSubDeviceInfo >  CSubDeviceInfoMap;
+    typedef std::map< cl_device_id, SSubDeviceInfo >    CSubDeviceInfoMap;
     CSubDeviceInfoMap   m_SubDeviceInfoMap;
 
     // This defines a mapping between the program handle and information
@@ -986,7 +987,7 @@ private:
         uint64_t        OptionsHash;
     };
 
-    typedef std::map< const cl_program, SProgramInfo >  CProgramInfoMap;
+    typedef std::map< cl_program, SProgramInfo >    CProgramInfoMap;
     CProgramInfoMap m_ProgramInfoMap;
 
     struct SHostTimingStats
@@ -1003,7 +1004,7 @@ private:
         uint64_t    TotalNS;
     };
 
-    typedef std::map< std::string, SHostTimingStats >   CHostTimingStatsMap;
+    typedef std::unordered_map< std::string, SHostTimingStats > CHostTimingStatsMap;
     CHostTimingStatsMap  m_HostTimingStatsMap;
 
     // These structures define a mapping between a device ID handle and
@@ -1057,7 +1058,7 @@ private:
         cl_ulong    TotalNS;
     };
 
-    typedef std::map< std::string, SDeviceTimingStats > CDeviceTimingStatsMap;
+    typedef std::unordered_map< std::string, SDeviceTimingStats >   CDeviceTimingStatsMap;
     typedef std::map< cl_device_id, CDeviceTimingStatsMap > CDeviceDeviceTimingStatsMap;
     CDeviceDeviceTimingStatsMap m_DeviceTimingStatsMap;
 
@@ -1075,7 +1076,7 @@ private:
         unsigned int    CompileCount;
     };
 
-    typedef std::map< const cl_kernel, SKernelInfo >    CKernelInfoMap;
+    typedef std::map< cl_kernel, SKernelInfo >  CKernelInfoMap;
     CKernelInfoMap  m_KernelInfoMap;
 
     // This defines a mapping between the "real" kernel name and a kernel
@@ -1084,7 +1085,7 @@ private:
 
     unsigned int    m_KernelID;
 
-    typedef std::map< const std::string, std::string >  CLongKernelNameMap;
+    typedef std::unordered_map< std::string, std::string >  CLongKernelNameMap;
     CLongKernelNameMap  m_LongKernelNameMap;
 
     // This is a list of pending events that haven't been added to the
@@ -1139,13 +1140,13 @@ private:
     typedef std::map< cl_sampler, std::string > CSamplerDataMap;
     CSamplerDataMap m_SamplerDataMap;
 
-    typedef std::map< const cl_mem, size_t >   CBufferInfoMap;
+    typedef std::map< cl_mem, size_t >  CBufferInfoMap;
     CBufferInfoMap      m_BufferInfoMap;
 
-    typedef std::map< const void*, size_t >    CSVMAllocInfoMap;
+    typedef std::map< const void*, size_t > CSVMAllocInfoMap;
     CSVMAllocInfoMap    m_SVMAllocInfoMap;
 
-    typedef std::map< const void*, size_t >    CUSMAllocInfoMap;
+    typedef std::map< const void*, size_t > CUSMAllocInfoMap;
     CUSMAllocInfoMap    m_USMAllocInfoMap;
 
     struct SImageInfo
@@ -1154,11 +1155,11 @@ private:
         size_t  ElementSize;
     };
 
-    typedef std::map< const cl_mem, SImageInfo >    CImageInfoMap;
+    typedef std::map< cl_mem, SImageInfo >  CImageInfoMap;
     CImageInfoMap   m_ImageInfoMap;
 
-    typedef std::map< cl_uint, const void* >                CKernelArgMemMap;
-    typedef std::map< const cl_kernel, CKernelArgMemMap >   CKernelArgMap;
+    typedef std::map< cl_uint, const void* >        CKernelArgMemMap;
+    typedef std::map< cl_kernel, CKernelArgMemMap > CKernelArgMap;
     CKernelArgMap   m_KernelArgMap;
 
     bool    m_AubCaptureStarted;
@@ -1168,7 +1169,7 @@ private:
     typedef std::set<std::string>   CAubCaptureSet;
     CAubCaptureSet  m_AubCaptureSet;
 
-    typedef std::map< const cl_context, SContextCallbackInfo* >  CContextCallbackInfoMap;
+    typedef std::map< cl_context, SContextCallbackInfo* >   CContextCallbackInfoMap;
     CContextCallbackInfoMap m_ContextCallbackInfoMap;
 
     struct SPrecompiledKernelOverrides
@@ -1185,7 +1186,7 @@ private:
         cl_kernel   Kernel_CopyImage2Dto2DUInt;
     };
 
-    typedef std::map< const cl_context, SPrecompiledKernelOverrides* >  CPrecompiledKernelOverridesMap;
+    typedef std::map< cl_context, SPrecompiledKernelOverrides* >    CPrecompiledKernelOverridesMap;
     CPrecompiledKernelOverridesMap  m_PrecompiledKernelOverridesMap;
 
     struct SBuiltinKernelOverrides
@@ -1195,16 +1196,16 @@ private:
         cl_kernel   Kernel_block_motion_estimate_intel;
     };
 
-    typedef std::map< const cl_context, SBuiltinKernelOverrides* >  CBuiltinKernelOverridesMap;
+    typedef std::map< cl_context, SBuiltinKernelOverrides* >    CBuiltinKernelOverridesMap;
     CBuiltinKernelOverridesMap  m_BuiltinKernelOverridesMap;
 
-    typedef std::map< const cl_accelerator_intel, cl_platform_id >  CAcceleratorInfoMap;
+    typedef std::map< cl_accelerator_intel, cl_platform_id >    CAcceleratorInfoMap;
     CAcceleratorInfoMap     m_AcceleratorInfoMap;
 
-    typedef std::map< const cl_semaphore_khr, cl_platform_id >  CSemaphoreInfoMap;
+    typedef std::map< cl_semaphore_khr, cl_platform_id >    CSemaphoreInfoMap;
     CSemaphoreInfoMap   m_SemaphoreInfoMap;
 
-    typedef std::map< const cl_command_buffer_khr, cl_platform_id > CCommandBufferInfoMap;
+    typedef std::map< cl_command_buffer_khr, cl_platform_id >   CCommandBufferInfoMap;
     CCommandBufferInfoMap   m_CommandBufferInfoMap;
 
     struct Config
@@ -2283,8 +2284,8 @@ inline bool CLIntercept::checkDumpImageEnqueueLimits(
     }
 
 #define DUMP_BUFFERS_BEFORE_ENQUEUE( kernel, command_queue )                \
-    if( pIntercept->checkDumpBufferEnqueueLimits( enqueueCounter ) &&       \
-        pIntercept->config().DumpBuffersBeforeEnqueue &&                    \
+    if( pIntercept->config().DumpBuffersBeforeEnqueue &&                    \
+        pIntercept->checkDumpBufferEnqueueLimits( enqueueCounter ) &&       \
         pIntercept->dumpBufferForKernel( kernel ) )                         \
     {                                                                       \
         pIntercept->dumpBuffersForKernel(                                   \
@@ -2292,8 +2293,8 @@ inline bool CLIntercept::checkDumpImageEnqueueLimits(
     }
 
 #define DUMP_BUFFERS_AFTER_ENQUEUE( kernel, command_queue )                 \
-    if( pIntercept->checkDumpBufferEnqueueLimits( enqueueCounter ) &&       \
-        pIntercept->config().DumpBuffersAfterEnqueue &&                     \
+    if( pIntercept->config().DumpBuffersAfterEnqueue &&                     \
+        pIntercept->checkDumpBufferEnqueueLimits( enqueueCounter ) &&       \
         pIntercept->dumpBufferForKernel( kernel ) )                         \
     {                                                                       \
         pIntercept->dumpBuffersForKernel(                                   \
@@ -2301,8 +2302,8 @@ inline bool CLIntercept::checkDumpImageEnqueueLimits(
     }
 
 #define DUMP_IMAGES_BEFORE_ENQUEUE( kernel, command_queue )                 \
-    if( pIntercept->checkDumpImageEnqueueLimits( enqueueCounter ) &&        \
-        pIntercept->config().DumpImagesBeforeEnqueue &&                     \
+    if( pIntercept->config().DumpImagesBeforeEnqueue &&                     \
+        pIntercept->checkDumpImageEnqueueLimits( enqueueCounter ) &&        \
         pIntercept->dumpImagesForKernel( kernel ) )                         \
     {                                                                       \
         pIntercept->dumpImagesForKernel(                                    \
@@ -2310,8 +2311,8 @@ inline bool CLIntercept::checkDumpImageEnqueueLimits(
     }
 
 #define DUMP_IMAGES_AFTER_ENQUEUE( kernel, command_queue )                  \
-    if( pIntercept->checkDumpImageEnqueueLimits( enqueueCounter ) &&        \
-        pIntercept->config().DumpImagesAfterEnqueue &&                      \
+    if( pIntercept->config().DumpImagesAfterEnqueue &&                      \
+        pIntercept->checkDumpImageEnqueueLimits( enqueueCounter ) &&        \
         pIntercept->dumpImagesForKernel( kernel ) )                         \
     {                                                                       \
         pIntercept->dumpImagesForKernel(                                    \

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -5,6 +5,7 @@
 */
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <cinttypes>
 #include <fstream>
@@ -947,7 +948,7 @@ private:
 
     bool        m_LoggedCLInfo;
 
-    uint64_t    m_EnqueueCounter;
+    std::atomic<uint64_t>   m_EnqueueCounter;
 
     clock::time_point   m_StartTime;
 
@@ -1753,13 +1754,12 @@ inline const CLIntercept::Config& CLIntercept::config() const
 //
 inline uint64_t CLIntercept::getEnqueueCounter() const
 {
-    return m_EnqueueCounter;
+    return m_EnqueueCounter.load(std::memory_order_relaxed);
 }
 
 inline uint64_t CLIntercept::incrementEnqueueCounter()
 {
-    std::lock_guard<std::mutex> lock(m_Mutex);
-    return m_EnqueueCounter++;
+    return m_EnqueueCounter.fetch_add(1, std::memory_order_relaxed);
 }
 
 #define GET_ENQUEUE_COUNTER()                                               \

--- a/intercept/src/objtracker.cpp
+++ b/intercept/src/objtracker.cpp
@@ -14,25 +14,29 @@ void CObjectTracker::ReportHelper(
     const CObjectTracker::CTracker& tracker,
     std::ostream& os )
 {
-    if( tracker.NumReleases < tracker.NumAllocations + tracker.NumRetains )
+    size_t  numAllocations = tracker.NumAllocations.load(std::memory_order_relaxed);
+    size_t  numRetains = tracker.NumRetains.load(std::memory_order_relaxed);
+    size_t  numReleases = tracker.NumReleases.load(std::memory_order_relaxed);
+
+    if( numReleases < numAllocations + numRetains )
     {
         os << "Possible leak of type " << label << "!" << std::endl;
-        os << "    Number of Allocations: " << tracker.NumAllocations << std::endl;
-        os << "    Number of Retains:     " << tracker.NumRetains << std::endl;
-        os << "    Number of Releases:    " << tracker.NumReleases << std::endl;
+        os << "    Number of Allocations: " << numAllocations << std::endl;
+        os << "    Number of Retains:     " << numRetains << std::endl;
+        os << "    Number of Releases:    " << numReleases << std::endl;
     }
-    else if( tracker.NumReleases > tracker.NumAllocations + tracker.NumRetains )
+    else if( numReleases > numAllocations + numRetains )
     {
         // If there are more releases than allocations or retains then this
         // is an unexpected situation.  It usually means that some allocations
         // aren't tracked correctly, or that a retain or release returned
         // an error.
         os << "Unexpected counts for type " << label << "!" << std::endl;
-        os << "    Number of Allocations: " << tracker.NumAllocations << std::endl;
-        os << "    Number of Retains:     " << tracker.NumRetains << std::endl;
-        os << "    Number of Releases:    " << tracker.NumReleases << std::endl;
+        os << "    Number of Allocations: " << numAllocations << std::endl;
+        os << "    Number of Retains:     " << numRetains << std::endl;
+        os << "    Number of Releases:    " << numReleases << std::endl;
     }
-    else if( tracker.NumAllocations )
+    else if( numAllocations )
     {
         os << "No " << label << " leaks detected." << std::endl;
     }

--- a/intercept/src/objtracker.cpp
+++ b/intercept/src/objtracker.cpp
@@ -44,8 +44,6 @@ void CObjectTracker::ReportHelper(
 
 void CObjectTracker::writeReport( std::ostream& os )
 {
-    std::lock_guard<std::mutex> lock(m_Mutex);
-
     os << std::endl;
     ReportHelper( "cl_device_id",       m_Devices,          os );
     ReportHelper( "cl_context",         m_Contexts,         os );

--- a/intercept/src/objtracker.h
+++ b/intercept/src/objtracker.h
@@ -22,8 +22,7 @@ public:
     {
         if( obj )
         {
-            std::lock_guard<std::mutex> lock(m_Mutex);
-            GetTracker(obj).NumAllocations++;
+            GetTracker(obj).NumAllocations.fetch_add(1, std::memory_order_relaxed);
         }
     }
 
@@ -32,8 +31,7 @@ public:
     {
         if( obj )
         {
-            std::lock_guard<std::mutex> lock(m_Mutex);
-            GetTracker(obj).NumRetains++;
+            GetTracker(obj).NumRetains.fetch_add(1, std::memory_order_relaxed);
         }
     }
 
@@ -42,8 +40,7 @@ public:
     {
         if( obj )
         {
-            std::lock_guard<std::mutex> lock(m_Mutex);
-            GetTracker(obj).NumReleases++;
+            GetTracker(obj).NumReleases.fetch_add(1, std::memory_order_relaxed);
         }
     }
 
@@ -55,9 +52,9 @@ private:
             NumRetains(0),
             NumReleases(0) {};
 
-        size_t  NumAllocations;
-        size_t  NumRetains;
-        size_t  NumReleases;
+        std::atomic<size_t> NumAllocations;
+        std::atomic<size_t> NumRetains;
+        std::atomic<size_t> NumReleases;
     };
 
     std::mutex  m_Mutex;

--- a/intercept/src/objtracker.h
+++ b/intercept/src/objtracker.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <mutex>
+#include <atomic>
 
 #include "common.h"
 
@@ -56,8 +56,6 @@ private:
         std::atomic<size_t> NumRetains;
         std::atomic<size_t> NumReleases;
     };
-
-    std::mutex  m_Mutex;
 
     CTracker    m_Devices;
     CTracker    m_Contexts;


### PR DESCRIPTION
## Description of Changes

A few additional changes to reduce host overhead:

* Removed a few critical sections by switching to atomics instead.
* Remove a few unnecessary constructions of std::strings by operating directly on const char*s instead.
* Switched a few maps with string keys to unordered maps instead to eliminate string compares.
* A few minor logical improvements.

## Testing Done

Tested with an API microbenchmark.  Veriried reduced overhead in general (with no controls set), with HostPerformanceTiming, and with ChromeCallLogging.
