### PR TITLE
switch to pinned dependencies for all GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
     - name: Check Tabs
       run: |
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
     - name: Create Build Directory
       run: cmake -E make_directory ${{runner.workspace}}/build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,10 +29,10 @@ jobs:
       security-events: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@f079b8493333aace61c81488f8bd40919487bd9f # v3.25.7
       with:
         languages: cpp
 
@@ -50,4 +50,4 @@ jobs:
       run: cmake --build . --parallel 4 --config $BUILD_TYPE
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@f079b8493333aace61c81488f8bd40919487bd9f # v3.25.7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
     - name: Create Build Directory
       run: cmake -E make_directory ./build
@@ -42,7 +42,7 @@ jobs:
       if: |
         startsWith(github.ref, 'refs/tags/') &&
         matrix.os == 'windows-latest'
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
       with:
         draft: true
         files: |
@@ -52,7 +52,7 @@ jobs:
       if: |
         startsWith(github.ref, 'refs/tags/') &&
         matrix.os == 'ubuntu-latest'
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
       with:
         draft: true
         files: |


### PR DESCRIPTION
## Description of Changes

Pins GitHub action dependencies as per OpenSSF best practices.

## Testing Done

Verified that automated builds succeed after updating GitHub actions.
