### PR TITLE
fix an OSX printf format specifier warning

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -2616,7 +2616,7 @@ void CLIntercept::getKernelArgString(
              ( arg_size == sizeof(cl_ulong) ) )
     {
         cl_ulong*   pData = (cl_ulong*)arg_value;
-        CLI_SPRINTF( s, 256, "index = %u, size = %zu, value = 0x%jx",
+        CLI_SPRINTF( s, 256, "index = %u, size = %zu, value = 0x%" PRIx64,
             arg_index,
             arg_size,
             pData[0] );


### PR DESCRIPTION
## Description of Changes

No functional changes.

Fixes a printf format specifier warning on OSX.

## Testing Done

Verified that CI builds are clean on all OSes and that 64-bit kernel arguments print as expected.
