### PR TITLE
add device performance timing check on a blocking free

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -9914,6 +9914,8 @@ clMemBlockingFreeINTEL(
             REMOVE_USM_ALLOCATION( ptr );
             CHECK_ERROR( retVal );
             CALL_LOGGING_EXIT( retVal );
+            DEVICE_PERFORMANCE_TIMING_CHECK();
+            FLUSH_CHROME_TRACE_BUFFERING();
 
             return retVal;
         }


### PR DESCRIPTION
## Description of Changes

Because a blocking free is a synchronizing event we should check for finished device performance timing events and flush buffered chrome tracing events on a call to a blocking free.

## Testing Done

Tested with an application that did a blocking free without a call to other synchronizing events.  Observed that all device performance timing events were properly included in the report.
