### PR TITLE
enable blocking tags without HostPerformanceTiming

### DIFF
--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -2771,7 +2771,12 @@ inline bool CLIntercept::checkAubCaptureEnqueueLimits(
     std::string hostTag, deviceTag;                                         \
     if( pIntercept->config().ChromeCallLogging ||                           \
         ( pIntercept->config().HostPerformanceTiming &&                     \
-          pIntercept->checkHostPerformanceTimingEnqueueLimits( enqueueCounter ) ) )\
+          pIntercept->checkHostPerformanceTimingEnqueueLimits( enqueueCounter ) ) ||\
+        ( ( pIntercept->config().DevicePerformanceTiming ||                   \
+            pIntercept->config().ITTPerformanceTiming ||                      \
+            pIntercept->config().ChromePerformanceTiming ||                   \
+            pIntercept->config().DevicePerfCounterEventBasedSampling ) &&     \
+          pIntercept->checkDevicePerformanceTimingEnqueueLimits( enqueueCounter ) ) )\
     {                                                                       \
         pIntercept->getTimingTagBlocking(                                   \
             __FUNCTION__,                                                   \


### PR DESCRIPTION
## Description of Changes

Fixes an issue that was causing some blocking tags to be omitted without HostPerformanceTiming.

Previously, only host tags set for blocking tags, but with transfer tracking device tags can be set as well.  This means that we need to check for DevicePerformanceTiming also, and cannot only test for HostPerformanceTiming.

## Testing Done

Verified that transfer tags are properly included with just DevicePerformanceTiming, without also needing to set HostPerformanceTiming.