### PR TITLE
dump modified program source or options to a "modified" directory

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -2114,7 +2114,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clBuildProgram)(
 
         SAVE_PROGRAM_OPTIONS_HASH( program, options );
         PROGRAM_OPTIONS_OVERRIDE_INIT( program, options, newOptions, isCompile );
-        DUMP_PROGRAM_OPTIONS( program, options, isCompile, isLink );
+        DUMP_PROGRAM_OPTIONS( program, newOptions ? newOptions : options, isCompile, isLink );
 
         CALL_LOGGING_ENTER( "program = %p, pfn_notify = %p", program, pfn_notify );
         BUILD_LOGGING_INIT();
@@ -2151,6 +2151,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clBuildProgram)(
 
         DUMP_OUTPUT_PROGRAM_BINARIES( program );
         DUMP_KERNEL_ISA_BINARIES( program );
+        // Note: this uses the original program options!
         AUTO_CREATE_SPIRV( program, options );
         INCREMENT_PROGRAM_COMPILE_COUNT( program );
         PROGRAM_OPTIONS_CLEANUP( newOptions );
@@ -2187,7 +2188,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clCompileProgram)(
 
         SAVE_PROGRAM_OPTIONS_HASH( program, options );
         PROGRAM_OPTIONS_OVERRIDE_INIT( program, options, newOptions, isCompile );
-        DUMP_PROGRAM_OPTIONS( program, options, isCompile, isLink );
+        DUMP_PROGRAM_OPTIONS( program, newOptions ? newOptions : options, isCompile, isLink );
 
         CALL_LOGGING_ENTER( "program = %p, pfn_notify = %p", program, pfn_notify );
         BUILD_LOGGING_INIT();
@@ -2260,7 +2261,6 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clLinkProgram)(
         const bool isCompile = false;
         const bool isLink = true;
         char*   newOptions = NULL;
-        cl_program  retVal = NULL;
 
         PROGRAM_LINK_OPTIONS_OVERRIDE_INIT( num_devices, device_list, options, newOptions );
 
@@ -2272,7 +2272,9 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clLinkProgram)(
         BUILD_LOGGING_INIT();
         HOST_PERFORMANCE_TIMING_START();
 
-        if( ( retVal == NULL ) && newOptions )
+        cl_program  retVal = NULL;
+
+        if( newOptions != NULL )
         {
             retVal = pIntercept->dispatch().clLinkProgram(
                 context,
@@ -2285,6 +2287,7 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clLinkProgram)(
                 user_data,
                 errcode_ret );
         }
+
         if( retVal == NULL )
         {
             retVal = pIntercept->dispatch().clLinkProgram(
@@ -2309,7 +2312,7 @@ CL_API_ENTRY cl_program CL_API_CALL CLIRN(clLinkProgram)(
         // This is a new program object, so we don't currently have a hash for it.
         SAVE_PROGRAM_NUMBER( retVal );
         SAVE_PROGRAM_OPTIONS_HASH( retVal, options );
-        DUMP_PROGRAM_OPTIONS( retVal, options, isCompile, isLink );
+        DUMP_PROGRAM_OPTIONS( retVal, newOptions ? newOptions : options, isCompile, isLink );
         DUMP_OUTPUT_PROGRAM_BINARIES( retVal );
         DUMP_KERNEL_ISA_BINARIES( retVal );
         INCREMENT_PROGRAM_COMPILE_COUNT( retVal );

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -4614,8 +4614,9 @@ void CLIntercept::dumpProgramSourceScript(
 ///////////////////////////////////////////////////////////////////////////////
 //
 void CLIntercept::dumpProgramSource(
-    uint64_t hash,
     cl_program program,
+    uint64_t hash,
+    bool modified,
     const char* singleString )
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
@@ -4628,6 +4629,11 @@ void CLIntercept::dumpProgramSource(
     {
         OS().GetDumpDirectoryName( sc_DumpDirectoryName, fileName );
     }
+    if( modified )
+    {
+        fileName += "/Modified";
+    }
+
     // Make the filename.  It will have the form:
     //   CLI_<program number>_<hash>_source.cl
     {
@@ -4685,8 +4691,9 @@ void CLIntercept::dumpProgramSource(
 ///////////////////////////////////////////////////////////////////////////////
 //
 void CLIntercept::dumpInputProgramBinaries(
-    uint64_t hash,
     const cl_program program,
+    uint64_t hash,
+    bool modified,
     cl_uint num_devices,
     const cl_device_id* device_list,
     const size_t* lengths,
@@ -4701,6 +4708,10 @@ void CLIntercept::dumpInputProgramBinaries(
     // Get the dump directory name.
     {
         OS().GetDumpDirectoryName( sc_DumpDirectoryName, fileName );
+    }
+    if( modified )
+    {
+        fileName += "/Modified";
     }
 
     // Make the filename.  It will have the form:
@@ -4794,8 +4805,9 @@ void CLIntercept::dumpInputProgramBinaries(
 ///////////////////////////////////////////////////////////////////////////////
 //
 void CLIntercept::dumpProgramSPIRV(
-    uint64_t hash,
     cl_program program,
+    uint64_t hash,
+    bool modified,
     const size_t length,
     const void* il )
 {
@@ -4808,6 +4820,10 @@ void CLIntercept::dumpProgramSPIRV(
     // Get the dump directory name.
     {
         OS().GetDumpDirectoryName( sc_DumpDirectoryName, fileName );
+    }
+    if( modified )
+    {
+        fileName += "/Modified";
     }
 
     // Make the filename.  It will have the form:
@@ -4837,7 +4853,7 @@ void CLIntercept::dumpProgramSPIRV(
         OS().MakeDumpDirectories( fileName );
     }
 
-    // Dump the program source to a .cl file.
+    // Dump the program source to a .spv file.
     {
         std::ofstream os;
         os.open(
@@ -5004,6 +5020,7 @@ void CLIntercept::dumpProgramOptionsScript(
 //
 void CLIntercept::dumpProgramOptions(
     const cl_program program,
+    bool modified,
     cl_bool isCompile,
     cl_bool isLink,
     const char* options )
@@ -5026,6 +5043,11 @@ void CLIntercept::dumpProgramOptions(
         {
             OS().GetDumpDirectoryName( sc_DumpDirectoryName, fileName );
         }
+        if( modified )
+        {
+            fileName += "/Modified";
+        }
+
         // Make the filename.  It will have the form:
         //   CLI_<program number>_<program hash>_<compile count>_<options hash>
         // Leave off the extension for now.
@@ -5051,6 +5073,12 @@ void CLIntercept::dumpProgramOptions(
             fileName += "/CLI_";
             fileName += numberString;
         }
+
+        // Now make directories as appropriate.
+        {
+            OS().MakeDumpDirectories( fileName );
+        }
+
         // Dump the program options to a .txt file.
         {
             fileName +=

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -314,19 +314,22 @@ public:
                 const cl_program program,
                 const char* singleString );
     void    dumpProgramSource(
-                uint64_t hash,
                 const cl_program program,
+                uint64_t hash,
+                bool modified,
                 const char* singleString );
     void    dumpInputProgramBinaries(
-                uint64_t hash,
                 const cl_program program,
+                uint64_t hash,
+                bool modified,
                 cl_uint num_devices,
                 const cl_device_id* device_list,
                 const size_t* lengths,
                 const unsigned char** binaries );
     void    dumpProgramSPIRV(
-                uint64_t hash,
                 const cl_program program,
+                uint64_t hash,
+                bool modified,
                 const size_t length,
                 const void* il );
     void    dumpProgramOptionsScript(
@@ -334,6 +337,7 @@ public:
                 const char* options );
     void    dumpProgramOptions(
                 const cl_program program,
+                bool modified,
                 cl_bool isCompile,
                 cl_bool isLink,
                 const char* options );
@@ -2506,14 +2510,14 @@ inline bool CLIntercept::checkAubCaptureEnqueueLimits(
     }
 
 #define DUMP_PROGRAM_OPTIONS( program, options, isCompile, isLink )         \
-    if( ( modified == false ) &&                                            \
-        ( pIntercept->config().DumpProgramSource ||                         \
-          pIntercept->config().DumpInputProgramBinaries ||                  \
-          pIntercept->config().DumpProgramBinaries ||                       \
-          pIntercept->config().DumpProgramSPIRV ) )                         \
+    if( pIntercept->config().DumpProgramSource ||                           \
+        pIntercept->config().DumpInputProgramBinaries ||                    \
+        pIntercept->config().DumpProgramBinaries ||                         \
+        pIntercept->config().DumpProgramSPIRV )                             \
     {                                                                       \
         pIntercept->dumpProgramOptions(                                     \
             program,                                                        \
+            modified,                                                       \
             isCompile,                                                      \
             isLink,                                                         \
             options );                                                      \
@@ -2598,11 +2602,14 @@ inline bool CLIntercept::checkAubCaptureEnqueueLimits(
     }
 
 #define DUMP_PROGRAM_SOURCE( program, singleString, hash )                  \
-    if( ( injected == false ) &&                                            \
-        ( pIntercept->config().DumpProgramSource ||                         \
-          pIntercept->config().AutoCreateSPIRV ) )                          \
+    if( pIntercept->config().DumpProgramSource ||                           \
+        pIntercept->config().AutoCreateSPIRV )                              \
     {                                                                       \
-        pIntercept->dumpProgramSource( hash, program, singleString );       \
+        pIntercept->dumpProgramSource(                                      \
+            program,                                                        \
+            hash,                                                           \
+            injected,                                                       \
+            singleString );                                                 \
     }                                                                       \
     else if( ( injected == false ) &&                                       \
              ( pIntercept->config().SimpleDumpProgramSource ||              \
@@ -2642,8 +2649,9 @@ inline bool CLIntercept::checkAubCaptureEnqueueLimits(
     if( pIntercept->config().DumpInputProgramBinaries )                     \
     {                                                                       \
         pIntercept->dumpInputProgramBinaries(                               \
-            _hash,                                                          \
             _program,                                                       \
+            _hash,                                                          \
+            false, /* modified */                                           \
             _num,                                                           \
             _devs,                                                          \
             _lengths,                                                       \
@@ -2672,10 +2680,9 @@ inline bool CLIntercept::checkAubCaptureEnqueueLimits(
     }
 
 #define DUMP_PROGRAM_SPIRV( program, length, il, hash )                     \
-    if( ( injected == false ) &&                                            \
-        pIntercept->config().DumpProgramSPIRV )                             \
+    if( pIntercept->config().DumpProgramSPIRV )                             \
     {                                                                       \
-        pIntercept->dumpProgramSPIRV( hash, program, length, il );          \
+        pIntercept->dumpProgramSPIRV( program, hash, injected, length, il );\
     }                                                                       \
     else                                                                    \
     {                                                                       \


### PR DESCRIPTION
## Description of Changes

Previously, if program source or program options were modified (say via injection, appending, or prepending) the modified program source or program options was not dumped to avoid mixing modified files with unmodified files.  After this change, the modified files are dumped to a "modified" directory for easier debugging, or to support diff'ing with the unmodified files to see what changed.

## Testing Done

Tested by modifying program source via injection and program options via appending.