### PR TITLE
prepare for a naming change for the MDAPI library on Linux

### DIFF
--- a/intercept/mdapi/MetricsDiscoveryHelper.cpp
+++ b/intercept/mdapi/MetricsDiscoveryHelper.cpp
@@ -38,7 +38,7 @@ static void* OpenLibrary( const std::string& metricsLibraryName )
 
 #elif defined(__linux__) || defined(__APPLE__)
 #ifdef __linux__
-static const char* cMDLibFileName = "libmd.so";
+static const char* cMDLibFileName = "libigdmd.so";
 #else
 static const char* cMDLibFileName = "libigdmd.dylib";
 #endif
@@ -49,9 +49,26 @@ static const char* cMDLibFileName = "libigdmd.dylib";
 
 static void* OpenLibrary( const std::string& metricsLibraryName )
 {
-    return !metricsLibraryName.empty() ?
-        dlopen(metricsLibraryName.c_str(), RTLD_LAZY | RTLD_LOCAL) :
-        dlopen(cMDLibFileName, RTLD_LAZY | RTLD_LOCAL);
+    void* ret = NULL;
+    if( !metricsLibraryName.empty() )
+    {
+        ret = dlopen(metricsLibraryName.c_str(), RTLD_LAZY | RTLD_LOCAL);
+    }
+    else
+    {
+        if( ret == NULL )
+        {
+            ret = dlopen(cMDLibFileName, RTLD_LAZY | RTLD_LOCAL);
+        }
+#if !defined(__APPLE__)
+        if( ret == NULL )
+        {
+            // old alternate name, may eventually be removed
+            ret = dlopen("libmd.so", RTLD_LAZY | RTLD_LOCAL);
+        }
+#endif
+    }
+    return ret;
 }
 
 #define GetFunctionAddress(_handle, _name)  dlsym(_handle, _name)


### PR DESCRIPTION
## Description of Changes

At some point in the near future the MDAPI library name on Linux will change from `libmd.so` to `libigdmd.so`.  This change prepares for this name change by first trying the new libary name, and if that fails, falling back to the old library name.

## Testing Done

Verified that the old file name is loaded by default.  Renamed the old file name to verify that the new file name is loaded as well.
