### PR TITLE
Build fix for undefined ref to dlopen

### DIFF
--- a/cliloader/CMakeLists.txt
+++ b/cliloader/CMakeLists.txt
@@ -24,6 +24,10 @@ add_dependencies(cliloader OpenCL)
 target_include_directories(cliloader PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../intercept)
 target_include_directories(cliloader PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
+if(CMAKE_DL_LIBS)
+    target_link_libraries(cliloader ${CMAKE_DL_LIBS})
+endif()
+
 if(WIN32)
     target_link_libraries(cliloader SetupAPI Shlwapi)
 endif()


### PR DESCRIPTION
(In general, it is desirable to create an issue for discussion before creating a pull request, though this is not required for simple changes.)

Fixes #

## Description of Changes

Fix build failure with dlopen. Currently, it fails to build on Linux

## Testing Done

cmake && make work fine on Ubuntu 20.04