### PR TITLE
minor aubcapture documentation updates and fixes

### DIFF
--- a/docs/aubcapture.md
+++ b/docs/aubcapture.md
@@ -29,7 +29,7 @@ method is deprecated, is not recommended, and is supported for internal use only
 Most published drivers are Release driver builds, which do not support AUB file capture.
 
 To initially enable NEO AUB file capture, please enable the NEO controls
-`AUBDumpSubcaptureMode` and `SetCommandStreamReceiver`.
+`AUBDumpSubCaptureMode` and `SetCommandStreamReceiver`.
 
 The mechanism to enable these controls is operating system dependent.
 
@@ -37,7 +37,11 @@ On Windows, enable NEO AUB file capture by setting two `REG_DWORD` registry valu
 in the registry key:
 
 ```
-HKEY_CURRENT_USER\SOFTWARE\INTEL\IGFX\OCL
+// For 32-bit systems, or 64-bit applications on a 64-bit system:
+HKEY_LOCAL_MACHINE\SOFTWARE\INTEL\IGFX\OCL
+
+// For 32-bit applications on a 64-bit system:
+HKEY_LOCAL_MACHINE\SOFTWARE\WoW6432Node\INTEL\IGFX\OCL
 ```
 
 The first registry value should be named `AUBDumpSubCaptureMode` and should have the
@@ -49,8 +53,14 @@ On Linux, enable NEO file AUB capture by setting the environment variable
 `AUBDumpSubCaptureMode` to the value `2`, indicating `Toggle` mode, and by setting
 the environment variable `SetCommandStreamReceiver` to the value `3`, indicating that
 commands should both be captured and sent to the GPU.
+The environment variable method may also be used on Windows.
+
 The `AUBDumpSubCaptureMode` and `SetCommandStreamReceiver` variables may also be set
 via the config file `igdrcl.config`, if preferred.
+
+Additionally, it is generally recommended to set the `PrintDebugSettings` variable to
+the value `1`, which will print the values of all non-default variables to the console,
+to verify they have been properly set.
 
 ## Testing AUB File Capture
 

--- a/intercept/OS/OS_linux.h
+++ b/intercept/OS/OS_linux.h
@@ -113,7 +113,7 @@ static inline bool SetAubCaptureEnvironmentVariables(
     bool start )
 {
     // For NEO AubCapture:
-    // As setup, need to set AUBDumpSubcaptureMode = 2.
+    // As setup, need to set AUBDumpSubCaptureMode = 2.
     // This will be the client's responsibility.
     //
     // To start/stop AubCapture:

--- a/intercept/OS/OS_windows.h
+++ b/intercept/OS/OS_windows.h
@@ -157,7 +157,7 @@ static inline bool SetAubCaptureRegistryKeys(
     DWORD dwValue )
 {
     // For NEO AubCapture:
-    // As setup, need to set AUBDumpSubcaptureMode = 2.
+    // As setup, need to set AUBDumpSubCaptureMode = 2.
     // This will be the client's responsibility.
     //
     // To start/stop AubCapture:
@@ -297,9 +297,6 @@ inline bool Services::StopAubCaptureKDC(
     std::string command = "kdc.exe -off";
     int res = system(command.c_str());
     //fprintf(stderr, "Running the command: %s returned %d\n", command.c_str(), res );
-
-    // This is the newer NEO method of AubCapture:
-    bool success = SetAubCaptureRegistryKeys( "", 0 );
 
     return res != -1;
 }


### PR DESCRIPTION
## Description of Changes

This is primarily a documentation update, to correct the capitalization of several aubcapture-related controls, and to correct the registry keys to enable aubcapture in the driver.

Note that the registry keys to enable aubcapture in the driver are in HKLM, but the registry keys to setup subcaptures is still HKCU (this is a good thing).

The only reason this is not NFC is because there was an extra call to disable the newer NEO aubcapture when disabling the older KDX aubcapture, that has been removed.  This should cause no functional changes in practice because the KDX aubcapture hasn't been used in years.

## Testing Done

Verifed aubfiles could be created on Windows after following the directions using a simple tester.
