### PR TITLE
fix a replay corner case with null kernel handles

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -962,8 +962,8 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateBuffer)(
             size,
             host_ptr );
 
-        if (pIntercept->config().DumpReplayKernelEnqueue != -1 ||
-            pIntercept->config().DumpReplayKernelName != "" )
+        if( pIntercept->config().DumpReplayKernelEnqueue != -1 ||
+            !pIntercept->config().DumpReplayKernelName.empty() )
         {
             // Make sure that there are no device only buffers
             // Since we need them to replay the kernel
@@ -1707,8 +1707,8 @@ CL_API_ENTRY cl_sampler CL_API_CALL CLIRN(clCreateSampler)(
 
         std::string propsStr;
         if( pIntercept->config().CallLogging ||
-            (pIntercept->config().DumpReplayKernelEnqueue != -1) ||
-            (pIntercept->config().DumpReplayKernelName != "") )
+            pIntercept->config().DumpReplayKernelEnqueue != -1 ||
+            !pIntercept->config().DumpReplayKernelName.empty() )
         {
         cl_sampler_properties sampler_properties[] = {
             CL_SAMPLER_NORMALIZED_COORDS, normalized_coords,
@@ -2764,14 +2764,14 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetKernelArg)(
 
         std::string argsString;
         if( pIntercept->config().CallLogging ||
-            (pIntercept->config().DumpReplayKernelEnqueue != -1) ||
-            (pIntercept->config().DumpReplayKernelName != "") )
+            pIntercept->config().DumpReplayKernelEnqueue != -1 ||
+            !pIntercept->config().DumpReplayKernelName.empty() )
         {
-        pIntercept->getKernelArgString(
-            arg_index,
-            arg_size,
-            arg_value,
-            argsString );
+            pIntercept->getKernelArgString(
+                arg_index,
+                arg_size,
+                arg_value,
+                argsString );
         }
         CALL_LOGGING_ENTER_KERNEL(
             kernel,
@@ -2780,7 +2780,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetKernelArg)(
             argsString.c_str() );
 
         if( pIntercept->config().DumpReplayKernelEnqueue != -1 ||
-            pIntercept->config().DumpReplayKernelName != "" )
+            !pIntercept->config().DumpReplayKernelName.empty() )
         {
             if( argsString.find( "CL_SAMPLER_NORMALIZED_COORDS" ) != std::string::npos && arg_value != nullptr )
             {
@@ -4817,7 +4817,13 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clEnqueueNDRangeKernel)(
 
         INCREMENT_ENQUEUE_COUNTER();
         DUMP_BUFFERS_BEFORE_ENQUEUE( kernel, command_queue );
-        DUMP_REPLAYABLE_KERNEL( kernel, command_queue, work_dim, global_work_offset, global_work_size, local_work_size );
+        DUMP_REPLAYABLE_KERNEL(
+            kernel,
+            command_queue,
+            work_dim,
+            global_work_offset,
+            global_work_size,
+            local_work_size );
         DUMP_IMAGES_BEFORE_ENQUEUE( kernel, command_queue );
         CHECK_AUBCAPTURE_START_KERNEL(
             kernel,
@@ -7059,8 +7065,8 @@ CL_API_ENTRY cl_sampler CL_API_CALL CLIRN(clCreateSamplerWithProperties) (
 
         std::string propsStr;
         if( pIntercept->config().CallLogging ||
-            (pIntercept->config().DumpReplayKernelEnqueue != -1) ||
-            (pIntercept->config().DumpReplayKernelName != ""))
+            pIntercept->config().DumpReplayKernelEnqueue != -1 ||
+            !pIntercept->config().DumpReplayKernelName.empty() )
         {
             pIntercept->getSamplerPropertiesString(
                 sampler_properties,

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -7541,12 +7541,17 @@ void CLIntercept::dumpBuffersForKernel(
         OS().GetDumpDirectoryName( sc_DumpDirectoryName, fileNamePrefix );
         fileNamePrefix += "/Replay/Enqueue_";
         if (byKernelName)
+        {
             fileNamePrefix += getShortKernelName(kernel);
+        }
         else
+        {
             fileNamePrefix += std::to_string(enqueueCounter);
+        }
         fileNamePrefix += "/";
         OS().MakeDumpDirectories( fileNamePrefix );
-    } else
+    }
+    else
     {
         // Get the dump directory name.
         {
@@ -7581,7 +7586,8 @@ void CLIntercept::dumpBuffersForKernel(
             if (replay)
             {
                 fileName += "Buffer" + std::to_string(arg_index) + ".bin";
-            } else
+            }
+            else
             {
                 char    tmpStr[ MAX_PATH ];
 
@@ -7781,7 +7787,8 @@ void CLIntercept::dumpImagesForKernel(
             fileNamePrefix += std::to_string(enqueueCounter);
         fileNamePrefix += "/";
         OS().MakeDumpDirectories( fileNamePrefix );
-    } else
+    }
+    else
     {
         // Get the dump directory name.
         {
@@ -7835,7 +7842,8 @@ void CLIntercept::dumpImagesForKernel(
                          << info.Format.image_channel_data_type << '\n'
                          << info.Format.image_channel_order << '\n'
                          << static_cast<int>(info.ImageType);
-            } else
+            }
+            else
             {
                 char    tmpStr[ MAX_PATH ];
 

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -2216,7 +2216,8 @@ inline bool CLIntercept::checkDumpByCounter( uint64_t enqueueCounter ) const
 
 inline bool CLIntercept::checkDumpByName( cl_kernel kernel )
 {
-    return getShortKernelName(kernel) == config().DumpReplayKernelName;
+    return !config().DumpReplayKernelName.empty() &&
+        getShortKernelName(kernel) == config().DumpReplayKernelName;
 }
 
 #define ADD_QUEUE( _context, _queue )                                       \
@@ -2263,9 +2264,9 @@ inline bool CLIntercept::checkDumpByName( cl_kernel kernel )
           pIntercept->config().DumpBuffersAfterMap ||                       \
           pIntercept->config().DumpBuffersBeforeUnmap ||                    \
           pIntercept->config().DumpBuffersBeforeEnqueue ||                  \
-          ( pIntercept->config().DumpReplayKernelEnqueue != -1 ) ||         \
-          ( pIntercept->config().DumpReplayKernelName != "" ) ||            \
-          pIntercept->config().DumpBuffersAfterEnqueue ) )                  \
+          pIntercept->config().DumpBuffersAfterEnqueue  ||                  \
+          pIntercept->config().DumpReplayKernelEnqueue != -1 ||             \
+          !pIntercept->config().DumpReplayKernelName.empty() ) )            \
     {                                                                       \
         pIntercept->addBuffer( _buffer );                                   \
     }
@@ -2274,8 +2275,8 @@ inline bool CLIntercept::checkDumpByName( cl_kernel kernel )
     if( _image &&                                                           \
         ( pIntercept->config().DumpImagesBeforeEnqueue ||                   \
           pIntercept->config().DumpImagesAfterEnqueue ||                    \
-          ( pIntercept->config().DumpReplayKernelEnqueue != -1 ) ||         \
-          ( pIntercept->config().DumpReplayKernelName != "" ) ) )           \
+          pIntercept->config().DumpReplayKernelEnqueue != -1 ||             \
+          !pIntercept->config().DumpReplayKernelName.empty() ) )            \
     {                                                                       \
         pIntercept->addImage( _image );                                     \
     }
@@ -2286,11 +2287,11 @@ inline bool CLIntercept::checkDumpByName( cl_kernel kernel )
           pIntercept->config().DumpBuffersAfterMap ||                       \
           pIntercept->config().DumpBuffersBeforeUnmap ||                    \
           pIntercept->config().DumpBuffersBeforeEnqueue ||                  \
-          ( pIntercept->config().DumpReplayKernelEnqueue != -1 ) ||         \
-          ( pIntercept->config().DumpReplayKernelName != "" ) ||            \
           pIntercept->config().DumpBuffersAfterEnqueue ||                   \
           pIntercept->config().DumpImagesBeforeEnqueue ||                   \
-          pIntercept->config().DumpImagesAfterEnqueue ) )                   \
+          pIntercept->config().DumpImagesAfterEnqueue ||                    \
+          pIntercept->config().DumpReplayKernelEnqueue != -1 ||             \
+          !pIntercept->config().DumpReplayKernelName.empty() ) )            \
     {                                                                       \
         pIntercept->checkRemoveMemObj( _memobj );                           \
     }
