### PR TITLE
minor updates for recent extensions

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -273,7 +273,7 @@ clRemapCommandBufferKHR(
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_command_buffer_mutable_dispatch
 
-// Note: This implements the provisional extension v0.9.0.
+// Note: This implements the provisional extension v0.9.1.
 
 typedef cl_uint             cl_command_buffer_structure_type_khr;
 typedef cl_bitfield         cl_mutable_dispatch_fields_khr;
@@ -309,6 +309,7 @@ typedef struct _cl_mutable_base_config_khr {
     cl_uint num_mutable_dispatch;
     const cl_mutable_dispatch_config_khr* mutable_dispatch_list;
 } cl_mutable_base_config_khr;
+typedef cl_bitfield         cl_mutable_dispatch_asserts_khr;
 
 #define CL_COMMAND_BUFFER_MUTABLE_KHR                       (1 << 1)
 
@@ -335,6 +336,12 @@ typedef struct _cl_mutable_base_config_khr {
 
 #define CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR           0
 #define CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR       1
+
+#define CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR      0x12B7
+
+#define CL_MUTABLE_DISPATCH_ASSERTS_KHR                     0x12B8
+
+#define CL_MUTABLE_DISPATCH_ASSERT_NO_ADDITIONAL_WORK_GROUPS_KHR (1 << 0)
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clUpdateMutableCommandsKHR(
@@ -646,16 +653,17 @@ typedef struct _cl_name_version_khr
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_external_memory
 
-// Note: This implements the provisional extension v0.9.0.
+// Note: This implements the provisional extension v0.9.3.
 
 typedef cl_uint             cl_external_memory_handle_type_khr;
 
 #define CL_PLATFORM_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR      0x2044
 
 #define CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR        0x204F
+#define CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR 0x2052
 
-#define CL_DEVICE_HANDLE_LIST_KHR                                0x2051
-#define CL_DEVICE_HANDLE_LIST_END_KHR                            0
+#define CL_MEM_DEVICE_HANDLE_LIST_KHR                            0x2051
+#define CL_MEM_DEVICE_HANDLE_LIST_END_KHR                        0
 
 #define CL_COMMAND_ACQUIRE_EXTERNAL_MEM_OBJECTS_KHR              0x2047
 #define CL_COMMAND_RELEASE_EXTERNAL_MEM_OBJECTS_KHR              0x2048
@@ -709,6 +717,8 @@ typedef cl_uint             cl_external_semaphore_handle_type_khr;
 #define CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR                0x203F
 #define CL_SEMAPHORE_EXPORT_HANDLE_TYPES_LIST_END_KHR       0
 
+#define CL_SEMAPHORE_EXPORTABLE_KHR                         0x2054
+
 extern CL_API_ENTRY cl_int CL_API_CALL
 clGetSemaphoreHandleForTypeKHR(
     cl_semaphore_khr semaphore,
@@ -726,6 +736,14 @@ clGetSemaphoreHandleForTypeKHR(
 
 // cl_khr_external_semaphore_sync_fd
 #define CL_SEMAPHORE_HANDLE_SYNC_FD_KHR                     0x2058
+
+typedef cl_properties       cl_semaphore_reimport_properties_khr;
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clReImportSemaphoreSyncFdKHR(
+    cl_semaphore_khr sema_object,
+    cl_semaphore_reimport_properties_khr* reimport_props,
+    int fd);
 
 // cl_khr_external_semaphore_win32
 #define CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KHR                0x2056
@@ -782,6 +800,9 @@ cl_program CL_API_CALL clCreateProgramWithILKHR(
 
 #define CL_CONTEXT_MEMORY_INITIALIZE_KHR            0x2030
 
+#define CL_CONTEXT_MEMORY_INITIALIZE_LOCAL_KHR              (1 << 0)
+#define CL_CONTEXT_MEMORY_INITIALIZE_PRIVATE_KHR            (1 << 1)
+
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_integer_dot_product
 
@@ -834,9 +855,8 @@ typedef cl_ulong cl_semaphore_payload_khr;
 #define CL_SEMAPHORE_PAYLOAD_KHR                                 0x203C
 #define CL_SEMAPHORE_TYPE_KHR                                    0x203D
 
-// Shared with cl_khr_external_memory:
-//#define CL_DEVICE_HANDLE_LIST_KHR                              0x2051
-//#define CL_DEVICE_HANDLE_LIST_END_KHR                          0
+#define CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR                      0x2053
+#define CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR                  0
 
 #define CL_COMMAND_SEMAPHORE_WAIT_KHR                            0x2042
 #define CL_COMMAND_SEMAPHORE_SIGNAL_KHR                          0x2043
@@ -1086,10 +1106,15 @@ cl_int CL_API_CALL clGetImageRequirementsInfoEXT(
 #define CL_DEVICE_SCHEDULING_WORKGROUP_BATCH_SIZE_ARM           (1 << 1)
 #define CL_DEVICE_SCHEDULING_WORKGROUP_BATCH_SIZE_MODIFIER_ARM  (1 << 2)
 #define CL_DEVICE_SCHEDULING_DEFERRED_FLUSH_ARM                 (1 << 3)
+#define CL_DEVICE_SCHEDULING_REGISTER_ALLOCATION_ARM            (1 << 4)
+#define CL_DEVICE_SCHEDULING_WARP_THROTTLING_ARM                (1 << 5)
+#define CL_DEVICE_SCHEDULING_COMPUTE_UNIT_BATCH_QUEUE_SIZE_ARM  (1 << 6)
+#define CL_DEVICE_SCHEDULING_COMPUTE_UNIT_LIMIT_ARM             (1 << 7)
 #define CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_ARM            0x41E5
 #define CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_MODIFIER_ARM   0x41E6
 #define CL_QUEUE_KERNEL_BATCHING_ARM                            0x41E7
 #define CL_QUEUE_DEFERRED_FLUSH_ARM                             0x41EC
+#define CL_QUEUE_COMPUTE_UNIT_LIMIT_ARM                         0x41F3
 
 ///////////////////////////////////////////////////////////////////////////////
 // cl_intel_accelerator

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -11161,6 +11161,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandNDRangeKernelKHR(
             std::string argsString;
             if( pIntercept->config().CallLogging )
             {
+                // TODO: properties string.
                 pIntercept->getEnqueueNDRangeKernelArgsString(
                     work_dim,
                     global_work_offset,

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -758,6 +758,12 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_command_buffer_structure_type_khr, CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR );
     ADD_ENUM_NAME( m_cl_command_buffer_structure_type_khr, CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR );
 
+    ADD_ENUM_NAME( m_cl_int, CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR );
+
+    ADD_ENUM_NAME( m_cl_int, CL_MUTABLE_DISPATCH_ASSERTS_KHR );
+
+    ADD_ENUM_NAME( m_cl_mutable_dispatch_asserts_khr, CL_MUTABLE_DISPATCH_ASSERT_NO_ADDITIONAL_WORK_GROUPS_KHR );
+
     // cl_khr_extended_versioning extension
     // Most enums for this extension were added to OpenCL 3.0.
     //CL_PLATFORM_NUMERIC_VERSION_KHR                  0x0906
@@ -771,7 +777,8 @@ CEnumNameMap::CEnumNameMap()
     // cl_khr_external_memory
     ADD_ENUM_NAME( m_cl_int, CL_PLATFORM_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR );
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR );
-    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_HANDLE_LIST_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_MEM_DEVICE_HANDLE_LIST_KHR );
     ADD_ENUM_NAME( m_cl_int, CL_COMMAND_ACQUIRE_EXTERNAL_MEM_OBJECTS_KHR );
     ADD_ENUM_NAME( m_cl_int, CL_COMMAND_RELEASE_EXTERNAL_MEM_OBJECTS_KHR );
 
@@ -797,6 +804,7 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR );
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR );
     ADD_ENUM_NAME( m_cl_int, CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_SEMAPHORE_EXPORTABLE_KHR );
 
     // cl_khr_external_semaphore_dx_fence
     ADD_ENUM_NAME( m_cl_int, CL_SEMAPHORE_HANDLE_D3D12_FENCE_KHR );
@@ -843,8 +851,7 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_int, CL_SEMAPHORE_PROPERTIES_KHR );
     ADD_ENUM_NAME( m_cl_int, CL_SEMAPHORE_PAYLOAD_KHR );
     ADD_ENUM_NAME( m_cl_int, CL_SEMAPHORE_TYPE_KHR );
-    // Shared with cl_khr_external_memory:
-    //CL_DEVICE_HANDLE_LIST_KHR                      0x2051
+    ADD_ENUM_NAME( m_cl_int, CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR );
     ADD_ENUM_NAME( m_cl_int, CL_COMMAND_SEMAPHORE_WAIT_KHR );
     ADD_ENUM_NAME( m_cl_int, CL_COMMAND_SEMAPHORE_SIGNAL_KHR );
     ADD_ENUM_NAME( m_cl_int, CL_INVALID_SEMAPHORE_KHR );
@@ -955,6 +962,7 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_int, CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_MODIFIER_ARM );
     ADD_ENUM_NAME( m_cl_int, CL_QUEUE_KERNEL_BATCHING_ARM );
     ADD_ENUM_NAME( m_cl_int, CL_QUEUE_DEFERRED_FLUSH_ARM );
+    ADD_ENUM_NAME( m_cl_int, CL_QUEUE_COMPUTE_UNIT_LIMIT_ARM );
 
     // cl_intel_accelerator
     ADD_ENUM_NAME( m_cl_int, CL_INVALID_ACCELERATOR_INTEL );

--- a/intercept/src/enummap.h
+++ b/intercept/src/enummap.h
@@ -115,6 +115,7 @@ public:
     GENERATE_MAP_AND_BITFIELD_FUNC( name_command_buffer_flags,       cl_command_buffer_flags_khr     );
     GENERATE_MAP_AND_FUNC(          name_command_buffer_structure_type, cl_command_buffer_structure_type_khr );
     GENERATE_MAP_AND_BITFIELD_FUNC( name_mutable_dispatch_fields,    cl_mutable_dispatch_fields_khr  );
+    GENERATE_MAP_AND_BITFIELD_FUNC( name_mutable_dispatch_asserts,   cl_mutable_dispatch_asserts_khr );
 
     #undef GENERATE_MAP_AND_FUNC
     #undef GENERATE_MAP_AND_BITFIELD_FUNC

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -2386,15 +2386,15 @@ void CLIntercept::getMemPropertiesString(
 
             switch( property )
             {
-            case CL_DEVICE_HANDLE_LIST_KHR:
+            case CL_MEM_DEVICE_HANDLE_LIST_KHR:
                 {
                     ++properties;
                     str += "{ ";
                     while( true )
                     {
-                        if( *properties == CL_DEVICE_HANDLE_LIST_END_KHR )
+                        if( *properties == CL_MEM_DEVICE_HANDLE_LIST_END_KHR )
                         {
-                            str += "CL_DEVICE_HANDLE_LIST_END_KHR";
+                            str += "CL_MEM_DEVICE_HANDLE_LIST_END_KHR";
                             properties++;
                             break;
                         }
@@ -2499,15 +2499,16 @@ void CLIntercept::getSemaphorePropertiesString(
                     properties += 2;
                 }
                 break;
-            case CL_DEVICE_HANDLE_LIST_KHR:
+            case CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR:
+            case CL_MEM_DEVICE_HANDLE_LIST_KHR: // for older implementations, with shared enums.
                 {
                     ++properties;
                     str += "{ ";
                     while( true )
                     {
-                        if( *properties == CL_DEVICE_HANDLE_LIST_END_KHR )
+                        if( *properties == CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR )
                         {
-                            str += "CL_DEVICE_HANDLE_LIST_END_KHR";
+                            str += "CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR";
                             properties++;
                             break;
                         }
@@ -2598,6 +2599,13 @@ void CLIntercept::getCommandBufferPropertiesString(
                 {
                     auto pt = (const cl_command_buffer_flags_khr*)( properties + 1 );
                     str += enumName().name_command_buffer_flags( pt[0] );
+                    properties += 2;
+                }
+                break;
+            case CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR:
+                {
+                    auto pt = (const cl_mutable_dispatch_asserts_khr*)( properties + 1 );
+                    str += enumName().name_mutable_dispatch_asserts( pt[0] );
                     properties += 2;
                 }
                 break;


### PR DESCRIPTION
## Description of Changes

* Add support for mutable dispatch asserts.
* Disambiguate external memory and semaphore device handle lists.
* Add CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR.
* Add CL_SEMAPHORE_EXPORTABLE_KHR.
* Add CL_QUEUE_COMPUTE_UNIT_LIMIT_ARM.

## Testing Done

Visual inspection, ran external memory sample, ran command buffer CTS tests.