### PR TITLE
update GitHub actions checkout to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Check Tabs
       run: |
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Create Build Directory
       run: cmake -E make_directory ${{runner.workspace}}/build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Create Build Directory
       run: cmake -E make_directory ${{runner.workspace}}/build


### PR DESCRIPTION
## Description of Changes

CI update to the latest version of the checkout action.

## Testing Done

Verified CI warning messages are fixed.