### PR TITLE
add enums for cl_khr_device_uuid to the enum map

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -501,6 +501,15 @@ cl_int CL_API_CALL clEnqueueReleaseD3D11ObjectsKHR(
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
+// cl_khr_device_uuid
+
+#define CL_DEVICE_UUID_KHR                                  0x106A
+#define CL_DRIVER_UUID_KHR                                  0x106B
+#define CL_DEVICE_LUID_VALID_KHR                            0x106C
+#define CL_DEVICE_LUID_KHR                                  0x106D
+#define CL_DEVICE_NODE_MASK_KHR                             0x106E
+
+///////////////////////////////////////////////////////////////////////////////
 // cl_khr_dx9_media_sharing
 
 #if defined(_WIN32)

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -656,6 +656,13 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_int, CL_COMMAND_RELEASE_D3D11_OBJECTS_KHR );
 #endif
 
+    // cl_khr_device_uuid
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_UUID_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_DRIVER_UUID_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_LUID_VALID_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_LUID_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_NODE_MASK_KHR );
+
 #if defined(_WIN32)
     // cl_khr_dx9_media_sharing
     ADD_ENUM_NAME( m_cl_int, CL_INVALID_DX9_MEDIA_ADAPTER_KHR );


### PR DESCRIPTION
## Description of Changes

Adds UUID enums for `cl_khr_device_uuid` to the enum map.  This enables these enums to be decoded by CallLogging.

## Testing Done

Tested with `clinfo`, which queries the device and driver UUIDs.
