### PR TITLE
[WIP] Implements functionality to automatcally hash buffers after a kernel was enqueued

### DIFF
--- a/intercept/src/controls.h
+++ b/intercept/src/controls.h
@@ -132,6 +132,10 @@ CLI_CONTROL( cl_uint,       DumpImagesMinEnqueue,                   0,     "The 
 CLI_CONTROL( cl_uint,       DumpImagesMaxEnqueue,                   UINT_MAX, "The Intercept Layer for OpenCL Applications will only dump image kernel arguments when the enqueue counter is less than this value, inclusive." )
 CLI_CONTROL( cl_uint,       DumpArgumentsOnSetMinEnqueue,           0,     "The Intercept Layer for OpenCL Applications will only dump argument values when the enqueue counter is greater than this value, inclusive." )
 CLI_CONTROL( cl_uint,       DumpArgumentsOnSetMaxEnqueue,           UINT_MAX, "The Intercept Layer for OpenCL Applications will only dump kernel arguments when the enqueue counter is less than this value, inclusive." )
+CLI_CONTROL( bool,          HashBuffersAfterEnqueue,                false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will calculate a hash of every binary buffer and output them to a file")
+CLI_CONTROL( bool,          HashBuffersWithEnqueueInfo,              false, "If set to a nonzero value, prepend the enqueue counter for the buffer to the hash")
+CLI_CONTROL( cl_uint,       HashBuffersMinEnqueue,                  0,     "The Intercept Layer for OpenCL Applications will only hash the buffer when the enqueue counter is greater than this value, inclusive." )
+CLI_CONTROL( cl_uint,       HashBuffersMaxEnqueue,                  UINT_MAX, "The Intercept Layer for OpenCL Applications will only hash the buffer when the enqueue counter is less than this value, inclusive." )
 
 CLI_CONTROL_SEPARATOR( Device Partitioning Controls: )
 CLI_CONTROL( bool,          AutoPartitionAllDevices,                false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will automatically partition parent devices and return all parent devices and all sub-devices." )

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -4877,8 +4877,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueNDRangeKernel)(
             CALL_LOGGING_EXIT_EVENT_WITH_TAG( retVal, event );
             ADD_EVENT( event ? event[0] : NULL );
         }
-
         DUMP_BUFFERS_AFTER_ENQUEUE( kernel, command_queue );
+        DUMP_HASHES( kernel, command_queue );
         DUMP_IMAGES_AFTER_ENQUEUE( kernel, command_queue );
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
         CHECK_AUBCAPTURE_STOP( command_queue );

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -7376,7 +7376,6 @@ void CLIntercept::dumpHashes(
             cl_command_queue command_queue,
             bool enqueueInfo )
 {
-    std::cout << "test\n";
     std::lock_guard<std::mutex> lock(m_Mutex);
     std::string fileNamePrefix = "";
 

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -573,6 +573,11 @@ public:
                 void* ptr,
                 size_t offset,
                 size_t size );
+    void    dumpHashes(
+                const uint64_t enqueueCounter,
+                cl_kernel kernel,
+                cl_command_queue command_queue,
+                bool enqueueInfo );
 
     void    addMapPointer(
                 const void* ptr,
@@ -2207,7 +2212,8 @@ inline bool CLIntercept::checkDumpImageEnqueueLimits(
           pIntercept->config().DumpBuffersAfterMap ||                       \
           pIntercept->config().DumpBuffersBeforeUnmap ||                    \
           pIntercept->config().DumpBuffersBeforeEnqueue ||                  \
-          pIntercept->config().DumpBuffersAfterEnqueue ) )                  \
+          pIntercept->config().DumpBuffersAfterEnqueue  ||                  \
+          pIntercept->config().HashBuffersAfterEnqueue) )                   \
     {                                                                       \
         pIntercept->addBuffer( _buffer );                                   \
     }
@@ -2228,7 +2234,8 @@ inline bool CLIntercept::checkDumpImageEnqueueLimits(
           pIntercept->config().DumpBuffersBeforeEnqueue ||                  \
           pIntercept->config().DumpBuffersAfterEnqueue ||                   \
           pIntercept->config().DumpImagesBeforeEnqueue ||                   \
-          pIntercept->config().DumpImagesAfterEnqueue ) )                   \
+          pIntercept->config().DumpImagesAfterEnqueue ||                    \
+          pIntercept->config().HashBuffersAfterEnqueue) )                   \
     {                                                                       \
         pIntercept->checkRemoveMemObj( _memobj );                           \
     }
@@ -2250,7 +2257,8 @@ inline bool CLIntercept::checkDumpImageEnqueueLimits(
 #define ADD_SVM_ALLOCATION( svmPtr, size )                                  \
     if( svmPtr &&                                                           \
         ( pIntercept->config().DumpBuffersBeforeEnqueue ||                  \
-          pIntercept->config().DumpBuffersAfterEnqueue ) )                  \
+          pIntercept->config().DumpBuffersAfterEnqueue ||                   \
+          pIntercept->config().HashBuffersAfterEnqueue) )                   \
     {                                                                       \
         pIntercept->addSVMAllocation( svmPtr, size );                       \
     }
