### PR TITLE
add a control to generate report data at a regular interval

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -261,6 +261,10 @@ If set to a nonzero value, the Intercept Layer for OpenCL Applications will emit
 
 If set to a nonzero value, the Intercept Layer for OpenCL Applications will write results to the file "clintercept\_report.txt".
 
+##### `ReportInterval` (cl_uint)
+
+If set to a nonzero value, the Intercept Layer for OpenCL Applications will generate a report at regular intervals (based on the enqueue counter).  This can be useful to generate report data while a long-running application is executing, or if an application does not exit cleanly.
+
 ### Performance Timing Controls
 
 ##### `HostPerformanceTiming` (bool)

--- a/intercept/src/controls.h
+++ b/intercept/src/controls.h
@@ -48,6 +48,7 @@ CLI_CONTROL( bool,          DemangleKernelNames,                    false, "If s
 CLI_CONTROL_SEPARATOR( Reporting Controls: )
 CLI_CONTROL( bool,          ReportToStderr,                         false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will emit reports to stderr." )
 CLI_CONTROL( bool,          ReportToFile,                           true,  "If set to a nonzero value, the Intercept Layer for OpenCL Applications will write results to the file \"clintercept_report.txt\"." )
+CLI_CONTROL( cl_uint,       ReportInterval,                         0,     "If set to a nonzero value, the Intercept Layer for OpenCL Applications will generate a report at regular intervals (based on the enqueue counter).  This can be useful to generate report data while a long-running application is executing, or if an application does not exit cleanly." )
 
 CLI_CONTROL_SEPARATOR( Performance Timing Controls: )
 CLI_CONTROL( bool,          HostPerformanceTiming,                  false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will track the minimum, maximum, and average host CPU time for each OpenCL entry point.  When the process exits, this information will be included in the file \"clIntercept_report.txt\"." )


### PR DESCRIPTION
## Description of Changes

Adds a control to generate report data at regular intervals.  This can be useful to generate report data while a long-running application is executing, or if an application does not exit cleanly.

Also fixes a corner case bug where the program binary hash was not properly generated when program options were dumped but not program binaries.

## Testing Done

Verified that report data is generated at regular intervals for an application that does not exit cleanly.
