### PR TITLE
add a check to verify proper permissions for MDAPI counters

### DIFF
--- a/docs/mdapi.md
+++ b/docs/mdapi.md
@@ -104,6 +104,12 @@ by setting `/proc/sys/dev/i915/perf_stream_paranoid` to `0`:
     $ echo 0 > /proc/sys/dev/i915/perf_stream_paranoid
     ```
 
+    or:
+
+    ```sh
+    $ sysctl dev.i915.perf_stream_paranoid=0
+    ```
+
     For more information, see:
     * https://software.intel.com/en-us/vtune-cookbook-real-time-monitoring-with-system-analyzer
 * MDAPI metrics are logged to CSV files in the usual log directory.

--- a/intercept/OS/OS_linux_common.h
+++ b/intercept/OS/OS_linux_common.h
@@ -8,6 +8,7 @@
 
 #include <sys/stat.h>
 #include <dlfcn.h>
+#include <fcntl.h>
 #include <pthread.h>
 #include <stdint.h>
 #include <string.h>

--- a/intercept/OS/OS_mac.h
+++ b/intercept/OS/OS_mac.h
@@ -39,6 +39,9 @@ public:
     bool    StopAubCapture(
                 uint64_t delay ) const;
 
+    bool    CheckMDAPIPermissions(
+                std::string& str ) const;
+
 private:
     DISALLOW_COPY_AND_ASSIGN( Services );
 };
@@ -93,6 +96,12 @@ inline bool Services::StopAubCapture(
     uint64_t delay ) const
 {
     return false;
+}
+
+inline bool Services::CheckMDAPIPermissions(
+    std::string& str ) const
+{
+    return true;
 }
 
 }

--- a/intercept/OS/OS_windows.h
+++ b/intercept/OS/OS_windows.h
@@ -45,6 +45,9 @@ public:
     bool    StopAubCaptureKDC(
                 uint64_t delay ) const;
 
+    bool    CheckMDAPIPermissions(
+                std::string& str ) const;
+
 private:
     HINSTANCE   m_hInstance;
 
@@ -299,6 +302,12 @@ inline bool Services::StopAubCaptureKDC(
     bool success = SetAubCaptureRegistryKeys( "", 0 );
 
     return res != -1;
+}
+
+inline bool Services::CheckMDAPIPermissions(
+    std::string& str ) const
+{
+    return true;
 }
 
 }

--- a/intercept/mdapi/intercept_mdapi.cpp
+++ b/intercept/mdapi/intercept_mdapi.cpp
@@ -145,7 +145,12 @@ void CLIntercept::initCustomPerfCounters()
 
     if( m_pMDHelper == NULL )
     {
-        if( config().DevicePerfCounterEventBasedSampling )
+        std::string permissionString;
+        if( OS().CheckMDAPIPermissions(permissionString) == false )
+        {
+            log( permissionString );
+        }
+        else if( config().DevicePerfCounterEventBasedSampling )
         {
             m_pMDHelper = MetricsDiscovery::MDHelper::CreateEBS(
                 config().DevicePerfCounterLibName,


### PR DESCRIPTION
Fixes #172

## Description of Changes

Adds a check for proper MDAPI permissions for Linux.  If the process is not run as root or if paranoid mode is enabled, the OpenCL Intercept Layer will log a helpful error message and will not try to initialize MDAPI further.

Windows and OSX are TODO.  Most of the permission issues occur on Linux.

## Testing Done

Verified that the correct error message is displayed without the propert MDAPI permissions on Linux, for both time-based and event-based sampling.  Verified that no error message is printed if the program is run as root or if paranoid mode is disabled.