### PR TITLE
Open in binary mode to save kernel arguments

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -7494,7 +7494,7 @@ void CLIntercept::dumpArgumentsForKernel(
         const auto pos = arg.first;
         const auto& value = arg.second;
         std::string fileName = fileNamePrefix + "Argument" + std::to_string(pos) + ".bin";
-        std::ofstream out{fileName};
+        std::ofstream out{fileName, std::ios::out | std::ios::binary};
         out.write(reinterpret_cast<char const*>(value.data()), value.size());
     }
 


### PR DESCRIPTION
On Windows, you have to specify opening a file in binary mode when writing binary data such as the kernel arguments.

This resulting into some pointer int4 values being of size 17 instead of 16. Intel happily accepts this, but AMD (rightfully) complains..

## Testing Done

Replay test case.
