### PR TITLE
add basic support for cl_khr_command_buffer_multi_device

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -13,7 +13,7 @@ extern "C" {
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_command_buffer
 
-// Note: This implements the provisional extension v0.9.0.
+// Note: This implements the provisional extension v0.9.2.
 
 typedef cl_bitfield         cl_device_command_buffer_capabilities_khr;
 typedef struct _cl_command_buffer_khr* cl_command_buffer_khr;
@@ -214,6 +214,36 @@ clGetCommandBufferInfoKHR(
     size_t param_value_size,
     void* param_value,
     size_t* param_value_size_ret) ;
+
+///////////////////////////////////////////////////////////////////////////////
+// cl_khr_command_buffer_multi_device
+
+// Note: This implements the provisional extension v0.9.0.
+
+typedef cl_bitfield         cl_platform_command_buffer_capabilities_khr;
+
+#define CL_PLATFORM_COMMAND_BUFFER_CAPABILITIES_KHR         0x0908
+#define CL_COMMAND_BUFFER_PLATFORM_UNIVERSAL_SYNC_KHR       (1 << 0)
+#define CL_COMMAND_BUFFER_PLATFORM_REMAP_QUEUES_KHR         (1 << 1)
+#define CL_COMMAND_BUFFER_PLATFORM_AUTOMATIC_REMAP_KHR      (1 << 2)
+
+#define CL_DEVICE_COMMAND_BUFFER_NUM_SYNC_DEVICES_KHR       0x12AB
+#define CL_DEVICE_COMMAND_BUFFER_SYNC_DEVICES_KHR           0x12AC
+
+#define CL_COMMAND_BUFFER_CAPABILITY_MULTIPLE_QUEUE_KHR     (1 << 4)
+
+#define CL_COMMAND_BUFFER_DEVICE_SIDE_SYNC_KHR              (1 << 2)
+
+extern CL_API_ENTRY cl_command_buffer_khr CL_API_CALL
+clRemapCommandBufferKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_bool automatic,
+    cl_uint num_queues,
+    const cl_command_queue* queues,
+    cl_uint num_handles,
+    const cl_mutable_command_khr* handles,
+    cl_mutable_command_khr* handles_ret,
+    cl_int* errcode_ret) ;
 
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_command_buffer_mutable_dispatch

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -11176,6 +11176,66 @@ CL_API_ENTRY cl_int CL_API_CALL clGetCommandBufferInfoKHR(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+// cl_khr_command_buffer_multi_device
+CL_API_ENTRY cl_command_buffer_khr CL_API_CALL clRemapCommandBufferKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_bool automatic,
+    cl_uint num_queues,
+    const cl_command_queue* queues,
+    cl_uint num_handles,
+    const cl_mutable_command_khr* handles,
+    cl_mutable_command_khr* handles_ret,
+    cl_int* errcode_ret)
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept )
+    {
+        cl_command_queue queue = num_queues ? queues[0] : NULL;
+        const auto& dispatchX = pIntercept->dispatchX(queue);
+        if( dispatchX.clRemapCommandBufferKHR )
+        {
+            GET_ENQUEUE_COUNTER();
+
+            CALL_LOGGING_ENTER( "command_buffer = %p, %s, num_queues = %u, num_handles = %u",
+                command_buffer,
+                automatic ? "automatic" : "non-automatic",
+                num_queues,
+                num_handles );
+            CHECK_ERROR_INIT( errcode_ret );
+            HOST_PERFORMANCE_TIMING_START();
+
+            cl_command_buffer_khr   retVal = dispatchX.clRemapCommandBufferKHR(
+                command_buffer,
+                automatic,
+                num_queues,
+                queues,
+                num_handles,
+                handles,
+                handles_ret,
+                errcode_ret );
+
+            HOST_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+
+            if( retVal != NULL )
+            {
+                pIntercept->addCommandBufferInfo(
+                    retVal,
+                    queue );
+            }
+
+            return retVal;
+        }
+    }
+
+    NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
 // cl_khr_command_buffer_mutable_dispatch
 CL_API_ENTRY cl_int CL_API_CALL clUpdateMutableCommandsKHR(
     cl_command_buffer_khr command_buffer,

--- a/intercept/src/dispatch.h
+++ b/intercept/src/dispatch.h
@@ -317,6 +317,17 @@ struct CLdispatchX
         void* param_value,
         size_t* param_value_size_ret);
 
