### PR TITLE
use .spvasm instead of .spvt for disassembled SPIR-V files

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -5061,7 +5061,7 @@ void CLIntercept::dumpProgramSPIRV(
             {
                 std::string command =
                     config().SPIRVDis +
-                    " -o " + fileName + "t" +
+                    " -o " + fileName + "asm" +
                     " " + fileName;
 
                 logf( "Running: %s\n", command.c_str() );
@@ -10307,7 +10307,7 @@ void CLIntercept::autoCreateSPIRV(
     {
         command =
             config().SPIRVDis +
-            " -o " + outputFileName + "t" +
+            " -o " + outputFileName + "asm" +
             " " + outputFileName;
 
         logf( "Running: %s\n", command.c_str() );


### PR DESCRIPTION
## Description of Changes

Use .spvasm as the file extension for disassembled SPIR-V files.  This is a much more common file extension than the previous .spvt extension and is more easily recognized by e.g. SPIR-V syntax highlighters.

## Testing Done

Dumped SPIR-V files and verified that the disassembled SPIR-V files had the intended .spvasm extension.
