### PR TITLE
Improve mutable dispatch logging

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -11273,7 +11273,9 @@ CL_API_ENTRY cl_int CL_API_CALL clUpdateMutableCommandsKHR(
                 pIntercept->getCommandBufferMutableConfigString(
                     mutable_config,
                     configStr );
-                CALL_LOGGING_INFO("mutable_config: %s", configStr.c_str() );
+                CALL_LOGGING_INFO("mutable_config %p: %s",
+                    mutable_config,
+                    configStr.c_str() );
             }
             HOST_PERFORMANCE_TIMING_START();
 

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -1710,15 +1710,15 @@ CL_API_ENTRY cl_sampler CL_API_CALL CLIRN(clCreateSampler)(
             pIntercept->config().DumpReplayKernelEnqueue != -1 ||
             !pIntercept->config().DumpReplayKernelName.empty() )
         {
-        cl_sampler_properties sampler_properties[] = {
-            CL_SAMPLER_NORMALIZED_COORDS, normalized_coords,
-            CL_SAMPLER_ADDRESSING_MODE,   addressing_mode,
-            CL_SAMPLER_FILTER_MODE,       filter_mode,
-            0
-        };
-        pIntercept->getSamplerPropertiesString(
-            sampler_properties,
-            propsStr );
+            cl_sampler_properties sampler_properties[] = {
+                CL_SAMPLER_NORMALIZED_COORDS, normalized_coords,
+                CL_SAMPLER_ADDRESSING_MODE,   addressing_mode,
+                CL_SAMPLER_FILTER_MODE,       filter_mode,
+                0
+            };
+            pIntercept->getSamplerPropertiesString(
+                sampler_properties,
+                propsStr );
         }
 
         CALL_LOGGING_ENTER( "context = %p, properties = [ %s ]",
@@ -11099,11 +11099,26 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandNDRangeKernelKHR(
         {
             GET_ENQUEUE_COUNTER();
 
+            // TODO: Should NullLocalWorkSize or local work size overrides apply
+            // here?
+
+            std::string argsString;
+            if( pIntercept->config().CallLogging )
+            {
+                pIntercept->getEnqueueNDRangeKernelArgsString(
+                    work_dim,
+                    global_work_offset,
+                    global_work_size,
+                    local_work_size,
+                    argsString );
+            }
             CALL_LOGGING_ENTER_KERNEL(
                 kernel,
-                "command_buffer = %p, command_queue = %p",
+                "command_buffer = %p, queue = %p, kernel = %p, %s",
                 command_buffer,
-                command_queue );
+                command_queue,
+                kernel,
+                argsString.c_str() );
             HOST_PERFORMANCE_TIMING_START();
 
             cl_int  retVal = dispatchX.clCommandNDRangeKernelKHR(
@@ -11123,7 +11138,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandNDRangeKernelKHR(
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
             CALL_LOGGING_EXIT( retVal );
-            ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
+            ADD_MUTABLE_COMMAND_NDRANGE( mutable_handle, command_buffer, work_dim );
 
             return retVal;
         }
@@ -11252,6 +11267,14 @@ CL_API_ENTRY cl_int CL_API_CALL clUpdateMutableCommandsKHR(
             CALL_LOGGING_ENTER( "command_buffer = %p, mutable_config = %p",
                 command_buffer,
                 mutable_config );
+            if( pIntercept->config().CallLogging )
+            {
+                std::string configStr;
+                pIntercept->getCommandBufferMutableConfigString(
+                    mutable_config,
+                    configStr );
+                CALL_LOGGING_INFO("mutable_config: %s", configStr.c_str() );
+            }
             HOST_PERFORMANCE_TIMING_START();
 
             cl_int  retVal = dispatchX.clUpdateMutableCommandsKHR(

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -748,8 +748,8 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_int, CL_MUTABLE_DISPATCH_GLOBAL_WORK_SIZE_KHR );
     ADD_ENUM_NAME( m_cl_int, CL_MUTABLE_DISPATCH_LOCAL_WORK_SIZE_KHR );
 
-    // CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR           0
-    // CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR       1
+    ADD_ENUM_NAME( m_cl_command_buffer_structure_type_khr, CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR );
+    ADD_ENUM_NAME( m_cl_command_buffer_structure_type_khr, CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR );
 
     // cl_khr_extended_versioning extension
     // Most enums for this extension were added to OpenCL 3.0.

--- a/intercept/src/enummap.h
+++ b/intercept/src/enummap.h
@@ -113,6 +113,7 @@ public:
     GENERATE_MAP_AND_BITFIELD_FUNC( name_platform_command_buffer_capabilities, cl_platform_command_buffer_capabilities_khr );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_device_command_buffer_capabilities, cl_device_command_buffer_capabilities_khr );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_command_buffer_flags,       cl_command_buffer_flags_khr     );
+    GENERATE_MAP_AND_FUNC(          name_command_buffer_structure_type, cl_command_buffer_structure_type_khr );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_mutable_dispatch_fields,    cl_mutable_dispatch_fields_khr  );
 
     #undef GENERATE_MAP_AND_FUNC

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -2627,7 +2627,7 @@ void CLIntercept::getCommandBufferMutableConfigString(
     if( mutable_config )
     {
         char s[256];
-        CLI_SPRINTF(s, 256, "type = %s (%04X), next = %p, num_mutable_dispatch = %u",
+        CLI_SPRINTF(s, 256, "type = %s (%u), next = %p, num_mutable_dispatch = %u",
             enumName().name_command_buffer_structure_type(mutable_config->type).c_str(),
             mutable_config->type,
             mutable_config->next,
@@ -2638,7 +2638,8 @@ void CLIntercept::getCommandBufferMutableConfigString(
         {
             const cl_mutable_dispatch_config_khr* dispatchConfig =
                 &mutable_config->mutable_dispatch_list[i];
-            CLI_SPRINTF(s, 256, "\n  dispatch config: type = %s (%04X), next = %p, command = %p:",
+            CLI_SPRINTF(s, 256, "\n  dispatch config %u: type = %s (%u), next = %p, command = %p:",
+                i,
                 enumName().name_command_buffer_structure_type(dispatchConfig->type).c_str(),
                 dispatchConfig->type,
                 dispatchConfig->next,

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -2654,40 +2654,70 @@ void CLIntercept::getCommandBufferMutableConfigString(
                     dispatchConfig->work_dim);
                 str += s;
 
-                for( cl_uint a = 0; a < dispatchConfig->num_args; a++ )
+                if( dispatchConfig->num_args != 0 &&
+                    dispatchConfig->arg_list == nullptr )
                 {
-                    const cl_mutable_dispatch_arg_khr* arg =
-                        &dispatchConfig->arg_list[a];
-                    CLI_SPRINTF(s, 256, "\n      arg %u: arg_index = %u, arg_size = %zu, arg_value = %p",
-                        a,
-                        arg->arg_index,
-                        arg->arg_size,
-                        arg->arg_value);
-                    str += s;
+                        CLI_SPRINTF(s, 256, "\n      error: num_args is %u and arg_list is NULL!",
+                            dispatchConfig->num_args);
+                        str += s;
+                }
+                else
+                {
+                    for( cl_uint a = 0; a < dispatchConfig->num_args; a++ )
+                    {
+                        const cl_mutable_dispatch_arg_khr* arg =
+                            &dispatchConfig->arg_list[a];
+                        CLI_SPRINTF(s, 256, "\n      arg %u: arg_index = %u, arg_size = %zu, arg_value = %p",
+                            a,
+                            arg->arg_index,
+                            arg->arg_size,
+                            arg->arg_value);
+                        str += s;
+                    }
                 }
 
-                for( cl_uint a = 0; a < dispatchConfig->num_svm_args; a++ )
+                if( dispatchConfig->num_svm_args != 0 &&
+                    dispatchConfig->arg_svm_list == nullptr )
                 {
-                    const cl_mutable_dispatch_arg_khr* arg =
-                        &dispatchConfig->arg_svm_list[a];
-                    CLI_SPRINTF(s, 256, "\n      svm arg %u: arg_index = %u, arg_value = %p",
-                        a,
-                        arg->arg_index,
-                        arg->arg_value);
-                    str += s;
+                        CLI_SPRINTF(s, 256, "\n      error: num_svm_args is %u and arg_svm_list is NULL!",
+                            dispatchConfig->num_svm_args);
+                        str += s;
+                }
+                else
+                {
+                    for( cl_uint a = 0; a < dispatchConfig->num_svm_args; a++ )
+                    {
+                        const cl_mutable_dispatch_arg_khr* arg =
+                            &dispatchConfig->arg_svm_list[a];
+                        CLI_SPRINTF(s, 256, "\n      svm arg %u: arg_index = %u, arg_value = %p",
+                            a,
+                            arg->arg_index,
+                            arg->arg_value);
+                        str += s;
+                    }
                 }
 
-                for( cl_uint a = 0; a < dispatchConfig->num_exec_infos; a++ )
+                if( dispatchConfig->num_exec_infos != 0 &&
+                    dispatchConfig->exec_info_list == nullptr )
                 {
-                    const cl_mutable_dispatch_exec_info_khr* info =
-                        &dispatchConfig->exec_info_list[a];
-                    CLI_SPRINTF(s, 256, "\n      exec info %u: param_name = %s (%04X), param_value_size = %zu, param_value = %p",
-                        a,
-                        enumName().name(info->param_name).c_str(),
-                        info->param_name,
-                        info->param_value_size,
-                        info->param_value);
-                    str += s;
+                        CLI_SPRINTF(s, 256, "\n      error: num_exec_infos is %u and exec_info_list is NULL!",
+                            dispatchConfig->num_exec_infos);
+                        str += s;
+                }
+                else
+                {
+                    for( cl_uint a = 0; a < dispatchConfig->num_exec_infos; a++ )
+                    {
+                        const cl_mutable_dispatch_exec_info_khr* info =
+                            &dispatchConfig->exec_info_list[a];
+                        CLI_SPRINTF(s, 256, "\n      exec info %u: param_name = %s (%04X), param_value_size = %zu, param_value = %p",
+                            a,
+                            enumName().name(info->param_name).c_str(),
+                            info->param_name,
+                            info->param_value_size,
+                            info->param_value);
+                        str += s;
+                    }
                 }
 
                 if( dispatchConfig->global_work_offset != nullptr ||

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -2667,11 +2667,44 @@ void CLIntercept::getCommandBufferMutableConfigString(
                     {
                         const cl_mutable_dispatch_arg_khr* arg =
                             &dispatchConfig->arg_list[a];
-                        CLI_SPRINTF(s, 256, "\n      arg %u: arg_index = %u, arg_size = %zu, arg_value = %p",
-                            a,
-                            arg->arg_index,
-                            arg->arg_size,
-                            arg->arg_value);
+                        if( ( arg->arg_value != NULL ) &&
+                            ( arg->arg_size == sizeof(cl_mem) ) )
+                        {
+                            cl_mem* pMem = (cl_mem*)arg->arg_value;
+                            CLI_SPRINTF(s, 256, "\n      arg %u: arg_index = %u, arg_size = %zu, arg_value = %p",
+                                a,
+                                arg->arg_index,
+                                arg->arg_size,
+                                pMem[0] );
+                        }
+                        else if( ( arg->arg_value != NULL ) &&
+                                 ( arg->arg_size == sizeof(cl_uint) ) )
+                        {
+                            cl_uint*    pData = (cl_uint*)arg->arg_value;
+                            CLI_SPRINTF(s, 256, "\n      arg %u: arg_index = %u, arg_size = %zu, arg_value = 0x%x",
+                                a,
+                                arg->arg_index,
+                                arg->arg_size,
+                                pData[0]);
+                        }
+                        else if( ( arg->arg_value != NULL ) &&
+                                 ( arg->arg_size == sizeof(cl_ulong) ) )
+                        {
+                            cl_ulong*   pData = (cl_ulong*)arg->arg_value;
+                            CLI_SPRINTF(s, 256, "\n      arg %u: arg_index = %u, arg_size = %zu, arg_value = 0x%" PRIx64,
+                                a,
+                                arg->arg_index,
+                                arg->arg_size,
+                                pData[0]);
+                        }
+                        else
+                        {
+                            CLI_SPRINTF(s, 256, "\n      arg %u: arg_index = %u, arg_size = %zu",
+                                a,
+                                arg->arg_index,
+                                arg->arg_size);
+                        }
+
                         str += s;
                     }
                 }

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -168,6 +168,9 @@ public:
     void    getCommandBufferPropertiesString(
                 const cl_command_buffer_properties_khr* properties,
                 std::string& str ) const;
+    void    getCommandBufferMutableConfigString(
+                const cl_mutable_base_config_khr* mutable_config,
+                std::string& str ) const;
     void    getCreateKernelsInProgramRetString(
                 cl_int retVal,
                 cl_kernel* kernels,
@@ -494,7 +497,8 @@ public:
 
     void    addMutableCommandInfo(
                 cl_mutable_command_khr cmd,
-                cl_command_buffer_khr cmdbuf );
+                cl_command_buffer_khr cmdbuf,
+                cl_uint dim );
 
     void    addSamplerString(
                 cl_sampler sampler,
@@ -1306,7 +1310,13 @@ private:
     typedef std::map< cl_command_buffer_khr, cl_platform_id >   CCommandBufferInfoMap;
     CCommandBufferInfoMap   m_CommandBufferInfoMap;
 
-    typedef std::map< cl_mutable_command_khr, cl_platform_id >  CMutableCommandInfoMap;
+    struct SMutableCommandInfo
+    {
+        cl_platform_id  Platform;
+        cl_uint         WorkDim;
+    };
+
+    typedef std::map< cl_mutable_command_khr, SMutableCommandInfo >  CMutableCommandInfoMap;
     CMutableCommandInfoMap  m_MutableCommandInfoMap;
 
     typedef std::list< cl_mutable_command_khr > CMutableCommandList;
@@ -1676,7 +1686,7 @@ inline cl_platform_id CLIntercept::getPlatform( cl_mutable_command_khr cmd ) con
     CMutableCommandInfoMap::const_iterator iter = m_MutableCommandInfoMap.find(cmd);
     if( iter != m_MutableCommandInfoMap.end() )
     {
-        return iter->second;
+        return iter->second.Platform;
     }
     else
     {
@@ -2357,7 +2367,13 @@ inline bool CLIntercept::checkDumpByName( cl_kernel kernel )
 #define ADD_MUTABLE_COMMAND( pCmd, cmdbuf )                                 \
     if( pCmd && pCmd[0] )                                                   \
     {                                                                       \
-        pIntercept->addMutableCommandInfo( pCmd[0], cmdbuf );               \
+        pIntercept->addMutableCommandInfo( pCmd[0], cmdbuf, 0 );            \
+    }
+
+#define ADD_MUTABLE_COMMAND_NDRANGE( pCmd, cmdbuf, workdim )                \
+    if( pCmd && pCmd[0] )                                                   \
+    {                                                                       \
+        pIntercept->addMutableCommandInfo( pCmd[0], cmdbuf, workdim );      \
     }
 
 #define SET_KERNEL_ARG( kernel, arg_index, arg_size, arg_value )            \


### PR DESCRIPTION
## Description of Changes

Improves call logging for mutable command buffer dispatches.
* Adds call logging for dispatch parameters for `clCommandNDRangeKernelKHR`.
* Adds decoding of the mutable config for `clUpdateMutableCommandsKHR`.

## Testing Done

Tested with the WIP mutable command buffer CTS tests.
