### PR TITLE
fix macros to remove unused variable warnings

### DIFF
--- a/intercept/src/common.h
+++ b/intercept/src/common.h
@@ -75,8 +75,8 @@
     #define CLI_SPRINTF(_s, _sz, _f, ...)   snprintf(_s, _sz, _f, ##__VA_ARGS__)
     #define CLI_VSPRINTF(_s, _sz, _f, _a)   vsnprintf(_s, _sz, _f, _a)
     // TODO: Investigate how to reliably use memcpy_s on Linux:
-    #define CLI_MEMCPY(_d, _dsz, _s, _sz)   memcpy(_d, _s, _sz)
-    #define CLI_STRCAT(_d, _dsz, _s)        strcat(_d, _s)
+    #define CLI_MEMCPY(_d, _dsz, _s, _sz)   ((void)(_dsz), memcpy(_d, _s, _sz))
+    #define CLI_STRCAT(_d, _dsz, _s)        ((void)(_dsz), strcat(_d, _s))
     #define CLI_STRTOK(_s, _d, _c)          strtok_r(_s, _d, _c)
     #define CLI_C_ASSERT(e) typedef char __attribute__((unused)) __C_ASSERT__[(e)?1:-1]
 #endif


### PR DESCRIPTION
## Description of Changes

Minor fixes to memcpy and strcat macros to remove unused variable warnings on Linux and OSX.

## Testing Done

Basic undirected testing, verified warnings were fixed via CI testing.
