### PR TITLE
fix one more lower_bound end iterator issue

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -14555,7 +14555,7 @@ cl_int CLIntercept::emulatedGetMemAllocInfoINTEL(
 
     SUSMContextInfo&    usmContextInfo = m_USMContextInfoMap[context];
 
-    if( usmContextInfo.AllocMap.size() == 0 )
+    if( usmContextInfo.AllocMap.empty() )
     {
         // No pointers allocated?
         return CL_INVALID_MEM_OBJECT;   // TODO: new error code?
@@ -14563,7 +14563,7 @@ cl_int CLIntercept::emulatedGetMemAllocInfoINTEL(
 
     CUSMAllocMap::iterator iter = usmContextInfo.AllocMap.lower_bound( ptr );
 
-    if( iter->first != ptr )
+    if( iter == usmContextInfo.AllocMap.end() || iter->first != ptr )
     {
         if( iter == usmContextInfo.AllocMap.begin() )
         {


### PR DESCRIPTION
## Description of Changes

Fix one more case where an `end` iterator could be erroneously dereferenced after calling `lower_bound`.

## Testing Done

Tested with a basic USM application with USM emulation enabled and saw an error from the Visual Studio runtime before this change, due to dereferencing an `end` iterator.  After this fix there was no Visual Studio error and the application ran correctly.