### PR TITLE
add support for querying kernel register counts

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -1765,6 +1765,11 @@ cl_int CL_API_CALL clGetKernelSuggestedLocalWorkSizeINTEL(
     const size_t *globalWorkSize,
     size_t *suggestedLocalWorkSize);
 
+///////////////////////////////////////////////////////////////////////////////
+// Unofficial cl_intel_maximum_registers extension:
+
+#define CL_KERNEL_REGISTER_COUNT_INTEL 0x425B
+
 #ifdef __cplusplus
 }
 #endif

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -3407,6 +3407,14 @@ void CLIntercept::logKernelInfo(
                     sizeof(sms),
                     &sms,
                     NULL );
+                cl_uint regCount = 0;
+                cl_int errorCode_regCount = dispatch().clGetKernelWorkGroupInfo(
+                    kernel,
+                    deviceList[i],
+                    CL_KERNEL_REGISTER_COUNT_INTEL,
+                    sizeof(regCount),
+                    &regCount,
+                    NULL );
                 if( errorCode == CL_SUCCESS )
                 {
                     logf( "    For device: %s\n",
@@ -3433,6 +3441,10 @@ void CLIntercept::logKernelInfo(
                         if( errorCode_sms == CL_SUCCESS )
                         {
                             logf( "        Spill Mem Size: %u\n", (cl_uint)sms);
+                        }
+                        if( errorCode_regCount == CL_SUCCESS )
+                        {
+                            logf( "        Register Count: %u\n", regCount);
                         }
                     }
                 }
@@ -5802,6 +5814,20 @@ void CLIntercept::getTimingTagsKernel(
                 if( simd )
                 {
                     ss << " SIMD" << simd;
+                }
+            }
+            {
+                cl_uint regCount = 0;
+                dispatch().clGetKernelWorkGroupInfo(
+                    kernel,
+                    device,
+                    CL_KERNEL_REGISTER_COUNT_INTEL,
+                    sizeof(regCount),
+                    &regCount,
+                    NULL );
+                if( regCount )
+                {
+                    ss << " REG" << regCount;
                 }
             }
             {


### PR DESCRIPTION
## Description of Changes

Adds support for an informal register count query.  If the implementation supports the informal register count query then the number of registers used by a kernel for a device are printed as part of KernelInfoLogging and verbose device timing.

## Testing Done

Tested with a simple application and a custom build that supports the register count query, because no released drivers support this query at the moment.
