### PR TITLE
update release script to update git information

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,17 @@ jobs:
 
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    # This isn't working currently, see https://github.com/actions/checkout/issues/1467.
+    # Instead, get the git information manually with the step below.
+    #   with:
+    #     fetch-tags: true
+
+    - name: Refresh Git Information
+      if: startsWith(github.ref, 'refs/tags/')
+      shell: bash
+      run: |
+          git fetch --force --tags
+          git checkout "${GITHUB_REF_NAME}"
 
     - name: Create Build Directory
       run: cmake -E make_directory ./build

--- a/cliloader/cliloader.cpp
+++ b/cliloader/cliloader.cpp
@@ -583,7 +583,7 @@ static bool parseArguments(int argc, char *argv[])
         std::string defaultDumpDir = getDefaultDumpDirectory();
         fprintf(stdout,
             "cliloader - A utility to simplify using the Intercept Layer for OpenCL Applications\n"
-            "  Version: %s, from %s\n"
+            "  Version: %s%s%s\n"
             "\n"
             "Usage: cliloader [OPTIONS] COMMAND\n"
             "\n"
@@ -630,7 +630,8 @@ static bool parseArguments(int argc, char *argv[])
             "    %s\n"
             "\n",
             g_scGitDescribe,
-            g_scGitRefSpec,
+            strlen(g_scGitRefSpec) > 0 ? ", from " : "",
+            strlen(g_scGitRefSpec) > 0 ? g_scGitRefSpec : "",
             defaultDumpDir.c_str(),
             g_scURL );
         return false;

--- a/cliprof/cliprof.cpp
+++ b/cliprof/cliprof.cpp
@@ -284,7 +284,7 @@ static bool parseArguments(int argc, char *argv[])
     {
         fprintf(stdout,
             "cliprof - A simple utility to enable profiling using the Intercept Layer for OpenCL Applications\n"
-            "  Version: %s, from %s\n"
+            "  Version: %s%s%s\n"
             "\n"
             "Usage: cliprof [OPTIONS] COMMAND\n"
             "\n"
@@ -298,7 +298,8 @@ static bool parseArguments(int argc, char *argv[])
             "    %s\n"
             "\n",
             g_scGitDescribe,
-            g_scGitRefSpec,
+            strlen(g_scGitRefSpec) > 0 ? ", from " : "",
+            strlen(g_scGitRefSpec) > 0 ? g_scGitRefSpec : "",
             g_scURL );
         return false;
     }


### PR DESCRIPTION
## Description of Changes

Improves release automation, by refreshing git information after checkout so the version tag and hash is correctly populated.

## Testing Done

Tested by pushing a test tag to my fork.