### PR TITLE
add a gettid workaround for older versions of glibc

### DIFF
--- a/intercept/OS/OS_linux_common.h
+++ b/intercept/OS/OS_linux_common.h
@@ -30,6 +30,14 @@
 #include <libutil.h>
 #endif
 
+#if defined(__linux__)
+// Workaround for older glibc versions that do not have gettid:
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
+    #include <sys/syscall.h>
+    #define gettid() syscall(SYS_gettid)
+#endif
+#endif
+
 /*****************************************************************************\
 
 MACRO:


### PR DESCRIPTION
## Description of Changes

A per the manual page for gettid(), library support was added in glibc 2.30.  For older versions of glibc we can use a syscall directly, instead.

## Testing Done

I don't have a way to test this directly, but I was helping someone to build the OpenCL intercept layer on a system with an older glibc and this solution worked for them.