@@ -2298,8 +2299,8 @@ inline bool CLIntercept::checkDumpByName( cl_kernel kernel )
 #define ADD_SAMPLER( sampler, str )                                         \
     if( sampler &&                                                          \
         ( pIntercept->config().CallLogging ||                               \
-          ( pIntercept->config().DumpReplayKernelEnqueue != -1 ) ||         \
-          ( pIntercept->config().DumpReplayKernelName != "" ) ) )           \
+          pIntercept->config().DumpReplayKernelEnqueue != -1 ||             \
+          !pIntercept->config().DumpReplayKernelName.empty() ) )            \
     {                                                                       \
         pIntercept->addSamplerString( sampler, str );                       \
     }
@@ -2307,8 +2308,8 @@ inline bool CLIntercept::checkDumpByName( cl_kernel kernel )
 #define REMOVE_SAMPLER( sampler )                                           \
     if( sampler &&                                                          \
         ( pIntercept->config().CallLogging ||                               \
-          ( pIntercept->config().DumpReplayKernelEnqueue != -1 ) ||         \
-          ( pIntercept->config().DumpReplayKernelName != "" ) ) )           \
+          pIntercept->config().DumpReplayKernelEnqueue != -1 ||             \
+          !pIntercept->config().DumpReplayKernelName.empty() ) )            \
     {                                                                       \
         pIntercept->checkRemoveSamplerString( sampler );                    \
     }
