### PR TITLE
use std::ignore to fix assert unused variable warnings

### DIFF
--- a/intercept/src/common.h
+++ b/intercept/src/common.h
@@ -50,7 +50,8 @@
         }                       \
     }
 #else
-    #define CLI_ASSERT(x)
+    #include <tuple>
+    #define CLI_ASSERT(x) std::ignore = (x)
 #endif
 
 #if defined(_WIN32) || defined(__linux__) || defined(__FreeBSD__)


### PR DESCRIPTION
Fixes #362

## Description of Changes

Uses [std::ignore](https://en.cppreference.com/w/cpp/utility/tuple/ignore) to fix unused variable warnings for release builds, where the "unused variables" were used for the assert macro.

## Testing Done

Examined automated builds for MacOS and observed that warnings were fixed.
