### PR TITLE
fix skipped initialization errors with /permissive-

### DIFF
--- a/intercept/mdapi/DriverStorePath.h
+++ b/intercept/mdapi/DriverStorePath.h
@@ -96,6 +96,10 @@ static bool GetIntelDriverStoreFullPath(
     unsigned long* pDriverStorePathLengthInCharacters)
 {
     bool result = false;
+    unsigned long deviceIndex = 0;
+    unsigned long interfaceIndex = 0;
+    unsigned long driverStorePathLengthInCharacters = 0;
+
     // allocated memory must be freed with delete operation
     unsigned char* pPropertyInfName = NULL;
     // allocated memory must be freed with delete operation
@@ -112,15 +116,12 @@ static bool GetIntelDriverStoreFullPath(
         goto END;
     }
 
-    unsigned long deviceIndex = 0;
     SP_DEVINFO_DATA devInfoData;
     ZeroMemory(&devInfoData, sizeof(SP_DEVINFO_DATA));
-    unsigned long interfaceIndex = 0;
     SP_DEVICE_INTERFACE_DATA deviceInterfaceData;
     ZeroMemory(&deviceInterfaceData, sizeof(SP_DEVICE_INTERFACE_DATA));
     DEVPROPKEY devPropKey;
     ZeroMemory(&devPropKey, sizeof(DEVPROPKEY));
-    unsigned long driverStorePathLengthInCharacters = 0;
 
     // enumerate display adapters
     while (true)


### PR DESCRIPTION
## Description of Changes

Fixes several initialization error issues identified by `/permissive-` similar to:

`DriverStorePath.h(123,19): error C2362: initialization of 'driverStorePathLengthInCharacters' is skipped by 'goto END'`

## Testing Done

Set `/permissive-` and observed that no compile errors occurred.
