### PR TITLE
add a control to demangle kernel names

### DIFF
--- a/cliloader/cliloader.cpp
+++ b/cliloader/cliloader.cpp
@@ -329,6 +329,10 @@ static bool parseArguments(int argc, char *argv[])
         {
             checkSetEnv("CLI_AppendPid", "1");
         }
+        else if( !strcmp(argv[i], "--demangle") )
+        {
+            checkSetEnv("CLI_DemangleKernelNames", "1");
+        }
         else if( !strcmp(argv[i], "-dsrc") || !strcmp(argv[i], "--dump-source") )
         {
             checkSetEnv("CLI_DumpProgramSource", "1");
@@ -471,6 +475,7 @@ static bool parseArguments(int argc, char *argv[])
             "  --error-logging [-e]             Detect and Log API Errors\n"
             "  --tid                            Include Thread ID in the API Call Log\n"
             "  --appendpid                      Include Process ID in the Dump Directory\n"
+            "  --demangle                       Demangle Kernel Names\n"
             "  --dump-source [-dsrc]            Dump Input Program Source\n"
             "  --dump-spirv [-dspv]             Dump Input Program IL (SPIR-V)\n"
             "  --dump-output-binaries           Dump Output Program Binaries\n"

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -243,6 +243,10 @@ If set to a nonzero value, the Intercept Layer for OpenCL Applications will appe
 
 If an OpenCL application uses kernels with very long names, the Intercept Layer for OpenCL Applications can substitute a "short" kernel identifier for a "long" kernel name in logs and reports.  This control defines how long a kernel name must be (in characters) before it is replaced by a "short" kernel identifier.
 
+##### `DemangleKernelNames` (bool)
+
+If set to a nonzero value, the Intercept Layer for OpenCL Applications will track kernel names that are demangled according to C++ ABI rules.  This setting requires compiler support for demangling and may not be available in all configurations.
+
 ### Reporting Controls
 
 ##### `ReportToStderr` (bool)

--- a/intercept/CMakeLists.txt
+++ b/intercept/CMakeLists.txt
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+include(CheckIncludeFileCXX)
+
 set(CLINTERCEPT_CL_HEADERS
     CL/cl.h
     CL/cl_gl.h
@@ -61,6 +63,7 @@ set(CLINTERCEPT_SOURCE_FILES
     src/cliprof_init.cpp
     src/common.h
     src/controls.h
+    src/demangle.h
     src/dispatch.cpp
     src/dispatch.h
     src/emulate.cpp
@@ -167,6 +170,12 @@ if(ENABLE_MDAPI)
     target_sources(OpenCL PRIVATE
         ${CLINTERCEPT_MDAPI_FILES}
     )
+endif()
+
+# Demangling Support (optional)
+CHECK_INCLUDE_FILE_CXX(cxxabi.h HAS_CXXABI)
+if(HAS_CXXABI)
+    target_compile_definitions(OpenCL PRIVATE USE_DEMANGLE)
 endif()
 
 if(WIN32)

--- a/intercept/src/controls.h
+++ b/intercept/src/controls.h
@@ -42,6 +42,7 @@ CLI_CONTROL( std::string,   DumpDir,                                "",    "If s
 CLI_CONTROL( bool,          AppendPid,                              false, "If set, the Intercept Layer for OpenCL Applications will append process ID to the log directory name." )
 CLI_CONTROL( bool,          KernelNameHashTracking,                 false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will append the program and build option hashes to the kernel name in logs and reports." )
 CLI_CONTROL( cl_uint,       LongKernelNameCutoff,                   UINT_MAX, "If an OpenCL application uses kernels with very long names, the Intercept Layer for OpenCL Applications can substitute a \"short\" kernel identifier for a \"long\" kernel name in logs and reports.  This control defines how long a kernel name must be (in characters) before it is replaced by a \"short\" kernel identifier." )
+CLI_CONTROL( bool,          DemangleKernelNames,                    false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will track kernel names that are demangled according to C++ ABI rules.  This setting requires compiler support for demangling and may not be available in all configurations." )
 
 CLI_CONTROL_SEPARATOR( Reporting Controls: )
 CLI_CONTROL( bool,          ReportToStderr,                         false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will emit reports to stderr." )

--- a/intercept/src/demangle.h
+++ b/intercept/src/demangle.h
@@ -23,7 +23,11 @@ static inline std::string demangle(const std::string& in)
     }
     else
     {
+        const std::string skip("typeinfo name for ");
         ret = demangled;
+        if (ret.rfind(skip, 0) == 0) {
+            ret.erase(0, skip.length());
+        }
     }
     free(demangled);
     return ret;

--- a/intercept/src/demangle.h
+++ b/intercept/src/demangle.h
@@ -1,0 +1,33 @@
+/*
+// Copyright (c) 2022 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+*/
+
+#pragma once
+
+#if defined(USE_DEMANGLE)
+#include <cxxabi.h>
+#endif
+#include <string>
+
+static inline std::string demangle(const std::string& in)
+{
+#if defined(USE_DEMANGLE)
+    std::string ret;
+    int status = 0;
+    char* demangled = abi::__cxa_demangle(in.c_str(), NULL, NULL, &status);
+    if( status != 0 )
+    {
+        ret = in;
+    }
+    else
+    {
+        ret = demangled;
+    }
+    free(demangled);
+    return ret;
+#else
+    return in;
+#endif
+}

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -14,6 +14,7 @@
 #include <time.h>       // strdate
 
 #include "common.h"
+#include "demangle.h"
 #include "emulate.h"
 #include "intercept.h"
 
@@ -453,6 +454,11 @@ bool CLIntercept::init()
         "    MDAPI(supported)\n"
 #else
         "    MDAPI(NOT supported)\n"
+#endif
+#if defined(USE_DEMANGLE)
+        "    Demangling(supported)\n"
+#else
+        "    Demangling(NOT supported)\n"
 #endif
 #if defined(CLINTERCEPT_HIGH_RESOLUTON_CLOCK)
         "    clock(high_resolution_clock)\n"
@@ -6450,8 +6456,11 @@ void CLIntercept::addKernelInfo(
     const SProgramInfo& programInfo = m_ProgramInfoMap[ program ];
 
     SKernelInfo& kernelInfo = m_KernelInfoMap[ kernel ];
+    std::string demangledName = config().DemangleKernelNames ?
+        demangle(kernelName) :
+        kernelName;
 
-    kernelInfo.KernelName = kernelName;
+    kernelInfo.KernelName = demangledName;
 
     kernelInfo.ProgramHash = programInfo.ProgramHash;
     kernelInfo.OptionsHash = programInfo.OptionsHash;
@@ -6459,7 +6468,7 @@ void CLIntercept::addKernelInfo(
     kernelInfo.ProgramNumber = programInfo.ProgramNumber;
     kernelInfo.CompileCount = programInfo.CompileCount - 1;
 
-    addShortKernelName( kernelName );
+    addShortKernelName( demangledName );
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6502,8 +6511,11 @@ void CLIntercept::addKernelInfo(
                     kernelName[ kernelNameSize ] = 0;
 
                     SKernelInfo& kernelInfo = m_KernelInfoMap[ kernel ];
+                    std::string demangledName = config().DemangleKernelNames ?
+                        demangle(kernelName) :
+                        kernelName;
 
-                    kernelInfo.KernelName = kernelName;
+                    kernelInfo.KernelName = demangledName;
 
                     kernelInfo.ProgramHash = programInfo.ProgramHash;
                     kernelInfo.OptionsHash = programInfo.OptionsHash;
@@ -6511,7 +6523,7 @@ void CLIntercept::addKernelInfo(
                     kernelInfo.ProgramNumber = programInfo.ProgramNumber;
                     kernelInfo.CompileCount = programInfo.CompileCount - 1;
 
-                    addShortKernelName( kernelName );
+                    addShortKernelName( demangledName );
                 }
 
                 delete [] kernelName;


### PR DESCRIPTION
## Description of Changes

Adds a control and cliloader option to demangle kernel names in logs and reports.  This can make it easier to profile and analyze SYCL applications where kernels names are mangled.

Currently demangling uses functionality from the `cxxabi.h` header file which is only available in some compiler toolchains.  If the intercept layer is built using a toolchain without `cxxabi.h` support then the build will succeed but demangling will not be available.

## Testing Done

Tested on Linux with a compiler toolchain supporting `cxxabi.h` and a SYCL application to verify that demangling works correctly.  Tested on Windows where MSVC does not support `cxxabi.h` to verify that builds succeed and applications still work even when demangling is unavailable.
