### PR TITLE
extend LeakChecking to track SVM and USM allocations

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -6338,6 +6338,7 @@ CL_API_ENTRY void* CL_API_CALL CLIRN(clSVMAlloc) (
         // if ErrorLogging is enabled.
         cl_int  errorCode = ( retVal != NULL ) ? CL_SUCCESS : CL_INVALID_OPERATION;
         CHECK_ERROR( errorCode );
+        ADD_POINTER_ALLOCATION( retVal );
         CALL_LOGGING_EXIT( errorCode, "returned %p", retVal );
 
         return retVal;
@@ -6370,6 +6371,7 @@ CL_API_ENTRY void CL_API_CALL CLIRN(clSVMFree) (
 
         HOST_PERFORMANCE_TIMING_END();
         REMOVE_SVM_ALLOCATION( svm_pointer );
+        ADD_POINTER_FREE( svm_pointer );
         CALL_LOGGING_EXIT( CL_SUCCESS );
     }
 }
@@ -9736,6 +9738,7 @@ CL_API_ENTRY void* CL_API_CALL clHostMemAllocINTEL(
             ADD_USM_ALLOCATION( retVal, size );
             USM_ALLOC_PROPERTIES_CLEANUP( newProperties );
             CHECK_ERROR( errcode_ret[0] );
+            ADD_POINTER_ALLOCATION( retVal );
             CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
             return retVal;
@@ -9812,6 +9815,7 @@ CL_API_ENTRY void* CL_API_CALL clDeviceMemAllocINTEL(
             ADD_USM_ALLOCATION( retVal, size );
             USM_ALLOC_PROPERTIES_CLEANUP( newProperties );
             CHECK_ERROR( errcode_ret[0] );
+            ADD_POINTER_ALLOCATION( retVal );
             CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
             return retVal;
@@ -9888,6 +9892,7 @@ CL_API_ENTRY void* CL_API_CALL clSharedMemAllocINTEL(
             ADD_USM_ALLOCATION( retVal, size );
             USM_ALLOC_PROPERTIES_CLEANUP( newProperties );
             CHECK_ERROR( errcode_ret[0] );
+            ADD_POINTER_ALLOCATION( retVal );
             CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
             return retVal;
@@ -9924,6 +9929,7 @@ CL_API_ENTRY cl_int CL_API_CALL clMemFreeINTEL(
             HOST_PERFORMANCE_TIMING_END();
             REMOVE_USM_ALLOCATION( ptr );
             CHECK_ERROR( retVal );
+            ADD_POINTER_FREE( ptr );
             CALL_LOGGING_EXIT( retVal );
 
             return retVal;
@@ -9961,6 +9967,7 @@ clMemBlockingFreeINTEL(
             HOST_PERFORMANCE_TIMING_END();
             REMOVE_USM_ALLOCATION( ptr );
             CHECK_ERROR( retVal );
+            ADD_POINTER_FREE( ptr );
             CALL_LOGGING_EXIT( retVal );
             DEVICE_PERFORMANCE_TIMING_CHECK();
             FLUSH_CHROME_TRACE_BUFFERING();

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -2008,6 +2008,18 @@ inline CObjectTracker& CLIntercept::objectTracker()
         pIntercept->objectTracker().AddRelease(_obj);                       \
     }
 
+#define ADD_POINTER_ALLOCATION( _ptr )                                      \
+    if( pIntercept->config().LeakChecking )                                 \
+    {                                                                       \
+        pIntercept->objectTracker().AddPointerAllocation(_ptr);             \
+    }
+
+#define ADD_POINTER_FREE( _ptr )                                            \
+    if( pIntercept->config().LeakChecking )                                 \
+    {                                                                       \
+        pIntercept->objectTracker().AddPointerFree(_ptr);                   \
+    }
+
 ///////////////////////////////////////////////////////////////////////////////
 //
 #define LOG_CLINFO()                                                        \

--- a/intercept/src/objtracker.h
+++ b/intercept/src/objtracker.h
@@ -44,6 +44,22 @@ public:
         }
     }
 
+    void    AddPointerAllocation( const void* ptr )
+    {
+        if( ptr )
+        {
+            m_Pointers.NumAllocations.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+
+    void    AddPointerFree( const void* ptr )
+    {
+        if( ptr )
+        {
+            m_Pointers.NumFrees.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+
 private:
     struct CTracker
     {
@@ -55,6 +71,16 @@ private:
         std::atomic<size_t> NumAllocations;
         std::atomic<size_t> NumRetains;
         std::atomic<size_t> NumReleases;
+    };
+
+    struct CPointerTracker
+    {
+        CPointerTracker() :
+            NumAllocations(0),
+            NumFrees(0) {};
+
+        std::atomic<size_t> NumAllocations;
+        std::atomic<size_t> NumFrees;
     };
 
     CTracker    m_Devices;
@@ -80,9 +106,15 @@ private:
     CTracker&   GetTracker( cl_semaphore_khr )  { return m_Semaphores;      }
     CTracker&   GetTracker( cl_command_buffer_khr ) { return m_CommandBuffers; }
 
+    CPointerTracker m_Pointers;
+
     static void ReportHelper(
         const std::string& label,
         const CTracker& tracker,
+        std::ostream& os );
+    static void ReportHelper(
+        const std::string& label,
+        const CPointerTracker& tracker,
         std::ostream& os );
 
     DISALLOW_COPY_AND_ASSIGN( CObjectTracker );


### PR DESCRIPTION
## Description of Changes

Extends LeakChecking to track SVM and USM allocations in addition to OpenCL objects.

The handling for SVM and USM allocations is a little different than the handling of OpenCL objects because you explicitly allocate and free them vs. allocating (creating) and releasing them, and there is no way to "retain" them.  Therefore, pointers are handled specifically, different from OpenCL objects.

## Testing Done

Tested with SVM and USM sample applications.