@@ -2316,9 +2317,9 @@ inline bool CLIntercept::checkDumpByName( cl_kernel kernel )
 #define ADD_SVM_ALLOCATION( svmPtr, size )                                  \
     if( svmPtr &&                                                           \
         ( pIntercept->config().DumpBuffersBeforeEnqueue ||                  \
-          ( pIntercept->config().DumpReplayKernelEnqueue != -1 ) ||         \
-          ( pIntercept->config().DumpReplayKernelName != "" ) ||            \
-          pIntercept->config().DumpBuffersAfterEnqueue ) )                  \
+          pIntercept->config().DumpBuffersAfterEnqueue ||                   \
+          pIntercept->config().DumpReplayKernelEnqueue != -1 ||             \
+          !pIntercept->config().DumpReplayKernelName.empty() ) )            \
     {                                                                       \
         pIntercept->addSVMAllocation( svmPtr, size );                       \
     }
@@ -2327,8 +2328,8 @@ inline bool CLIntercept::checkDumpByName( cl_kernel kernel )
     if( svmPtr &&                                                           \
         ( pIntercept->config().DumpBuffersBeforeEnqueue ||                  \
           pIntercept->config().DumpBuffersAfterEnqueue ||                   \
-        ( pIntercept->config().DumpReplayKernelEnqueue != -1 ) ||           \
-        ( pIntercept->config().DumpReplayKernelName != "" ) ) )             \
+          pIntercept->config().DumpReplayKernelEnqueue != -1 ||             \
+          !pIntercept->config().DumpReplayKernelName.empty() ) )            \
     {                                                                       \
         pIntercept->removeSVMAllocation( svmPtr );                          \
     }
@@ -2336,9 +2337,9 @@ inline bool CLIntercept::checkDumpByName( cl_kernel kernel )
 #define ADD_USM_ALLOCATION( usmPtr, size )                                  \
     if( usmPtr &&                                                           \
         ( pIntercept->config().DumpBuffersBeforeEnqueue ||                  \
-          ( pIntercept->config().DumpReplayKernelEnqueue != -1 ) ||         \
-          ( pIntercept->config().DumpReplayKernelName != "" ) ||            \
-          pIntercept->config().DumpBuffersAfterEnqueue ) )                  \
+          pIntercept->config().DumpBuffersAfterEnqueue ||                   \
+          pIntercept->config().DumpReplayKernelEnqueue != -1 ||             \
+          !pIntercept->config().DumpReplayKernelName.empty() ) )            \
     {                                                                       \
         pIntercept->addUSMAllocation( usmPtr, size );                       \
     }
