### PR TITLE
allow cliloader to proceed in more cases

### DIFF
--- a/cliloader/cliloader.cpp
+++ b/cliloader/cliloader.cpp
@@ -784,18 +784,21 @@ int main(int argc, char *argv[])
                 NULL );
             if( childThread == NULL )
             {
-                die("replacing functions in child thread");
+                DEBUG("couldn't create child thread to replace functions\n");
             }
-            DEBUG("created child thread to replace functions\n");
-
-            // Wait for child thread to complete:
-            if( WaitForSingleObject(childThread, INFINITE) != WAIT_OBJECT_0 )
+            else
             {
-                die("waiting for initialization thread");
+                DEBUG("created child thread to replace functions\n");
+
+                // Wait for child thread to complete:
+                if( WaitForSingleObject(childThread, INFINITE) != WAIT_OBJECT_0 )
+                {
+                    die("waiting for initialization thread");
+                }
+                DEBUG("child thread to replace functions completed\n");
+                CloseHandle(childThread);
+                DEBUG("cleaned up child thread to replace functions\n");
             }
-            DEBUG("child thread to replace functions completed\n");
-            CloseHandle(childThread);
-            DEBUG("cleaned up child thread to replace functions\n");
         }
     }
 

--- a/cliprof/cliprof.cpp
+++ b/cliprof/cliprof.cpp
@@ -432,18 +432,21 @@ int main(int argc, char *argv[])
             NULL );
         if( childThread == NULL )
         {
-            die("replacing functions in child thread");
+            DEBUG("couldn't create child thread to replace functions\n");
         }
-        DEBUG("created child thread to replace functions\n");
-
-        // Wait for child thread to complete:
-        if( WaitForSingleObject(childThread, INFINITE) != WAIT_OBJECT_0 )
+        else
         {
-            die("waiting for initialization thread");
+            DEBUG("created child thread to replace functions\n");
+
+            // Wait for child thread to complete:
+            if( WaitForSingleObject(childThread, INFINITE) != WAIT_OBJECT_0 )
+            {
+                die("waiting for initialization thread");
+            }
+            DEBUG("child thread to replace functions completed\n");
+            CloseHandle(childThread);
+            DEBUG("cleaned up child thread to replace functions\n");
         }
-        DEBUG("child thread to replace functions completed\n");
-        CloseHandle(childThread);
-        DEBUG("cleaned up child thread to replace functions\n");
     }
 
     // Resume child process:


### PR DESCRIPTION
## Description of Changes

On Windows, if the child thread to replace functions cannot be created, we should still continue, since loading the intercept layer OpenCL.dll in the child process is usually enough to successfully intercept OpenCL calls.

## Testing Done

Forced the child thread to fail creation.  Observed that cliloader could proceed, and that interception was successful.