### PR TITLE
adds analog DumpArgumentsOnSet{Min,Max}Enqueue

### DIFF
--- a/intercept/src/controls.h
+++ b/intercept/src/controls.h
@@ -126,6 +126,8 @@ CLI_CONTROL( cl_uint,       DumpBuffersMinEnqueue,                  0,     "The 
 CLI_CONTROL( cl_uint,       DumpBuffersMaxEnqueue,                  UINT_MAX, "The Intercept Layer for OpenCL Applications will only dump buffer, SVM, and USM kernel arguments when the enqueue counter is less than this value, inclusive." )
 CLI_CONTROL( cl_uint,       DumpImagesMinEnqueue,                   0,     "The Intercept Layer for OpenCL Applications will only dump image kernel arguments when the enqueue counter is greater than this value, inclusive." )
 CLI_CONTROL( cl_uint,       DumpImagesMaxEnqueue,                   UINT_MAX, "The Intercept Layer for OpenCL Applications will only dump image kernel arguments when the enqueue counter is less than this value, inclusive." )
+CLI_CONTROL( cl_uint,       DumpArgumentsOnSetMinEnqueue,           0,     "The Intercept Layer for OpenCL Applications will only dump argument values when the enqueue counter is greater than this value, inclusive." )
+CLI_CONTROL( cl_uint,       DumpArgumentsOnSetMaxEnqueue,           UINT_MAX, "The Intercept Layer for OpenCL Applications will only dump kernel arguments when the enqueue counter is less than this value, inclusive." )
 
 CLI_CONTROL_SEPARATOR( Device Partitioning Controls: )
 CLI_CONTROL( bool,          AutoPartitionAllDevices,                false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will automatically partition parent devices and return all parent devices and all sub-devices." )

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -2204,7 +2204,9 @@ inline bool CLIntercept::checkDumpImageEnqueueLimits(
     }
 
 #define SET_KERNEL_ARG( kernel, arg_index, arg_size, arg_value )            \
-    if ( pIntercept->config().DumpArgumentsOnSet )                          \
+    if( pIntercept->config().DumpArgumentsOnSet &&                          \
+        enqueueCounter >= pIntercept->config().DumpArgumentsOnSetMinEnqueue && \
+        enqueueCounter <= pIntercept->config().DumpArgumentsOnSetMaxEnqueue ) \
     {                                                                       \
         pIntercept->dumpArgument(                                           \
             enqueueCounter, kernel, arg_index, arg_size, arg_value );       \


### PR DESCRIPTION
From earlier discussion. Let me know if I need to file an issue to reference.

## Description of Changes

This adds the ability to constrain argument dumping. In large projects (e.g. OpenMM tests) there are 10k's of kernels executed and we can run out of disk space or inodes dumping all arguments for each of those.

## Testing Done

Tested in several local programs for argument dumping.