@@ -2346,9 +2347,9 @@ inline bool CLIntercept::checkDumpByName( cl_kernel kernel )
 #define REMOVE_USM_ALLOCATION( usmPtr )                                     \
     if( usmPtr &&                                                           \
         ( pIntercept->config().DumpBuffersBeforeEnqueue ||                  \
-          ( pIntercept->config().DumpReplayKernelEnqueue != -1 ) ||         \
-          ( pIntercept->config().DumpReplayKernelName != "" ) ||            \
-          pIntercept->config().DumpBuffersAfterEnqueue ) )                  \
+          pIntercept->config().DumpBuffersAfterEnqueue ||                   \
+          pIntercept->config().DumpReplayKernelEnqueue != -1 ||             \
+          !pIntercept->config().DumpReplayKernelName.empty() ) )            \
     {                                                                       \
         pIntercept->removeUSMAllocation( usmPtr );                          \
     }
@@ -2367,42 +2368,35 @@ inline bool CLIntercept::checkDumpByName( cl_kernel kernel )
         pIntercept->dumpArgument(                                           \
             enqueueCounter, kernel, arg_index, arg_size, arg_value );       \
     }                                                                       \
-    if( ( pIntercept->config().DumpBuffersBeforeEnqueue ||                  \
-          pIntercept->config().DumpBuffersAfterEnqueue ||                   \
-          (pIntercept->config().DumpReplayKernelEnqueue != -1) ||           \
-          ( pIntercept->config().DumpReplayKernelName != "" ) ||            \
-          pIntercept->config().DumpImagesBeforeEnqueue ||                   \
-          pIntercept->config().DumpImagesAfterEnqueue ) &&                  \
-        ( arg_value != NULL ) &&                                            \
-        ( arg_size == sizeof(cl_mem) ) )                                    \
+    if( pIntercept->config().DumpBuffersBeforeEnqueue ||                    \
+        pIntercept->config().DumpBuffersAfterEnqueue ||                     \
+        pIntercept->config().DumpImagesBeforeEnqueue ||                     \
+        pIntercept->config().DumpImagesAfterEnqueue ||                      \
+        pIntercept->config().DumpReplayKernelEnqueue != -1 ||               \
+        !pIntercept->config().DumpReplayKernelName.empty() )                \
     {                                                                       \
-        cl_mem* pMem = (cl_mem*)arg_value;                                  \
-        pIntercept->setKernelArg( kernel, arg_index, pMem[0] );             \
-    }                                                                       \
-    if ( pIntercept->config().DumpBuffersBeforeEnqueue ||                   \
-          pIntercept->config().DumpBuffersAfterEnqueue ||                   \
-          ( pIntercept->config().DumpReplayKernelEnqueue != -1 ) ||         \
-          ( pIntercept->config().DumpReplayKernelName != "" ) ||            \
-          pIntercept->config().DumpImagesBeforeEnqueue ||                   \
-          pIntercept->config().DumpImagesAfterEnqueue )                     \
-    {                                                                       \
+        if( (arg_value != NULL) && (arg_size == sizeof(cl_mem)) )           \
+        {                                                                   \
+            cl_mem* pMem = (cl_mem*)arg_value;                              \
+            pIntercept->setKernelArg( kernel, arg_index, pMem[0] );         \
+        }                                                                   \
         pIntercept->setKernelArg( kernel, arg_index, arg_value, arg_size ); \
     }
 
 #define SET_KERNEL_ARG_SVM_POINTER( kernel, arg_index, arg_value )          \
     if( pIntercept->config().DumpBuffersBeforeEnqueue ||                    \
-        ( pIntercept->config().DumpReplayKernelEnqueue != -1 ) ||           \
-        ( pIntercept->config().DumpReplayKernelName != "" ) ||              \
-        pIntercept->config().DumpBuffersAfterEnqueue )                      \
+        pIntercept->config().DumpBuffersAfterEnqueue ||                     \
+        pIntercept->config().DumpReplayKernelEnqueue != -1 ||               \
+        !pIntercept->config().DumpReplayKernelName.empty() )                \
     {                                                                       \
         pIntercept->setKernelArgSVMPointer( kernel, arg_index, arg_value ); \
     }
 
 #define SET_KERNEL_ARG_USM_POINTER( kernel, arg_index, arg_value )          \
     if( pIntercept->config().DumpBuffersBeforeEnqueue ||                    \
-        ( pIntercept->config().DumpReplayKernelEnqueue != -1 ) ||           \
-        ( pIntercept->config().DumpReplayKernelName != "" ) ||              \
-        pIntercept->config().DumpBuffersAfterEnqueue )                      \
+        pIntercept->config().DumpBuffersAfterEnqueue ||                     \
+        pIntercept->config().DumpReplayKernelEnqueue != -1 ||               \
+        !pIntercept->config().DumpReplayKernelName.empty() )                \
     {                                                                       \
         pIntercept->setKernelArgUSMPointer( kernel, arg_index, arg_value ); \
     }
