### PR TITLE
track cloned kernels as kernel object allocations

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -7279,6 +7279,7 @@ CL_API_ENTRY cl_kernel CL_API_CALL CLIRN(clCloneKernel) (
 
         HOST_PERFORMANCE_TIMING_END();
         CHECK_ERROR( errcode_ret[0] );
+        ADD_OBJECT_ALLOCATION( retVal );
         CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
         if( retVal != NULL )


### PR DESCRIPTION
## Description of Changes

clCloneKernel creates a new kernel object so it should be considered a kernel object allocation.  If it does not, object tracking for LeakChecking will not behave properly.

## Testing Done

Tested with a new OpenCL SDK sample that calls clCloneKernel.