### PR TITLE
adds cliloader options to capture enqeues or kernels

### DIFF
--- a/cliloader/cliloader.cpp
+++ b/cliloader/cliloader.cpp
@@ -497,6 +497,30 @@ static bool parseArguments(int argc, char *argv[])
         {
             checkSetEnv("CLI_LeakChecking", "1");
         }
+        else if( !strcmp(argv[i], "--capture-enqueue") )
+        {
+            ++i;
+            if( i < argc )
+            {
+                checkSetEnv("CLI_CaptureReplay", "1");
+                checkSetEnv("CLI_InitializeBuffers", "1");
+                checkSetEnv("CLI_AppendBuildOptions", "-cl-kernel-arg-info");
+                checkSetEnv("CLI_CaptureReplayMinEnqueue", argv[i]);
+                checkSetEnv("CLI_CaptureReplayMaxEnqueue", argv[i]);
+            }
+        }
+        else if( !strcmp(argv[i], "--capture-kernel") )
+        {
+            ++i;
+            if( i < argc )
+            {
+                checkSetEnv("CLI_CaptureReplay", "1");
+                checkSetEnv("CLI_InitializeBuffers", "1");
+                checkSetEnv("CLI_AppendBuildOptions", "-cl-kernel-arg-info");
+                checkSetEnv("CLI_CaptureReplayKernelName", argv[i]);
+                checkSetEnv("CLI_CaptureReplayNumKernelEnqueuesCapture", "1");
+            }
+        }
         else if( !strcmp(argv[i], "-f") || !strcmp(argv[i], "--output-to-file") )
         {
             checkSetEnv("CLI_LogToFile", "1");
@@ -586,6 +610,8 @@ static bool parseArguments(int argc, char *argv[])
             "  --mdapi-tbs                      Report Time-Based MDAPI Metrics (Intel GPU Only)\n"
             "  --mdapi-group <NAME>             Choose MDAPI Metrics to Collect (Intel GPU Only)\n"
             "  --host-timing [-h]               Report Host API Execution Time\n"
+            "  --capture-enqueue <NUMBER>       Capture the Specified Kernel Enqueue\n"
+            "  --capture-kernel <NAME>          Capture the Specified Kernel Name\n"
             "  --leak-checking [-l]             Track and Report OpenCL Leaks\n"
             "  --output-to-file [-f]            Log and Report to Files vs. stderr\n"
             "  --dump-dir <DIR>                 Specify the dump directory for log and report files,\n"


### PR DESCRIPTION
## Description of Changes

Adds two cliloader options for capturing kernel enqueues by number or kernels by name.  These two options provide similar functionality as the capture_and_validate script using the familiar cliloader interface, albeit without any validation functionality.

## Testing Done

Verified that kernels could be captured by enqueue number and by name, as expected.
