### PR TITLE
add support for cl_khr_command_buffer_mutable_dispatch

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -215,6 +215,85 @@ clGetCommandBufferInfoKHR(
     size_t* param_value_size_ret) ;
 
 ///////////////////////////////////////////////////////////////////////////////
+// cl_khr_command_buffer_mutable_dispatch
+
+// Note: This implements the provisional extension v0.9.0.
+
+typedef cl_uint             cl_command_buffer_structure_type_khr;
+typedef cl_bitfield         cl_mutable_dispatch_fields_khr;
+typedef cl_uint             cl_mutable_command_info_khr;
+typedef struct _cl_mutable_dispatch_arg_khr {
+    cl_uint arg_index;
+    size_t arg_size;
+    const void* arg_value;
+} cl_mutable_dispatch_arg_khr;
+typedef struct _cl_mutable_dispatch_exec_info_khr {
+    cl_uint param_name;
+    size_t param_value_size;
+    const void* param_value;
+} cl_mutable_dispatch_exec_info_khr;
+typedef struct _cl_mutable_dispatch_config_khr {
+    cl_command_buffer_structure_type_khr type;
+    const void* next;
+    cl_mutable_command_khr command;
+    cl_uint num_args;
+    cl_uint num_svm_args;
+    cl_uint num_exec_infos;
+    cl_uint work_dim;
+    const cl_mutable_dispatch_arg_khr* arg_list;
+    const cl_mutable_dispatch_arg_khr* arg_svm_list;
+    const cl_mutable_dispatch_exec_info_khr* exec_info_list;
+    const size_t* global_work_offset;
+    const size_t* global_work_size;
+    const size_t* local_work_size;
+} cl_mutable_dispatch_config_khr;
+typedef struct _cl_mutable_base_config_khr {
+    cl_command_buffer_structure_type_khr type;
+    const void* next;
+    cl_uint num_mutable_dispatch;
+    const cl_mutable_dispatch_config_khr* mutable_dispatch_list;
+} cl_mutable_base_config_khr;
+
+#define CL_COMMAND_BUFFER_MUTABLE_KHR                       (1 << 1)
+
+#define CL_INVALID_MUTABLE_COMMAND_KHR                      -1141
+
+#define CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR         0x12B0
+
+#define CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR            0x12B1
+#define CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR               (1 << 0)
+#define CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR                 (1 << 1)
+#define CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR                  (1 << 2)
+#define CL_MUTABLE_DISPATCH_ARGUMENTS_KHR                   (1 << 3)
+#define CL_MUTABLE_DISPATCH_EXEC_INFO_KHR                   (1 << 4)
+
+#define CL_MUTABLE_COMMAND_COMMAND_QUEUE_KHR                0x12A0
+#define CL_MUTABLE_COMMAND_COMMAND_BUFFER_KHR               0x12A1
+#define CL_MUTABLE_COMMAND_COMMAND_TYPE_KHR                 0x12AD
+#define CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR            0x12A2
+#define CL_MUTABLE_DISPATCH_KERNEL_KHR                      0x12A3
+#define CL_MUTABLE_DISPATCH_DIMENSIONS_KHR                  0x12A4
+#define CL_MUTABLE_DISPATCH_GLOBAL_WORK_OFFSET_KHR          0x12A5
+#define CL_MUTABLE_DISPATCH_GLOBAL_WORK_SIZE_KHR            0x12A6
+#define CL_MUTABLE_DISPATCH_LOCAL_WORK_SIZE_KHR             0x12A7
+
+#define CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR           0
+#define CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR       1
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clUpdateMutableCommandsKHR(
+    cl_command_buffer_khr command_buffer,
+    const cl_mutable_base_config_khr* mutable_config) ;
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clGetMutableCommandInfoKHR(
+    cl_mutable_command_khr command,
+    cl_mutable_command_info_khr param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret) ;
+
+///////////////////////////////////////////////////////////////////////////////
 // cl_khr_create_command_queue
 
 typedef cl_properties cl_queue_properties_khr;

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -10571,6 +10571,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandBarrierWithWaitListKHR(
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
             CALL_LOGGING_EXIT( retVal );
+            ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
             return retVal;
         }
