### PR TITLE
reduce event profiling queries

### DIFF
--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -833,10 +833,6 @@ public:
                 const uint64_t enqueueCounter,
                 clock::time_point start,
                 clock::time_point end );
-    void    chromeCallLoggingSubset(
-                const char* name,
-                clock::time_point start,
-                clock::time_point end );
     void    chromeRegisterCommandQueue(
                 cl_command_queue queue );
     void    chromeTraceEvent(

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -819,7 +819,11 @@ public:
     void    ittTraceEvent(
                 const std::string& name,
                 cl_event event,
-                const clock::time_point queuedTime );
+                clock::time_point queuedTime,
+                cl_ulong commandQueued,
+                cl_ulong commandSubmit,
+                cl_ulong commandStart,
+                cl_ulong commandEnd );
 #endif
 
     void    chromeCallLoggingExit(
@@ -827,6 +831,10 @@ public:
                 const std::string& tag,
                 bool includeId,
                 const uint64_t enqueueCounter,
+                clock::time_point start,
+                clock::time_point end );
+    void    chromeCallLoggingSubset(
+                const char* name,
                 clock::time_point start,
                 clock::time_point end );
     void    chromeRegisterCommandQueue(
@@ -837,8 +845,11 @@ public:
                 int64_t profilingDeltaNS,
                 uint64_t enqueueCounter,
                 unsigned int queueNumber,
-                cl_event event,
-                clock::time_point queuedTime );
+                clock::time_point queuedTime,
+                cl_ulong commandQueued,
+                cl_ulong commandSubmit,
+                cl_ulong commandStart,
+                cl_ulong commandEnd );
 
     // USM Emulation:
     void*   emulatedHostMemAlloc(


### PR DESCRIPTION
## Description of Changes

Refactors device performance timing checks to reduce redundant event profiling queries when different types of device performance timing are all active.  This can produce a significant performance improvement on some devices where event profiling queries are expensive.

## Testing Done

Tested by running the math bruteforce conformance test with chrome performance timing and device performance timing enabled.