@@ -2258,7 +2266,8 @@ inline bool CLIntercept::checkDumpImageEnqueueLimits(
 #define REMOVE_SVM_ALLOCATION( svmPtr )                                     \
     if( svmPtr &&                                                           \
         ( pIntercept->config().DumpBuffersBeforeEnqueue ||                  \
-          pIntercept->config().DumpBuffersAfterEnqueue ) )                  \
+          pIntercept->config().DumpBuffersAfterEnqueue ||                   \
+          pIntercept->config().HashBuffersAfterEnqueue) )                   \
     {                                                                       \
         pIntercept->removeSVMAllocation( svmPtr );                          \
     }
@@ -2266,7 +2275,8 @@ inline bool CLIntercept::checkDumpImageEnqueueLimits(
 #define ADD_USM_ALLOCATION( usmPtr, size )                                  \
     if( usmPtr &&                                                           \
         ( pIntercept->config().DumpBuffersBeforeEnqueue ||                  \
-          pIntercept->config().DumpBuffersAfterEnqueue ) )                  \
+          pIntercept->config().DumpBuffersAfterEnqueue ||                   \
+          pIntercept->config().HashBuffersAfterEnqueue) )                   \
     {                                                                       \
         pIntercept->addUSMAllocation( usmPtr, size );                       \
     }
@@ -2274,7 +2284,8 @@ inline bool CLIntercept::checkDumpImageEnqueueLimits(
 #define REMOVE_USM_ALLOCATION( usmPtr )                                     \
     if( usmPtr &&                                                           \
         ( pIntercept->config().DumpBuffersBeforeEnqueue ||                  \
-          pIntercept->config().DumpBuffersAfterEnqueue ) )                  \
+          pIntercept->config().DumpBuffersAfterEnqueue ||                   \
+          pIntercept->config().HashBuffersAfterEnqueue) )                   \
     {                                                                       \
         pIntercept->removeUSMAllocation( usmPtr );                          \
     }
@@ -2296,7 +2307,8 @@ inline bool CLIntercept::checkDumpImageEnqueueLimits(
     if( ( pIntercept->config().DumpBuffersBeforeEnqueue ||                  \
           pIntercept->config().DumpBuffersAfterEnqueue ||                   \
           pIntercept->config().DumpImagesBeforeEnqueue ||                   \
-          pIntercept->config().DumpImagesAfterEnqueue ) &&                  \
+          pIntercept->config().DumpImagesAfterEnqueue ||                    \
+          pIntercept->config().HashBuffersAfterEnqueue ) &&                 \
         ( arg_value != NULL ) &&                                            \
         ( arg_size == sizeof(cl_mem) ) )                                    \
     {                                                                       \
@@ -2395,6 +2407,15 @@ inline bool CLIntercept::checkDumpImageEnqueueLimits(
         pIntercept->dumpBuffersForKernel(                                   \
             "Post", enqueueCounter, kernel, command_queue );                \
     }
+
+#define DUMP_HASHES( kernel, command_queue )                                \
+    if(pIntercept->config().HashBuffersAfterEnqueue &&                      \
+       (pIntercept->config().HashBuffersMinEnqueue <= enqueueCounter) &&    \
+       (pIntercept->config().HashBuffersMaxEnqueue >= enqueueCounter))      \
+    {                                                                       \
+        pIntercept->dumpHashes(enqueueCounter, kernel, command_queue,       \
+                               pIntercept->config().HashBuffersWithEnqueueInfo);      \
+    }                                                                       
 
 #define DUMP_IMAGES_BEFORE_ENQUEUE( kernel, command_queue )                 \
     if( pIntercept->config().DumpImagesBeforeEnqueue &&                     \

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -544,6 +544,10 @@ public:
                 cl_kernel kernel,
                 cl_uint arg_index,
                 const void* arg );
+    std::vector<char> getBufferForAllocation(
+                cl_kernel kernel,
+                cl_command_queue command_queue,
+                void* allocation );
     void    dumpBuffersForKernel(
                 const std::string& name,
                 const uint64_t enqueueCounter,


### PR DESCRIPTION
Partially implements #44 

## Description of Changes

Implements functionality to hash a buffer *after* a kernel enqueued.
1. Refactored Hash function, so that it now accepts a buffer of bytes whose size may not be a multiple of `sizeof(int)`
2. Refactored functionality to get a buffer corresponding to an allocation, so that it can be re-used in other functions:  
     - `std::vector<char> CLIntercept::getBufferForAllocation(...)`
3. Added controls:
    - `HashBuffersAfterEnqueue`: bool
    - `HashBuffersWithEnqueueInfo`: bool
    - `HashBuffersMinEnqueue` : cl_uint
    - `HashBuffersMaxEnqueue`: cl_uint
4. Added function which calculates the hash of the buffer and puts it into a file:
    - `void dumpHashes(...)`

Remarks/questions:
- It includes a pessimization, when you want to dump the buffers and calculate the hashes of these buffers, this will incur an extra copy of the buffer when using USM/UVM buffers.
- Right now we just append to the file, which has a fixed filename. So when running the CLI multiple times, the hashes just get appended to that file
- The enqueueNumber can differ between platforms, maybe add an option so that only the Argument index gets added to the line? Like this:
    - `Argument idx: 0, Hash: 18008159493775627770`
    - Makes for easier diff-ing between platforms to spot divergence.


## Testing Done

On small test programs. The hash function has not yet been tested on buffers whose size does not evenly divide into `sizeof(int)`!
