### PR TITLE
add a fallback that loads the mdapi library with an explicit soversion

### DIFF
--- a/cliloader/printmetrics.h
+++ b/cliloader/printmetrics.h
@@ -43,6 +43,12 @@ static void* OpenLibrary()
 #if !defined(__APPLE__)
     if (ret == NULL)
     {
+        // try adding an explicit soversion
+        std::string check(cMDLibFileName); check += ".1";
+        ret = dlopen(check.c_str(), RTLD_LAZY | RTLD_LOCAL);
+    }
+    if (ret == NULL)
+    {
         // old alternate name, may eventually be removed
         ret = dlopen("libmd.so", RTLD_LAZY | RTLD_LOCAL);
     }

--- a/intercept/mdapi/MetricsDiscoveryHelper.cpp
+++ b/intercept/mdapi/MetricsDiscoveryHelper.cpp
@@ -61,6 +61,12 @@ static void* OpenLibrary( const std::string& metricsLibraryName )
             ret = dlopen(cMDLibFileName, RTLD_LAZY | RTLD_LOCAL);
         }
 #if !defined(__APPLE__)
+        if (ret == NULL)
+        {
+            // try adding an explicit soversion
+            std::string check(cMDLibFileName); check += ".1";
+            ret = dlopen(check.c_str(), RTLD_LAZY | RTLD_LOCAL);
+        }
         if( ret == NULL )
         {
             // old alternate name, may eventually be removed


### PR DESCRIPTION
## Description of Changes

If the MDAPI cannot be loaded using the default file name, try loading with an explicit soversion also.  This enables MDAPI metrics to be collected in more cases, if the file name (usually a symbolic link) without the explicit soversion does not get installed for some reason.

## Testing Done

Tested by forcing the intial `dlopen` to fail, therefore relying on the fallback path, and was successfully able to enumerate and collect metrics.