@@ -2476,31 +2470,40 @@ inline bool CLIntercept::checkDumpByName( cl_kernel kernel )
             "Pre", enqueueCounter, kernel, command_queue, false, false );   \
     }
 
-#define DUMP_BUFFERS_AFTER_ENQUEUE( kernel, command_queue )                     \
-    if(( pIntercept->config().DumpBuffersAfterEnqueue &&                        \
-        pIntercept->checkDumpBufferEnqueueLimits( enqueueCounter ) &&           \
-        pIntercept->dumpBufferForKernel( kernel )) ||                           \
-        (hasDumpedBufferByName && !hasDumpedValidationBufferByName ))           \
-    {                                                                           \
-        hasDumpedValidationBufferByName = true;                                 \
-        pIntercept->dumpBuffersForKernel(                                       \
-            "Post", enqueueCounter, kernel, command_queue, false,               \
-                pIntercept->config().DumpReplayKernelName != "" );              \
+#define DUMP_BUFFERS_AFTER_ENQUEUE( kernel, command_queue )                 \
+    if( ( pIntercept->config().DumpBuffersAfterEnqueue &&                   \
+          pIntercept->checkDumpBufferEnqueueLimits( enqueueCounter ) &&     \
+          pIntercept->dumpBufferForKernel( kernel ) ) ||                    \
+        ( hasDumpedBufferByName && !hasDumpedValidationBufferByName ) )     \
+    {                                                                       \
+        hasDumpedValidationBufferByName = true;                             \
+        pIntercept->dumpBuffersForKernel(                                   \
+            "Post", enqueueCounter, kernel, command_queue, false,           \
+             !pIntercept->config().DumpReplayKernelName.empty() );          \
     }
 
-#define DUMP_REPLAYABLE_KERNEL( kernel, command_queue, work_dim, gws_offset, gws, lws )                        \
-    if ( pIntercept->checkDumpByCounter( enqueueCounter ) ||                                                   \
-        ( pIntercept->checkDumpByName( kernel ) && ( !hasDumpedBufferByName || !hasDumpedImageByName ) ) )     \
-    {                                                                                                          \
-        hasDumpedBufferByName = true;                                                                          \
-        hasDumpedImageByName = true;                                                                           \
-        pIntercept->dumpBuffersForKernel(                                                                      \
-            "", enqueueCounter, kernel, command_queue, true, pIntercept->config().DumpReplayKernelName != "");       \
-        pIntercept->dumpImagesForKernel(                                                                             \
-            "", enqueueCounter, kernel, command_queue, true, pIntercept->config().DumpReplayKernelName != "");       \
-        pIntercept->dumpKernelSourceOrDeviceBinary(kernel, enqueueCounter, pIntercept->config().DumpReplayKernelName != "");       \
-        pIntercept->dumpKernelInfo(kernel, enqueueCounter, work_dim, gws_offset, gws, lws, pIntercept->config().DumpReplayKernelName != ""); \
-        pIntercept->dumpArgumentsForKernel(kernel, enqueueCounter, pIntercept->config().DumpReplayKernelName != ""); \
+#define DUMP_REPLAYABLE_KERNEL( kernel, command_queue, work_dim, gws_offset, gws, lws ) \
+    if ( pIntercept->checkDumpByCounter( enqueueCounter ) ||                \
+        ( pIntercept->checkDumpByName( kernel ) &&                          \
+          ( !hasDumpedBufferByName || !hasDumpedImageByName ) ) )           \
+    {                                                                       \
+        hasDumpedBufferByName = true;                                       \
+        hasDumpedImageByName = true;                                        \
+        pIntercept->dumpBuffersForKernel(                                   \
+            "", enqueueCounter, kernel, command_queue, true,                \
+            !pIntercept->config().DumpReplayKernelName.empty() );           \
+        pIntercept->dumpImagesForKernel(                                    \
+            "", enqueueCounter, kernel, command_queue, true,                \
+            !pIntercept->config().DumpReplayKernelName.empty() );           \
+        pIntercept->dumpKernelSourceOrDeviceBinary(                         \
+            kernel, enqueueCounter,                                         \
+            !pIntercept->config().DumpReplayKernelName.empty() );           \
+        pIntercept->dumpKernelInfo(                                         \
+            kernel, enqueueCounter, work_dim, gws_offset, gws, lws,         \
+            !pIntercept->config().DumpReplayKernelName.empty() );           \
+        pIntercept->dumpArgumentsForKernel(                                 \
+            kernel, enqueueCounter,                                         \
+            !pIntercept->config().DumpReplayKernelName.empty() );           \
     }
 
 #define DUMP_IMAGES_BEFORE_ENQUEUE( kernel, command_queue )                 \
@@ -2515,13 +2518,13 @@ inline bool CLIntercept::checkDumpByName( cl_kernel kernel )
 #define DUMP_IMAGES_AFTER_ENQUEUE( kernel, command_queue )                  \
     if( ( pIntercept->config().DumpImagesAfterEnqueue &&                    \
           pIntercept->checkDumpImageEnqueueLimits( enqueueCounter )  &&     \
-          pIntercept->dumpImagesForKernel( kernel ) ) ||                      \
+          pIntercept->dumpImagesForKernel( kernel ) ) ||                    \
           ( hasDumpedImageByName && !hasDumpedValidationImageByName ) )     \
     {                                                                       \
         hasDumpedValidationImageByName = true;                              \
         pIntercept->dumpImagesForKernel(                                    \
             "Post", enqueueCounter, kernel, command_queue, false,           \
-            pIntercept->config().DumpReplayKernelName != "" );              \
+            !pIntercept->config().DumpReplayKernelName.empty() );           \
     }
 
 #define ADD_MAP_POINTER( _ptr, _flags, _sz )                                \
@@ -2682,7 +2685,7 @@ inline bool CLIntercept::checkAubCaptureEnqueueLimits(
         pIntercept->config().AutoCreateSPIRV ||                             \
         pIntercept->config().AubCaptureUniqueKernels ||                     \
         pIntercept->config().DumpReplayKernelEnqueue != -1 ||               \
-        pIntercept->config().DumpReplayKernelName != "" )                   \
+        !pIntercept->config().DumpReplayKernelName.empty() )                \
     {                                                                       \
         pIntercept->combineProgramStrings(                                  \
             count,                                                          \


### PR DESCRIPTION
## Description of Changes

Fixes an odd corner cases where a null kernel handle would result in an empty kernel name string which would "match" the default empty replay kernel name and try to dump replay information.  Fixed by adding an explicit check for an empty replay kernel name.

Additionally:
* Switches the checks for an empty replay kernel name from a comparison against `""` to a call to `.empty()`, which should be slightly more efficient.
* A bit of tidying up for parentheses and whitespace.

## Testing Done

Tested replay by enqueue number and for a specific kernel name.
