### PR TITLE
improve logging for semaphores

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -11,7 +11,7 @@ extern "C" {
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-// cl_khr_create_command_queue
+// cl_khr_command_buffer
 
 // Note: This implements the provisional extension v0.9.0.
 

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -5416,9 +5416,21 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueWaitSemaphoresKHR(
 
             if( pIntercept->config().NullEnqueue == false )
             {
-                CALL_LOGGING_ENTER( "queue = %p, num_sema_objects = %u",
+                std::string semaphoreString;
+                if( pIntercept->config().CallLogging &&
+                    num_sema_objects )
+                {
+                    std::string str;
+                    pIntercept->getSemaphoreListString(
+                        num_sema_objects,
+                        sema_objects,
+                        str );
+                    semaphoreString += ", sema_objects = ";
+                    semaphoreString += str;
+                }
+                CALL_LOGGING_ENTER( "queue = %p%s",
                     queue,
-                    num_sema_objects );
+                    semaphoreString.c_str() );
                 CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
                 DEVICE_PERFORMANCE_TIMING_START( event );
                 HOST_PERFORMANCE_TIMING_START();
@@ -5475,9 +5487,21 @@ CL_API_ENTRY cl_int CL_API_CALL clEnqueueSignalSemaphoresKHR(
 
             if( pIntercept->config().NullEnqueue == false )
             {
-                CALL_LOGGING_ENTER( "queue = %p, num_sema_objects = %u",
+                std::string semaphoreString;
+                if( pIntercept->config().CallLogging &&
+                    num_sema_objects )
+                {
+                    std::string str;
+                    pIntercept->getSemaphoreListString(
+                        num_sema_objects,
+                        sema_objects,
+                        str );
+                    semaphoreString += ", sema_objects = ";
+                    semaphoreString += str;
+                }
+                CALL_LOGGING_ENTER( "queue = %p%s",
                     queue,
-                    num_sema_objects );
+                    semaphoreString.c_str() );
                 CHECK_EVENT_LIST( num_events_in_wait_list, event_wait_list, event );
                 DEVICE_PERFORMANCE_TIMING_START( event );
                 HOST_PERFORMANCE_TIMING_START();

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -2070,6 +2070,39 @@ void CLIntercept::getEventListString(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+void CLIntercept::getSemaphoreListString(
+    cl_uint numSemaphores,
+    const cl_semaphore_khr* semaphoreList,
+    std::string& str ) const
+{
+    {
+        std::ostringstream  ss;
+        ss << "( size = ";
+        ss << numSemaphores;
+        ss << " )[ ";
+        str += ss.str();
+    }
+    if( semaphoreList )
+    {
+        for( cl_uint i = 0; i < numSemaphores; i++ )
+        {
+            if( i > 0 )
+            {
+                str += ", ";
+            }
+            {
+                char    s[256];
+                CLI_SPRINTF( s, 256, "%p", semaphoreList[i] );
+                str += s;
+            }
+        }
+    }
+    str += " ]";
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
 void CLIntercept::getContextPropertiesString(
     const cl_context_properties* properties,
     std::string& str ) const
@@ -2406,7 +2439,15 @@ void CLIntercept::getSemaphorePropertiesString(
         while( properties[0] != 0 )
         {
             cl_int  property = (cl_int)properties[0];
-            str += enumName().name( property ) + " = ";
+            if( property == 0x2455 ) // workaround
+            {
+                str += "CL_SEMAPHORE_TYPE_KHR_0x2455 = ";
+                property = CL_SEMAPHORE_TYPE_KHR;
+            }
+            else
+            {
+                str += enumName().name( property ) + " = ";
+            }
 
             switch( property )
             {
@@ -2429,7 +2470,7 @@ void CLIntercept::getSemaphorePropertiesString(
                             properties++;
                             break;
                         }
-                        else if( *properties == 0x2052 )
+                        else if( *properties == 0x2052 ) // workaround
                         {
                             str += "CL_DEVICE_HANDLE_LIST_END_KHR_0x2502";
                             properties++;

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -146,6 +146,10 @@ public:
                 cl_uint num_events,
                 const cl_event* event_list,
                 std::string& str ) const;
+    void    getSemaphoreListString(
+                cl_uint num_semaphores,
+                const cl_semaphore_khr* semaphore_list,
+                std::string& str ) const;
     void    getContextPropertiesString(
                 const cl_context_properties* properties,
                 std::string& str ) const;


### PR DESCRIPTION
## Description of Changes

Improves call logging when signaling and waiting on semaphores.

## Testing Done

Tested with a work-in-progress application that synchronizes between OpenCL and Vulkan using semaphores.
