### PR TITLE
clarify that kernel info logging is reporting the max work group size

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -3430,7 +3430,7 @@ void CLIntercept::logKernelInfo(
                     }
                     if( config().KernelInfoLogging )
                     {
-                        logf( "        Work Group Size: %zu\n", wgs);
+                        logf( "        Max Work Group Size: %zu\n", wgs);
                         if( rwgs[0] != 0 || rwgs[1] != 0 || rwgs[2] != 0 )
                         {
                             logf( "        Required Work Group Size: < %zu, %zu, %zu >\n",


### PR DESCRIPTION
## Description of Changes

Clarifies that the value reported by kernel info logging is the maximum work-group size supported by the kernel, even though the enum for the query is `CL_KERNEL_WORK_GROUP_SIZE`.

## Testing Done

Ran an application with kernel info logging enabled and viewed the modified label.
