### PR TITLE
add units to HostPerformanceTimeLogging

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -5862,10 +5862,10 @@ void CLIntercept::updateHostTimingStats(
     if( config().HostPerformanceTimeLogging )
     {
         uint64_t    numberOfCalls = hostTimingStats.NumberOfCalls;
-        logf( "Host Time for call %u: %s = %u\n",
-            (unsigned int)numberOfCalls,
+        logf( "Host Time for call %" PRIu64 ": %s = %" PRIu64 " ns\n",
+            numberOfCalls,
             key.c_str(),
-            (unsigned int)nsDelta );
+            nsDelta );
     }
 }
 


### PR DESCRIPTION
## Description of Changes

Add units to the output for HostPerformanceTimeLogging so it is clear how long each call took.  Also, print the full 64-bit value, to properly handle outputs greater than 4B ns (~4s).

## Testing Done

Tested with a simple application with HostPerformanceTimeLogging.
