### PR TITLE
update chome tracing for the newer perfetto ui

### DIFF
--- a/intercept/src/chrometracer.cpp
+++ b/intercept/src/chrometracer.cpp
@@ -149,7 +149,7 @@ void CChromeTracer::writeDeviceTiming(
     if( m_AddFlowEvents )
     {
         int size = CLI_SPRINTF(m_StringBuffer, CLI_STRING_BUFFER_SIZE,
-            "{\"ph\":\"f\",\"pid\":%" PRIu64 ",\"tid\":-%u,\"name\":\"Command\""
+            "{\"ph\":\"f\",\"pid\":%" PRIu64 ",\"tid\":0.%u,\"name\":\"Command\""
             ",\"cat\":\"Commands\",\"ts\":%.3f,\"id\":%" PRIu64 "},\n",
             m_ProcessId,
             queueNumber,
@@ -159,7 +159,7 @@ void CChromeTracer::writeDeviceTiming(
     }
 
     int size = CLI_SPRINTF(m_StringBuffer, CLI_STRING_BUFFER_SIZE,
-        "{\"ph\":\"X\",\"pid\":%" PRIu64 ",\"tid\":-%u,\"name\":\"%s\""
+        "{\"ph\":\"X\",\"pid\":%" PRIu64 ",\"tid\":0.%u,\"name\":\"%s\""
         ",\"ts\":%.3f,\"dur\":%.3f,\"args\":{\"id\":%" PRIu64 "}},\n",
         m_ProcessId,
         queueNumber,

--- a/intercept/src/chrometracer.cpp
+++ b/intercept/src/chrometracer.cpp
@@ -149,7 +149,7 @@ void CChromeTracer::writeDeviceTiming(
     if( m_AddFlowEvents )
     {
         int size = CLI_SPRINTF(m_StringBuffer, CLI_STRING_BUFFER_SIZE,
-            "{\"ph\":\"f\",\"pid\":%" PRIu64 ",\"tid\":0.%u,\"name\":\"Command\""
+            "{\"ph\":\"f\",\"pid\":%" PRIu64 ",\"tid\":%u.1,\"name\":\"Command\""
             ",\"cat\":\"Commands\",\"ts\":%.3f,\"id\":%" PRIu64 "},\n",
             m_ProcessId,
             queueNumber,
@@ -159,7 +159,7 @@ void CChromeTracer::writeDeviceTiming(
     }
 
     int size = CLI_SPRINTF(m_StringBuffer, CLI_STRING_BUFFER_SIZE,
-        "{\"ph\":\"X\",\"pid\":%" PRIu64 ",\"tid\":0.%u,\"name\":\"%s\""
+        "{\"ph\":\"X\",\"pid\":%" PRIu64 ",\"tid\":%u.1,\"name\":\"%s\""
         ",\"ts\":%.3f,\"dur\":%.3f,\"args\":{\"id\":%" PRIu64 "}},\n",
         m_ProcessId,
         queueNumber,

--- a/intercept/src/chrometracer.h
+++ b/intercept/src/chrometracer.h
@@ -81,12 +81,12 @@ public:
     {
         m_TraceFile
             << "{\"ph\":\"M\", \"name\":\"thread_name\", \"pid\":" << m_ProcessId
-            << ", \"tid\":-" << queueNumber
+            << ", \"tid\":0." << queueNumber
             << ", \"args\":{\"name\":\"" << queueName
             << "\"}},\n";
         m_TraceFile
             << "{\"ph\":\"M\", \"name\":\"thread_sort_index\", \"pid\":" << m_ProcessId
-            << ", \"tid\":-" << queueNumber
+            << ", \"tid\":0." << queueNumber
             << ", \"args\":{\"sort_index\":\"" << queueNumber
             << "\"}},\n";
     }

--- a/intercept/src/chrometracer.h
+++ b/intercept/src/chrometracer.h
@@ -81,13 +81,13 @@ public:
     {
         m_TraceFile
             << "{\"ph\":\"M\", \"name\":\"thread_name\", \"pid\":" << m_ProcessId
-            << ", \"tid\":0." << queueNumber
-            << ", \"args\":{\"name\":\"" << queueName
+            << ", \"tid\":" << queueNumber
+            << ".1, \"args\":{\"name\":\"" << queueName
             << "\"}},\n";
         m_TraceFile
             << "{\"ph\":\"M\", \"name\":\"thread_sort_index\", \"pid\":" << m_ProcessId
-            << ", \"tid\":0." << queueNumber
-            << ", \"args\":{\"sort_index\":\"" << queueNumber
+            << ", \"tid\":" << queueNumber
+            << ".1, \"args\":{\"sort_index\":\"" << queueNumber
             << "\"}},\n";
     }
 


### PR DESCRIPTION
## Description of Changes

The current method of numbering chrome tracing device queues with a negative "thread number" works well with the `chrome://tracing` interface, but doesn't work well with the newer `ui.perfetto.dev` interface.  Switching to a "thread number" with a decimal point appears to work just as well with the `chrome://tracing` interface and mostly works well with the newer `ui.perfetto.dev` interface also, unless the device queue number has the same thread ID as a host thread, and even then it's not terrible.  So, switch to decimal thread numbers instead.

## Testing Done

Tested with the queueexperiments sample.  Verified that output looks good both through `chrome://tracing` and `ui.perfetto.dev`, and even looks OK (but not perfect) if the device thread number matches the host thread number.