+    // cl_khr_command_buffer_multi_device
+    cl_command_buffer_khr (CL_API_CALL *clRemapCommandBufferKHR) (
+        cl_command_buffer_khr command_buffer,
+        cl_bool automatic,
+        cl_uint num_queues,
+        const cl_command_queue* queues,
+        cl_uint num_handles,
+        const cl_mutable_command_khr* handles,
+        cl_mutable_command_khr* handles_ret,
+        cl_int* errcode_ret) ;
+
     // cl_khr_command_buffer_mutable_dispatch
     cl_int (CL_API_CALL *clUpdateMutableCommandsKHR) (
         cl_command_buffer_khr command_buffer,

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -710,6 +710,20 @@ CEnumNameMap::CEnumNameMap()
 
     ADD_ENUM_NAME( m_cl_int, CL_COMMAND_COMMAND_BUFFER_KHR );
 
+    // cl_khr_command_buffer_multi_device
+    ADD_ENUM_NAME( m_cl_int, CL_PLATFORM_COMMAND_BUFFER_CAPABILITIES_KHR );
+
+    ADD_ENUM_NAME( m_cl_platform_command_buffer_capabilities_khr, CL_COMMAND_BUFFER_PLATFORM_UNIVERSAL_SYNC_KHR );
+    ADD_ENUM_NAME( m_cl_platform_command_buffer_capabilities_khr, CL_COMMAND_BUFFER_PLATFORM_REMAP_QUEUES_KHR );
+    ADD_ENUM_NAME( m_cl_platform_command_buffer_capabilities_khr, CL_COMMAND_BUFFER_PLATFORM_AUTOMATIC_REMAP_KHR );
+
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_COMMAND_BUFFER_NUM_SYNC_DEVICES_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_COMMAND_BUFFER_SYNC_DEVICES_KHR );
+
+    ADD_ENUM_NAME( m_cl_device_command_buffer_capabilities_khr, CL_COMMAND_BUFFER_CAPABILITY_MULTIPLE_QUEUE_KHR );
+
+    ADD_ENUM_NAME( m_cl_command_buffer_flags_khr, CL_COMMAND_BUFFER_DEVICE_SIDE_SYNC_KHR );
+
     // cl_khr_command_buffer_mutable_dispatch
     ADD_ENUM_NAME( m_cl_command_buffer_flags_khr, CL_COMMAND_BUFFER_MUTABLE_KHR );
 

--- a/intercept/src/enummap.h
+++ b/intercept/src/enummap.h
@@ -110,6 +110,7 @@ public:
     GENERATE_MAP_AND_BITFIELD_FUNC( name_device_usm_capabilities,    cl_device_unified_shared_memory_capabilities_intel );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_mem_alloc_flags,            cl_mem_alloc_flags_intel        );
     GENERATE_MAP_AND_FUNC(          name_semaphore_type,             cl_semaphore_type_khr           );
+    GENERATE_MAP_AND_BITFIELD_FUNC( name_platform_command_buffer_capabilities, cl_platform_command_buffer_capabilities_khr );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_device_command_buffer_capabilities, cl_device_command_buffer_capabilities_khr );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_command_buffer_flags,       cl_command_buffer_flags_khr     );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_mutable_dispatch_fields,    cl_mutable_dispatch_fields_khr  );

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -12651,6 +12651,9 @@ void* CLIntercept::getExtensionFunctionAddress(
     CHECK_RETURN_EXTENSION_FUNCTION( clCommandNDRangeKernelKHR );
     CHECK_RETURN_EXTENSION_FUNCTION( clGetCommandBufferInfoKHR );
 
+    // cl_khr_command_buffer_mutlti_device
+    CHECK_RETURN_EXTENSION_FUNCTION( clRemapCommandBufferKHR );
+
     // cl_khr_command_buffer_mutable_dispatch
     CHECK_RETURN_EXTENSION_FUNCTION( clUpdateMutableCommandsKHR );
     CHECK_RETURN_EXTENSION_FUNCTION( clGetMutableCommandInfoKHR );

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -12651,7 +12651,7 @@ void* CLIntercept::getExtensionFunctionAddress(
     CHECK_RETURN_EXTENSION_FUNCTION( clCommandNDRangeKernelKHR );
     CHECK_RETURN_EXTENSION_FUNCTION( clGetCommandBufferInfoKHR );
 
-    // cl_khr_command_buffer_mutlti_device
+    // cl_khr_command_buffer_multi_device
     CHECK_RETURN_EXTENSION_FUNCTION( clRemapCommandBufferKHR );
 
     // cl_khr_command_buffer_mutable_dispatch


### PR DESCRIPTION
## Description of Changes

Adds basic support for tracing new enums and APIs for cl_khr_command_buffer_multi_device.

## Testing Done

Basic testing with a stub emulation layer, verified that the new remap API was properly traced.
