### PR TITLE
enable parallel builds to speed up CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Build
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: cmake --build . --config $BUILD_TYPE
+      run: cmake --build . --parallel 4 --config $BUILD_TYPE
 
     #- name: Test
     #  working-directory: ${{runner.workspace}}/build


### PR DESCRIPTION
## Description of Changes

No functional changes - enables parallel builds via CMake to speed up GitHub actions CI.

## Testing Done

Verified that CI completed faster, especially MacOS.
