### PR TITLE
Add functionality to automatically detect NaNs in buffers/images before/after kernel enqueue

### DIFF
--- a/intercept/src/controls.h
+++ b/intercept/src/controls.h
@@ -44,6 +44,7 @@ CLI_CONTROL( bool,          AppendPid,                              false, "If s
 CLI_CONTROL( bool,          KernelNameHashTracking,                 false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will append the program and build option hashes to the kernel name in logs and reports." )
 CLI_CONTROL( cl_uint,       LongKernelNameCutoff,                   UINT_MAX, "If an OpenCL application uses kernels with very long names, the Intercept Layer for OpenCL Applications can substitute a \"short\" kernel identifier for a \"long\" kernel name in logs and reports.  This control defines how long a kernel name must be (in characters) before it is replaced by a \"short\" kernel identifier." )
 CLI_CONTROL( bool,          DemangleKernelNames,                    false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will track kernel names that are demangled according to C++ ABI rules.  This setting requires compiler support for demangling and may not be available in all configurations." )
+CLI_CONTROL( bool,          DetectNaNs,                             false, "If set, the Intercept Layer for OpenCL Applications will detect NaNs appearing in fp buffers and fp images and log the first kernel (name and enqueue counter) which caused these NaNs." )
 
 CLI_CONTROL_SEPARATOR( Reporting Controls: )
 CLI_CONTROL( bool,          ReportToStderr,                         false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will emit reports to stderr." )

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -4817,8 +4817,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueNDRangeKernel)(
 
         INCREMENT_ENQUEUE_COUNTER();
         DUMP_BUFFERS_BEFORE_ENQUEUE( kernel, command_queue );
-        DUMP_REPLAYABLE_KERNEL( kernel, command_queue, work_dim, global_work_offset, global_work_size, local_work_size );
         DUMP_IMAGES_BEFORE_ENQUEUE( kernel, command_queue );
+        DUMP_REPLAYABLE_KERNEL( kernel, command_queue, work_dim, global_work_offset, global_work_size, local_work_size );
+        CHECK_FOR_NANS( "Before", kernel, command_queue, work_dim, global_work_size );
         CHECK_AUBCAPTURE_START_KERNEL(
             kernel,
             work_dim,
@@ -4926,6 +4927,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueNDRangeKernel)(
 
         DUMP_BUFFERS_AFTER_ENQUEUE( kernel, command_queue );
         DUMP_IMAGES_AFTER_ENQUEUE( kernel, command_queue );
+        CHECK_FOR_NANS( "After", kernel, command_queue, work_dim, global_work_size );
         FINISH_OR_FLUSH_AFTER_ENQUEUE( command_queue );
         CHECK_AUBCAPTURE_STOP( command_queue );
 


### PR DESCRIPTION
Implements #305 

## Description of Changes

Added a control `DetectNaNs (bool)`, when set to true, it checks all images/buffers which are of floating point type after and before an enqueue to check for NaNs.

## Testing Done

Tested with a buffer example on Windows on Intel iGPU.
Further testing WIP.

```
import numpy as np
import pyopencl as cl

a_np = np.zeros(8).astype(np.float32)
a_np[:] = 0.1

b_np = np.zeros(8).astype(np.int32)
b_np[:] = 10

ctx = cl.create_some_context()
queue = cl.CommandQueue(ctx)

mf = cl.mem_flags
a_g = cl.Buffer(ctx, mf.READ_ONLY | mf.COPY_HOST_PTR, hostbuf=a_np)
b_g = cl.Buffer(ctx, mf.READ_ONLY | mf.COPY_HOST_PTR, hostbuf=b_np)

flags = []
prg1 = cl.Program(ctx, """
__kernel void sum(__global float *res_g)
{
  int gid = get_global_id(0);
  res_g[gid] = 0.0f; 
}
""").build(flags)

prg2 = cl.Program(ctx, """
__kernel void insertNaN(__global float *res_g)
{
  int gid = get_global_id(0);
  res_g[gid] = NAN;
}
""").build(flags)

prg3 = cl.Program(ctx, """
__kernel void makeInt(__global int *res_g)
{
  int gid = get_global_id(0);
  res_g[gid] = 10;
}
""").build(flags)

res_g = cl.Buffer(ctx, mf.READ_WRITE, a_np.nbytes)
knl1 = prg1.sum  # Use this Kernel object for repeated calls
knl1(queue, a_np.shape, None, res_g)
knl1(queue, a_np.shape, None, res_g)
knl1(queue, a_np.shape, None, res_g)

knl2 = prg2.insertNaN
knl2(queue, a_np.shape, None, res_g)

knl1(queue, a_np.shape, None, res_g)
knl1(queue, a_np.shape, None, res_g)
knl3 = prg3.makeInt
knl3(queue, b_np.shape, None, res_g)
knl1(queue, a_np.shape, None, res_g)

knl2(queue, a_np.shape, None, res_g)

knl1(queue, a_np.shape, None, res_g)
```

Gives:

> After kernel: insertNaN, EnqueueCtr: 3, arg_index: 0, data type: float*, has a NaN.
> Before kernel: sum, EnqueueCtr: 4, arg_index: 0, data type: float*, has a NaN.
> After kernel: insertNaN, EnqueueCtr: 8, arg_index: 0, data type: float*, has a NaN.
> Before kernel: sum, EnqueueCtr: 9, arg_index: 0, data type: float*, has a NaN.
