### PR TITLE
add tracing for cl_intel_create_buffer_with_properties

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -1248,6 +1248,20 @@ typedef struct _cl_queue_family_properties_intel {
 #define CL_QUEUE_CAPABILITY_KERNEL_INTEL                    (1 << 26)
 
 ///////////////////////////////////////////////////////////////////////////////
+// cl_intel_create_buffer_with_properties
+
+typedef cl_properties cl_mem_properties_intel;
+
+extern CL_API_ENTRY
+cl_mem CL_API_CALL clCreateBufferWithPropertiesINTEL(
+    cl_context context,
+    const cl_mem_properties_intel* properties,
+    cl_mem_flags flags,
+    size_t size,
+    void* host_ptr,
+    cl_int* errcode_ret);
+
+///////////////////////////////////////////////////////////////////////////////
 // cl_intel_device_attribute_query
 typedef cl_bitfield         cl_device_feature_capabilities_intel;
 
@@ -1498,9 +1512,7 @@ cl_int CL_API_CALL clGetSupportedVA_APIMediaSurfaceFormatsINTEL(
 #define CL_QUEUE_THREAD_LOCAL_EXEC_ENABLE_INTEL     (((cl_bitfield)1) << 31)
 
 ///////////////////////////////////////////////////////////////////////////////
-// cl_intel_unified_shared_memory POC
-
-// These enums are in sync with revision Q of the USM spec.
+// cl_intel_unified_shared_memory
 
 // cl_device_info
 #define CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL                   0x4190
@@ -1517,7 +1529,8 @@ typedef cl_bitfield cl_device_unified_shared_memory_capabilities_intel;
 #define CL_UNIFIED_SHARED_MEMORY_CONCURRENT_ACCESS_INTEL        (1 << 2)
 #define CL_UNIFIED_SHARED_MEMORY_CONCURRENT_ATOMIC_ACCESS_INTEL (1 << 3)
 
-typedef cl_properties cl_mem_properties_intel;
+// Declared previously:
+// typedef cl_properties cl_mem_properties_intel;
 
 // cl_mem_properties_intel
 #define CL_MEM_ALLOC_FLAGS_INTEL        0x4195

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -1072,6 +1072,68 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateBufferWithProperties)(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+// cl_intel_create_buffer_with_properties
+// This function should stay in sync with clCreateBufferWithProperties, above.
+CL_API_ENTRY cl_mem CL_API_CALL clCreateBufferWithPropertiesINTEL(
+    cl_context context,
+    const cl_mem_properties_intel* properties,
+    cl_mem_flags flags,
+    size_t size,
+    void* host_ptr,
+    cl_int* errcode_ret )
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept )
+    {
+        const auto& dispatchX = pIntercept->dispatchX(context);
+        if( dispatchX.clCreateBufferWithPropertiesINTEL )
+        {
+            GET_ENQUEUE_COUNTER();
+
+            std::string propsStr;
+            if( pIntercept->config().CallLogging )
+            {
+                pIntercept->getMemPropertiesString(
+                    properties,
+                    propsStr );
+            }
+            CALL_LOGGING_ENTER( "context = %p, properties = [ %s ], flags = %s (%llX), size = %zu, host_ptr = %p",
+                context,
+                propsStr.c_str(),
+                pIntercept->enumName().name_mem_flags( flags ).c_str(),
+                flags,
+                size,
+                host_ptr );
+            INITIALIZE_BUFFER_CONTENTS_INIT( flags, size, host_ptr );
+            CHECK_ERROR_INIT( errcode_ret );
+            HOST_PERFORMANCE_TIMING_START();
+
+            cl_mem  retVal = dispatchX.clCreateBufferWithPropertiesINTEL(
+                context,
+                properties,
+                flags,
+                size,
+                host_ptr,
+                errcode_ret );
+
+            HOST_PERFORMANCE_TIMING_END();
+            ADD_BUFFER( retVal );
+            INITIALIZE_BUFFER_CONTENTS_CLEANUP( flags, host_ptr );
+            DUMP_BUFFER_AFTER_CREATE( retVal, flags, host_ptr, size );
+            CHECK_ERROR( errcode_ret[0] );
+            ADD_OBJECT_ALLOCATION( retVal );
+            CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
+
+            return retVal;
+        }
+    }
+
+    NULL_FUNCTION_POINTER_SET_ERROR_RETURN_NULL(errcode_ret);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
 // cl_nv_create_buffer
 CL_API_ENTRY cl_mem CL_API_CALL clCreateBufferNV(
     cl_context context,

--- a/intercept/src/dispatch.h
+++ b/intercept/src/dispatch.h
@@ -535,6 +535,15 @@ struct CLdispatchX
     cl_int (CL_API_CALL *clReleaseAcceleratorINTEL) (
         cl_accelerator_intel accelerator );
 
+    // cl_intel_create_buffer_with_properties
+    cl_mem (CL_API_CALL *clCreateBufferWithPropertiesINTEL) (
+        cl_context context,
+        const cl_mem_properties_intel* properties,
+        cl_mem_flags flags,
+        size_t size,
+        void* host_ptr,
+        cl_int* errcode_ret);
+
 #if defined(_WIN32)
     // cl_intel_dx9_media_sharing
     cl_int  (CL_API_CALL *clGetDeviceIDsFromDX9INTEL) (

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -13171,6 +13171,9 @@ void* CLIntercept::getExtensionFunctionAddress(
     CHECK_RETURN_EXTENSION_FUNCTION( clRetainAcceleratorINTEL );
     CHECK_RETURN_EXTENSION_FUNCTION( clReleaseAcceleratorINTEL );
 
+    // cl_intel_create_buffer_with_properties
+    CHECK_RETURN_EXTENSION_FUNCTION( clCreateBufferWithPropertiesINTEL );
+
 #if defined(_WIN32)
     // cl_intel_dx9_media_sharing
     CHECK_RETURN_EXTENSION_FUNCTION( clGetDeviceIDsFromDX9INTEL );


### PR DESCRIPTION
## Description of Changes

Add tracing for `clCreateBufferWithPropertiesINTEL`, which is part of `cl_intel_create_buffer_with_properties`.

Most applications should be using the core `clCreateBufferWithProperties` instead, but some applications are still using the Intel extension, so we may as well trace it also.

## Testing Done

Tested with an application that calls `clCreateBufferWithPropertiesINTEL`.  Without these changes, LeakChecking was reported unexpected counts, because the extra allocations were not being traced even though the calls to `clReleaseMemObject` were.  With this change the calls to `clCreateBufferWithPropertiesINTEL` are properly traced and LeakChecking works, as expected.