### PR TITLE
bump project version to 3.0.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 set(CMAKE_CXX_STANDARD 11)
 #set(CMAKE_VERBOSE_MAKEFILE ON)
 
-project(CLIntercept VERSION 3.0.3 LANGUAGES CXX)
+project(CLIntercept VERSION 3.0.4 LANGUAGES CXX)
 
 if(NOT CMAKE_BUILD_TYPE)
     message(STATUS "No build type selected, default to RelWithDebInfo")


### PR DESCRIPTION
## Description of Changes

Bump the project version in preparation for an upcoming release

## Testing Done

Verified that the DLL version is 3.0.0.4 after this change, as expected.