@@ -10626,6 +10627,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyBufferKHR(
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
             CALL_LOGGING_EXIT( retVal );
+            ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
             return retVal;
         }
@@ -10689,6 +10691,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyBufferRectKHR(
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
             CALL_LOGGING_EXIT( retVal );
+            ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
             return retVal;
         }
@@ -10744,6 +10747,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyBufferToImageKHR(
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
             CALL_LOGGING_EXIT( retVal );
+            ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
             return retVal;
         }
@@ -10799,6 +10803,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyImageKHR(
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
             CALL_LOGGING_EXIT( retVal );
+            ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
             return retVal;
         }
@@ -10854,6 +10859,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyImageToBufferKHR(
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
             CALL_LOGGING_EXIT( retVal );
+            ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
             return retVal;
         }
@@ -10909,6 +10915,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandFillBufferKHR(
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
             CALL_LOGGING_EXIT( retVal );
+            ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
             return retVal;
         }
@@ -10962,6 +10969,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandFillImageKHR(
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
             CALL_LOGGING_EXIT( retVal );
+            ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
             return retVal;
         }
@@ -11020,6 +11028,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandNDRangeKernelKHR(
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
             CALL_LOGGING_EXIT( retVal );
+            ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
             return retVal;
         }
@@ -11054,6 +11063,83 @@ CL_API_ENTRY cl_int CL_API_CALL clGetCommandBufferInfoKHR(
 
             cl_int  retVal = dispatchX.clGetCommandBufferInfoKHR(
                 command_buffer,
+                param_name,
+                param_value_size,
+                param_value,
+                param_value_size_ret );
+
+            HOST_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
+
+            return retVal;
+        }
+    }
+
+    NULL_FUNCTION_POINTER_RETURN_ERROR();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// cl_khr_command_buffer_mutable_dispatch
+CL_API_ENTRY cl_int CL_API_CALL clUpdateMutableCommandsKHR(
+    cl_command_buffer_khr command_buffer,
+    const cl_mutable_base_config_khr* mutable_config)
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept )
+    {
+        const auto& dispatchX = pIntercept->dispatchX(command_buffer);
+        if( dispatchX.clUpdateMutableCommandsKHR )
+        {
+            GET_ENQUEUE_COUNTER();
+            CALL_LOGGING_ENTER( "command_buffer = %p, mutable_config = %p",
+                command_buffer,
+                mutable_config );
+            HOST_PERFORMANCE_TIMING_START();
+
+            cl_int  retVal = dispatchX.clUpdateMutableCommandsKHR(
+                command_buffer,
+                mutable_config );
+
+            HOST_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
+
+            return retVal;
+        }
+    }
+
+    NULL_FUNCTION_POINTER_RETURN_ERROR();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// cl_khr_command_buffer_mutable_dispatch
+CL_API_ENTRY cl_int CL_API_CALL clGetMutableCommandInfoKHR(
+    cl_mutable_command_khr command,
+    cl_mutable_command_info_khr param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept )
+    {
+        const auto& dispatchX = pIntercept->dispatchX(command);
+        if( dispatchX.clGetMutableCommandInfoKHR )
+        {
+            GET_ENQUEUE_COUNTER();
+            CALL_LOGGING_ENTER( "command_buffer = %p, param_name = %s (%08X)",
+                command,
+                pIntercept->enumName().name( param_name ).c_str(),
+                param_name );
+            HOST_PERFORMANCE_TIMING_START();
+
+            cl_int  retVal = dispatchX.clGetMutableCommandInfoKHR(
+                command,
                 param_name,
                 param_value_size,
                 param_value,

--- a/intercept/src/dispatch.h
+++ b/intercept/src/dispatch.h
@@ -317,6 +317,19 @@ struct CLdispatchX
         void* param_value,
         size_t* param_value_size_ret);
 
+    // cl_khr_command_buffer_mutable_dispatch
+    cl_int (CL_API_CALL *clUpdateMutableCommandsKHR) (
+        cl_command_buffer_khr command_buffer,
+        const cl_mutable_base_config_khr* mutable_config) ;
+
+    // cl_khr_command_buffer_mutable_dispatch
+    cl_int (CL_API_CALL *clGetMutableCommandInfoKHR) (
+        cl_mutable_command_khr command,
+        cl_mutable_command_info_khr param_name,
+        size_t param_value_size,
+        void* param_value,
+        size_t* param_value_size_ret) ;
+
     // cl_khr_create_command_queue
     cl_command_queue    (CL_API_CALL *clCreateCommandQueueWithPropertiesKHR) (
         cl_context context,

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -709,6 +709,33 @@ CEnumNameMap::CEnumNameMap()
 
     ADD_ENUM_NAME( m_cl_int, CL_COMMAND_COMMAND_BUFFER_KHR );
 
+    // cl_khr_command_buffer_mutable_dispatch
+    ADD_ENUM_NAME( m_cl_command_buffer_flags_khr, CL_COMMAND_BUFFER_MUTABLE_KHR );
+
+    ADD_ENUM_NAME( m_cl_int, CL_INVALID_MUTABLE_COMMAND_KHR );
+
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR );
+
+    ADD_ENUM_NAME( m_cl_int, CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR );
+    ADD_ENUM_NAME( m_cl_mutable_dispatch_fields_khr, CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR );
+    ADD_ENUM_NAME( m_cl_mutable_dispatch_fields_khr, CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR );
+    ADD_ENUM_NAME( m_cl_mutable_dispatch_fields_khr, CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR );
+    ADD_ENUM_NAME( m_cl_mutable_dispatch_fields_khr, CL_MUTABLE_DISPATCH_ARGUMENTS_KHR );
+    ADD_ENUM_NAME( m_cl_mutable_dispatch_fields_khr, CL_MUTABLE_DISPATCH_EXEC_INFO_KHR );
+
+    ADD_ENUM_NAME( m_cl_int, CL_MUTABLE_COMMAND_COMMAND_QUEUE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_MUTABLE_COMMAND_COMMAND_BUFFER_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_MUTABLE_COMMAND_COMMAND_TYPE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_MUTABLE_DISPATCH_KERNEL_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_MUTABLE_DISPATCH_DIMENSIONS_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_MUTABLE_DISPATCH_GLOBAL_WORK_OFFSET_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_MUTABLE_DISPATCH_GLOBAL_WORK_SIZE_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_MUTABLE_DISPATCH_LOCAL_WORK_SIZE_KHR );
+
+    // CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR           0
+    // CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR       1
+
     // cl_khr_extended_versioning extension
     // Most enums for this extension were added to OpenCL 3.0.
     //CL_PLATFORM_NUMERIC_VERSION_KHR                  0x0906

--- a/intercept/src/enummap.h
+++ b/intercept/src/enummap.h
@@ -112,6 +112,7 @@ public:
     GENERATE_MAP_AND_FUNC(          name_semaphore_type,             cl_semaphore_type_khr           );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_device_command_buffer_capabilities, cl_device_command_buffer_capabilities_khr );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_command_buffer_flags,       cl_command_buffer_flags_khr     );
+    GENERATE_MAP_AND_BITFIELD_FUNC( name_mutable_dispatch_fields,    cl_mutable_dispatch_fields_khr  );
 
     #undef GENERATE_MAP_AND_FUNC
     #undef GENERATE_MAP_AND_BITFIELD_FUNC


### PR DESCRIPTION
## Description of Changes

Adds support for tracing the new cl_khr_command_buffer_mutable_dispatch extension.

https://github.com/KhronosGroup/OpenCL-Docs/pull/819

## Testing Done

Tested with a sample app and the command buffer emulation layer (PR soon).
