### PR TITLE
add device perf timing check when a context refcount reaches zero

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -621,6 +621,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseContext)(
         CHECK_ERROR( retVal );
         ADD_OBJECT_RELEASE( context );
         CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", --ref_count );
+        DEVICE_PERFORMANCE_TIMING_CHECK_CONDITIONAL( ref_count == 0 );
+        FLUSH_CHROME_TRACE_BUFFERING_CONDITIONAL( ref_count == 0 );
 
 #if 0
         pIntercept->report();

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -3295,7 +3295,7 @@ inline void CLIntercept::flushChromeTraceBuffering()
     {                                                                       \
         TOOL_OVERHEAD_TIMING_START();                                       \
         pIntercept->flushChromeTraceBuffering();                            \
-        TOOL_OVERHEAD_TIMING_END( "(chrome trace flush overhead) ");        \
+        TOOL_OVERHEAD_TIMING_END( "(chrome trace flush overhead)" );        \
     }
 
 #define FLUSH_CHROME_TRACE_BUFFERING_CONDITIONAL( _condition )              \
@@ -3307,7 +3307,7 @@ inline void CLIntercept::flushChromeTraceBuffering()
     {                                                                       \
         TOOL_OVERHEAD_TIMING_START();                                       \
         pIntercept->flushChromeTraceBuffering();                            \
-        TOOL_OVERHEAD_TIMING_END( "(chrome trace flush overhead) ");        \
+        TOOL_OVERHEAD_TIMING_END( "(chrome trace flush overhead)" );        \
     }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description of Changes

Adds a device performance timing check and flush chrome trace buffering if a context reference count reaches zero, so the context is eligible for deletion.  This may allow some applications that do not explicitly end with a call to clFinish on all command queues to emit additional device performance timing information.

## Testing Done

Tested with the new OpenCL SDK callback sample that does not necessarily call clFinish or any other blocking operation.