### PR TITLE
add a cliloader control to dump MDAPI metrics

### DIFF
--- a/cliloader/CMakeLists.txt
+++ b/cliloader/CMakeLists.txt
@@ -10,6 +10,7 @@ configure_file(git_version.h.in "${CMAKE_CURRENT_BINARY_DIR}/git_version.h" @ONL
 set( CLILOADER_SOURCE_FILES
     cliloader.cpp
     printcontrols.h
+    printmetrics.h
     "${CMAKE_CURRENT_BINARY_DIR}/git_version.h"
 )
 source_group( Source FILES
@@ -23,6 +24,9 @@ add_dependencies(cliloader OpenCL)
 target_include_directories(cliloader PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../intercept)
 target_include_directories(cliloader PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
+if(WIN32)
+    target_link_libraries(cliloader SetupAPI Shlwapi)
+endif()
 if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
     target_link_libraries(cliloader PRIVATE procstat util)
 endif()

--- a/cliloader/cliloader.cpp
+++ b/cliloader/cliloader.cpp
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "printcontrols.h"
+#include "printmetrics.h"
 
 bool debug = false;
 
@@ -345,6 +346,11 @@ static bool parseArguments(int argc, char *argv[])
             printControls();
             return false;
         }
+        else if (!strcmp(argv[i], "--metrics"))
+        {
+            printMetrics();
+            return false;
+        }
 #if !defined(_WIN32)
         else if( !strcmp(argv[i], "--no-LD_PRELOAD") )
         {
@@ -512,6 +518,7 @@ static bool parseArguments(int argc, char *argv[])
             "Options:\n"
             "  --debug                          Enable cliloader Debug Messages\n"
             "  --controls                       Print All Controls and Exit\n"
+            "  --metrics                        Print All MDAPI Metrics and Exit\n"
 #if !defined(_WIN32)
             "  --no-LD_PRELOAD                  Do not set LD_PRELOAD\n"
             "  --no-LD_LIBRARY_PATH             Do not set LD_LIBRARY_PATH\n"
@@ -534,9 +541,9 @@ static bool parseArguments(int argc, char *argv[])
             "  --chrome-kernel-timeline [-ckt]  Record Per-Kernel Device Timeline to a JSON Trace File\n"
             "  --chrome-device-stages [-cds]    Record Device Timeline Stages to a JSON Trace File\n"
             "  --driver-diagnostics [-ddiag]    Log Driver Diagnostics\n"
-            "  --mdapi-ebs                      Report Event-Based MDAPI Counters (Intel GPU Only)\n"
-            "  --mdapi-tbs                      Report Time-Based MDAPI Counters (Intel GPU Only)\n"
-            "  --mdapi-group <NAME>             Choose MDAPI Counters to Collect (Intel GPU Only)\n"
+            "  --mdapi-ebs                      Report Event-Based MDAPI Metrics (Intel GPU Only)\n"
+            "  --mdapi-tbs                      Report Time-Based MDAPI Metrics (Intel GPU Only)\n"
+            "  --mdapi-group <NAME>             Choose MDAPI Metrics to Collect (Intel GPU Only)\n"
             "  --host-timing [-h]               Report Host API Execution Time\n"
             "  --leak-checking [-l]             Track and Report OpenCL Leaks\n"
             "  --output-to-file [-f]            Log and Report to Files vs. stderr\n"

--- a/cliloader/printcontrols.h
+++ b/cliloader/printcontrols.h
@@ -45,7 +45,7 @@ static const std::vector<cliControl> controls =
 #undef CLI_CONTROL
 #undef CLI_CONTROL_SEPARATOR
 
-void printControls()
+static void printControls()
 {
     for (const auto& control : controls )
     {

--- a/cliloader/printmetrics.h
+++ b/cliloader/printmetrics.h
@@ -1,0 +1,205 @@
+/*
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+*/
+
+#pragma once
+
+#include <stdio.h>
+#include <string>
+#include "mdapi/metrics_discovery_api.h"
+
+#if defined(_WIN32)
+static const wchar_t* cMDLibFileName =
+sizeof(void*) == 8 ?
+    L"igdmd64.dll" :
+    L"igdmd32.dll";
+
+#include <Windows.h>
+#include "mdapi/DriverStorePath.h"
+
+static void* OpenLibrary()
+{
+    return (void*)LoadDynamicLibrary(cMDLibFileName);
+}
+
+#define GetFunctionAddress(_handle, _name)  GetProcAddress((HMODULE)_handle, _name)
+
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__FreeBSD__)
+static const char* cMDLibFileName = "libigdmd.so";
+#else
+static const char* cMDLibFileName = "libigdmd.dylib";
+#endif
+
+#include <dlfcn.h>
+#include <stdarg.h>
+#include <string.h>
+
+static void* OpenLibrary()
+{
+    void* ret = dlopen(cMDLibFileName, RTLD_LAZY | RTLD_LOCAL);
+#if !defined(__APPLE__)
+    if (ret == NULL)
+    {
+        // old alternate name, may eventually be removed
+        ret = dlopen("libmd.so", RTLD_LAZY | RTLD_LOCAL);
+    }
+#endif
+    return ret;
+}
+
+#define GetFunctionAddress(_handle, _name)  dlsym(_handle, _name)
+#define GetLastError()                      dlerror()
+
+#endif
+
+namespace MetricsDiscovery
+{
+
+static bool printMetricsHelper(const std::string& metricsFileName)
+{
+    OpenMetricsDevice_fn            OpenMetricsDevice;
+    CloseMetricsDevice_fn           CloseMetricsDevice;
+    OpenMetricsDeviceFromFile_fn    OpenMetricsDeviceFromFile;
+
+    TCompletionCode res = CC_OK;
+
+    IMetricsDevice_1_5* metricsDevice;
+
+    void* pLibrary = OpenLibrary();
+    if (pLibrary == NULL)
+    {
+        fprintf(stderr, "Couldn't load metrics discovery library!\n");
+        return false;
+    }
+
+    CloseMetricsDevice = (CloseMetricsDevice_fn)GetFunctionAddress(pLibrary, "CloseMetricsDevice");
+    if (CloseMetricsDevice == NULL)
+    {
+        fprintf(stderr, "CloseMetricsDevice NULL, error: %d\n", GetLastError());
+        return false;
+    }
+
+    OpenMetricsDevice = (OpenMetricsDevice_fn)GetFunctionAddress(pLibrary, "OpenMetricsDevice");
+    if (OpenMetricsDevice == NULL)
+    {
+        fprintf(stderr, "OpenMetricsDevice NULL, error: %d\n", GetLastError());
+        return false;
+    }
+
+    OpenMetricsDeviceFromFile = (OpenMetricsDeviceFromFile_fn)GetFunctionAddress(pLibrary, "OpenMetricsDeviceFromFile");
+    if (OpenMetricsDeviceFromFile == NULL)
+    {
+        fprintf(stderr, "OpenMetricsDeviceFromFile NULL, error: %d\n", GetLastError());
+        return false;
+    }
+
+    if (!metricsFileName.empty())
+    {
+        res = OpenMetricsDeviceFromFile(metricsFileName.c_str(), (void*)"", &metricsDevice);
+        if (res != CC_OK)
+        {
+            res = OpenMetricsDeviceFromFile(metricsFileName.c_str(), (void*)"abcdefghijklmnop", &metricsDevice);
+        }
+        if (res != CC_OK)
+        {
+            fprintf(stderr, "OpenMetricsDeviceFromFile failed, res: %d\n", res);
+            return false;
+        }
+    }
+    else
+    {
+        res = OpenMetricsDevice(&metricsDevice);
+        if (res != CC_OK)
+        {
+            fprintf(stderr, "OpenMetricsDevice failed, res: %d\n", res);
+            return false;
+        }
+    }
+
+    TMetricsDeviceParams_1_0* deviceParams = metricsDevice->GetParams();
+    if (NULL == deviceParams)
+    {
+        fprintf(stderr, "DeviceParams null\n");
+        return false;
+    }
+
+    fprintf(stderr, "MDAPI Headers: v%d.%d.%d, MDAPI Lib: v%d.%d.%d\n",
+        MD_API_MAJOR_NUMBER_CURRENT,
+        MD_API_MINOR_NUMBER_CURRENT,
+        MD_API_BUILD_NUMBER_CURRENT,
+        deviceParams->Version.MajorNumber,
+        deviceParams->Version.MinorNumber,
+        deviceParams->Version.BuildNumber);
+    if (deviceParams->Version.MajorNumber < 1 ||
+        (deviceParams->Version.MajorNumber == 1 && deviceParams->Version.MinorNumber < 1))
+    {
+        fprintf(stderr, "MDAPI Lib version must be at least v1.1!\n");
+        return false;
+    }
+
+    bool found = false;
+    for (uint32_t cg = 0; !found && cg < deviceParams->ConcurrentGroupsCount; cg++)
+    {
+        IConcurrentGroup_1_1* group = metricsDevice->GetConcurrentGroup(cg);
+        TConcurrentGroupParams_1_0* groupParams = group->GetParams();
+
+        if (groupParams)
+        {
+            fprintf(stderr, "\nMetric Group: %s (%d Metric Set%s)\n",
+                groupParams->Description,
+                groupParams->MetricSetsCount,
+                groupParams->MetricSetsCount > 1 ? "s" : "");
+            fprintf(stderr, "========================================\n\n");
+
+            for (uint32_t ms = 0; ms < groupParams->MetricSetsCount; ms++)
+            {
+                IMetricSet_1_1* metricSet = group->GetMetricSet(ms);
+                TMetricSetParams_1_0* setParams = metricSet->GetParams();
+
+                if (setParams)
+                {
+                    fprintf(stderr, "Metric Set: %s (%d Metric%s)\n",
+                        setParams->ShortName,
+                        setParams->MetricsCount,
+                        setParams->MetricsCount > 1 ? "s" : "");
+                    fprintf(stderr, "----------------------------------------\n\n");
+
+                    for (uint32_t m = 0; m < setParams->MetricsCount; m++)
+                    {
+                        TMetricParams_1_0* metricParams = metricSet->GetMetric(m)->GetParams();
+
+                        if (metricParams)
+                        {
+                            fprintf(stderr,
+                                "%s\\%s (%s):\n"
+                                "%s\n\n",
+                                setParams->SymbolName,
+                                metricParams->ShortName,
+                                metricParams->SymbolName,
+                                metricParams->LongName);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    res = CloseMetricsDevice(metricsDevice);
+    if (res != CC_OK)
+    {
+        fprintf(stderr, "CloseMetricsDevice failed, res: %d\n", res);
+        return false;
+    }
+
+    return true;
+}
+
+};
+
+static void printMetrics()
+{
+    MetricsDiscovery::printMetricsHelper("");
+}

--- a/cliloader/printmetrics.h
+++ b/cliloader/printmetrics.h
@@ -51,7 +51,6 @@ static void* OpenLibrary()
 }
 
 #define GetFunctionAddress(_handle, _name)  dlsym(_handle, _name)
-#define GetLastError()                      dlerror()
 
 #endif
 
@@ -78,21 +77,21 @@ static bool printMetricsHelper(const std::string& metricsFileName)
     CloseMetricsDevice = (CloseMetricsDevice_fn)GetFunctionAddress(pLibrary, "CloseMetricsDevice");
     if (CloseMetricsDevice == NULL)
     {
-        fprintf(stderr, "CloseMetricsDevice NULL, error: %d\n", GetLastError());
+        fprintf(stderr, "Couldn't get pointer to CloseMetricsDevice!\n");
         return false;
     }
 
     OpenMetricsDevice = (OpenMetricsDevice_fn)GetFunctionAddress(pLibrary, "OpenMetricsDevice");
     if (OpenMetricsDevice == NULL)
     {
-        fprintf(stderr, "OpenMetricsDevice NULL, error: %d\n", GetLastError());
+        fprintf(stderr, "Couldn't get pointer to OpenMetricsDevice!\n");
         return false;
     }
 
     OpenMetricsDeviceFromFile = (OpenMetricsDeviceFromFile_fn)GetFunctionAddress(pLibrary, "OpenMetricsDeviceFromFile");
     if (OpenMetricsDeviceFromFile == NULL)
     {
-        fprintf(stderr, "OpenMetricsDeviceFromFile NULL, error: %d\n", GetLastError());
+        fprintf(stderr, "Couldn't get pointer to OpenMetricsDeviceFromFile!\n");
         return false;
     }
 
@@ -177,8 +176,8 @@ static bool printMetricsHelper(const std::string& metricsFileName)
                                 "%s\\%s (%s):\n"
                                 "%s\n\n",
                                 setParams->SymbolName,
-                                metricParams->ShortName,
                                 metricParams->SymbolName,
+                                metricParams->ShortName,
                                 metricParams->LongName);
                         }
                     }

--- a/intercept/mdapi/DriverStorePath.h
+++ b/intercept/mdapi/DriverStorePath.h
@@ -315,3 +315,6 @@ static HMODULE LoadDynamicLibrary(const wchar_t* pFileName, HANDLE hFile = NULL,
 
     return hModule;
 }
+
+#undef DEBUG
+#undef DBG

--- a/intercept/mdapi/MetricsDiscoveryHelper.cpp
+++ b/intercept/mdapi/MetricsDiscoveryHelper.cpp
@@ -72,7 +72,6 @@ static void* OpenLibrary( const std::string& metricsLibraryName )
 }
 
 #define GetFunctionAddress(_handle, _name)  dlsym(_handle, _name)
-#define GetLastError()                      dlerror()
 #define OutputDebugString(_buf)             fprintf(stderr, "%s", _buf);
 
 #endif
@@ -236,21 +235,21 @@ bool MDHelper::InitMetricsDiscovery(
     CloseMetricsDevice = (CloseMetricsDevice_fn)GetFunctionAddress(pLibrary, "CloseMetricsDevice");
     if (CloseMetricsDevice == NULL)
     {
-        DebugPrint("CloseMetricsDevice NULL, error: %d\n", GetLastError());
+        DebugPrint("Couldn't get pointer to CloseMetricsDevice!\n");
         return false;
     }
 
     OpenMetricsDevice = (OpenMetricsDevice_fn)GetFunctionAddress(pLibrary, "OpenMetricsDevice");
     if (OpenMetricsDevice == NULL)
     {
-        DebugPrint("OpenMetricsDevice NULL, error: %d\n", GetLastError());
+        DebugPrint("Couldn't get pointer to OpenMetricsDevice!\n");
         return false;
     }
 
     OpenMetricsDeviceFromFile = (OpenMetricsDeviceFromFile_fn)GetFunctionAddress(pLibrary, "OpenMetricsDeviceFromFile");
     if (OpenMetricsDeviceFromFile == NULL)
     {
-        DebugPrint("OpenMetricsDeviceFromFile NULL, error: %d\n", GetLastError());
+        DebugPrint("Couldn't get pointer to OpenMetricsDeviceFromFile!\n");
         return false;
     }
 


### PR DESCRIPTION
## Description of Changes

Adds a cliloader control to dump available metrics on the device.

## Testing Done

Verified that the new command line option works on both Windows and Linux.
