### PR TITLE
Critical bug fix, memory corruption due to typo

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -7458,7 +7458,7 @@ void CLIntercept::dumpKernelInfo(
         dispatch().clGetKernelArgInfo(kernel, idx, CL_KERNEL_ARG_TYPE_NAME, 0, nullptr, &argNameSize);
 
         std::string argName(argNameSize, ' ');
-        int error = dispatch().clGetKernelArgInfo(kernel, idx, CL_KERNEL_ARG_TYPE_NAME, argNameSize, &argName, nullptr);
+        int error = dispatch().clGetKernelArgInfo(kernel, idx, CL_KERNEL_ARG_TYPE_NAME, argNameSize, &argName[0], nullptr);
         if ( error == CL_KERNEL_ARG_INFO_NOT_AVAILABLE )
         {
             log("Note: Kernel Argument info not available for replaying.\n");


### PR DESCRIPTION
Out of bounds memory write due to missing [0]. Now trying to write on the variable instead of the heap allocated buffer.

Interestingly, this was only visible with strings larger than 16 chars due to Small String Optimization.
