### PR TITLE
handle a command buffer creation negative test case

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -10351,7 +10351,7 @@ CL_API_ENTRY cl_command_buffer_khr CL_API_CALL clCreateCommandBufferKHR(
 
     if( pIntercept )
     {
-        cl_command_queue queue = num_queues ? queues[0] : NULL;
+        cl_command_queue queue = num_queues && queues ? queues[0] : NULL;
         const auto& dispatchX = pIntercept->dispatchX(queue);
         if( dispatchX.clCreateCommandBufferKHR )
         {
@@ -11263,7 +11263,7 @@ CL_API_ENTRY cl_command_buffer_khr CL_API_CALL clRemapCommandBufferKHR(
 
     if( pIntercept )
     {
-        cl_command_queue queue = num_queues ? queues[0] : NULL;
+        cl_command_queue queue = num_queues && queues ? queues[0] : NULL;
         const auto& dispatchX = pIntercept->dispatchX(queue);
         if( dispatchX.clRemapCommandBufferKHR )
         {


### PR DESCRIPTION
## Description of Changes

It is possible to pass in a nonzero number of queues but a null queue array pointer.  This is an error, but we still shouldn't crash.

## Testing Done

Found while testing the new command buffer negative CTS tests.
