### PR TITLE
only log MDAPI event profiling errors for kernel events

### DIFF
--- a/intercept/mdapi/intercept_mdapi.cpp
+++ b/intercept/mdapi/intercept_mdapi.cpp
@@ -458,9 +458,21 @@ void CLIntercept::getMDAPICountersFromEvent(
             }
             else
             {
-                logf("Couldn't get MDAPI data!  clGetEventProfilingInfo returned '%s' (%08X)!\n",
-                    enumName().name(errorCode).c_str(),
-                    errorCode );
+                // Currently, MDAPI data is only included for kernels, so only
+                // report an errors for kernel events.
+                cl_command_type type = 0;
+                dispatch().clGetEventInfo(
+                    event,
+                    CL_EVENT_COMMAND_TYPE,
+                    sizeof(type),
+                    &type,
+                    NULL );
+                if( type == CL_COMMAND_NDRANGE_KERNEL )
+                {
+                    logf("Couldn't get MDAPI data for kernel!  clGetEventProfilingInfo returned '%s' (%08X)!\n",
+                        enumName().name(errorCode).c_str(),
+                        errorCode );
+                }
             }
 
             delete [] pReport;


### PR DESCRIPTION
## Description of Changes

With the current implementation in the GPU drivers MDAPI metrics are only included for kernels, and are not included for other event types, such as clEnqueueReadBuffer, clEnqueueWriteBuffer, etc.  This causes distracting error messages to be printed because the calls to get MDAPI event profiling info for the other types of events is failing.  This PR filters these events so the error messages are only printed for kernel events, where the failure is currently unexpected.

## Testing Done

Tested with a MDAPI event based sampling enabled and a sample app that enqueues kernels and other commands.  Observed that MDAPI metrics are collected for kernels and no errors are seen.
