### PR TITLE
Update MDAPI Checks for xe Kernel Driver

### DIFF
--- a/cliloader/cliloader.cpp
+++ b/cliloader/cliloader.cpp
@@ -594,7 +594,7 @@ static bool parseArguments(int argc, char *argv[])
         )
     {
         std::string defaultDumpDir = getDefaultDumpDirectory();
-        fprintf(stdout,
+        printf(
             "cliloader - A utility to simplify using the Intercept Layer for OpenCL Applications\n"
             "  Version: %s%s%s\n"
             "\n"

--- a/cliloader/printcontrols.h
+++ b/cliloader/printcontrols.h
@@ -51,13 +51,13 @@ static void printControls()
     {
         if (control.IsSeparator)
         {
-            fprintf(stdout, "%s\n", control.Name);
-            fprintf(stdout, "========================================\n\n");
+            printf("%s\n", control.Name);
+            printf("========================================\n\n");
         }
         else
         {
-            fprintf(stdout, "%s (%s):\n", control.Name, control.Type);
-            fprintf(stdout, "%s\n\n", control.Description);
+            printf("%s (%s):\n", control.Name, control.Type);
+            printf("%s\n\n", control.Description);
         }
     }
 }

--- a/cliloader/printmetrics.h
+++ b/cliloader/printmetrics.h
@@ -93,11 +93,11 @@ static bool printMetricsForDevice(IMetricsDeviceLatest* pMetricsDevice)
             continue;
         }
 
-        fprintf(stderr, "\nMetric Group: %s (%d Metric Set%s)\n",
+        printf("\nMetric Group: %s (%d Metric Set%s)\n",
             pGroupParams->Description,
             pGroupParams->MetricSetsCount,
             pGroupParams->MetricSetsCount > 1 ? "s" : "");
-        fprintf(stderr, "========================================\n\n");
+        printf("========================================\n\n");
 
         for (uint32_t ms = 0; ms < pGroupParams->MetricSetsCount; ms++)
         {
@@ -109,11 +109,11 @@ static bool printMetricsForDevice(IMetricsDeviceLatest* pMetricsDevice)
                 continue;
             }
 
-            fprintf(stderr, "Metric Set: %s (%d Metric%s)\n",
+            printf("Metric Set: %s (%d Metric%s)\n",
                 pSetParams->ShortName,
                 pSetParams->MetricsCount,
                 pSetParams->MetricsCount > 1 ? "s" : "");
-            fprintf(stderr, "----------------------------------------\n\n");
+            printf("----------------------------------------\n\n");
 
             for (uint32_t m = 0; m < pSetParams->MetricsCount; m++)
             {
@@ -124,7 +124,7 @@ static bool printMetricsForDevice(IMetricsDeviceLatest* pMetricsDevice)
                     continue;
                 }
 
-                fprintf(stderr,
+                printf(
                     "%s\\%s (%s):\n"
                     "%s\n\n",
                     pSetParams->SymbolName,
@@ -165,7 +165,7 @@ static bool printMetricsForAdapterGroup(void* pLibrary, bool devicesOnly)
         return false;
     }
 
-    fprintf(stderr, "MDAPI Headers: v%d.%d.%d, MDAPI Lib: v%d.%d.%d\n",
+    printf("MDAPI Headers: v%d.%d.%d, MDAPI Lib: v%d.%d.%d\n",
         MD_API_MAJOR_NUMBER_CURRENT,
         MD_API_MINOR_NUMBER_CURRENT,
         MD_API_BUILD_NUMBER_CURRENT,
@@ -179,7 +179,7 @@ static bool printMetricsForAdapterGroup(void* pLibrary, bool devicesOnly)
     }
     else
     {
-        fprintf(stderr, "Found %u MDAPI Adapter%s:\n",
+        printf("Found %u MDAPI Adapter%s:\n",
             pAdapterGroupParams->AdapterCount,
             pAdapterGroupParams->AdapterCount > 1 ? "s" : "");
         for (uint32_t a = 0; a < pAdapterGroupParams->AdapterCount; a++)
@@ -198,11 +198,11 @@ static bool printMetricsForAdapterGroup(void* pLibrary, bool devicesOnly)
                 continue;
             }
 
-            fprintf(stderr, "Adapter %u: %s (%s)\n",
+            printf("Adapter %u: %s (%s)\n",
                 a,
                 pAdapterParams->ShortName,
                 adapterTypeToString(pAdapterParams->Type));
-            fprintf(stderr, "\tPCI Vendor Id: %04X, Device Id: %04X, Bus Info: %02X:%02X.%02X\n",
+            printf("\tPCI Vendor Id: %04X, Device Id: %04X, Bus Info: %02X:%02X.%02X\n",
                 pAdapterParams->VendorId,
                 pAdapterParams->DeviceId,
                 pAdapterParams->BusNumber,
@@ -227,17 +227,17 @@ static bool printMetricsForAdapterGroup(void* pLibrary, bool devicesOnly)
                     continue;
                 }
 
-                fprintf(stderr, "\nAdapter %u: %s (%s)\n",
+                printf("\nAdapter %u: %s (%s)\n",
                     a,
                     pAdapterParams->ShortName,
                     adapterTypeToString(pAdapterParams->Type));
-                fprintf(stderr, "\tPCI Vendor Id: %04X, Device Id: %04X, Bus Info: %02X:%02X.%02X\n",
+                printf("\tPCI Vendor Id: %04X, Device Id: %04X, Bus Info: %02X:%02X.%02X\n",
                     pAdapterParams->VendorId,
                     pAdapterParams->DeviceId,
                     pAdapterParams->BusNumber,
                     pAdapterParams->DeviceNumber,
                     pAdapterParams->FunctionNumber);
-                fprintf(stderr, "########################################\n\n");
+                printf("########################################\n\n");
 
                 IMetricsDeviceLatest* pMetricsDevice = NULL;
                 res = pAdapter->OpenMetricsDevice(&pMetricsDevice);
@@ -303,7 +303,7 @@ static bool printMetricsForLegacyDevice(void* pLibrary)
         return false;
     }
 
-    fprintf(stderr, "MDAPI Headers: v%d.%d.%d, MDAPI Lib: v%d.%d.%d\n",
+    printf("MDAPI Headers: v%d.%d.%d, MDAPI Lib: v%d.%d.%d\n",
         MD_API_MAJOR_NUMBER_CURRENT,
         MD_API_MINOR_NUMBER_CURRENT,
         MD_API_BUILD_NUMBER_CURRENT,

--- a/cliprof/cliprof.cpp
+++ b/cliprof/cliprof.cpp
@@ -282,7 +282,7 @@ static bool parseArguments(int argc, char *argv[])
 #endif
         )
     {
-        fprintf(stdout,
+        printf(
             "cliprof - A simple utility to enable profiling using the Intercept Layer for OpenCL Applications\n"
             "  Version: %s%s%s\n"
             "\n"

--- a/docs/mdapi.md
+++ b/docs/mdapi.md
@@ -110,17 +110,41 @@ indices, use `cliloader` and pass the `--mdapi-devices` option.
 option.
 * Collecting MDAPI metrics currently requires elevated privileges
 because metrics are collected system-wide.
-* On Linux, MDAPI metrics may be enabled for non-root users
-by setting `/proc/sys/dev/i915/perf_stream_paranoid` to `0`:
+* On Linux, MDAPI metrics may be enabled for non-root users.
+The mechanism to do so depends on the kernel driver used for the GPU.
+To determine the kernel driver for your GPU, run:
 
     ```sh
-    $ echo 0 > /proc/sys/dev/i915/perf_stream_paranoid
+    $ lspci -nn -k | grep -Ei 'VGA|DISPLAY' -A2
+    ```
+
+    This will tell you if your kernel driver is the `i915` kernel driver or the
+    `xe` kernel driver.
+
+    For the `i915` kernel driver, set `/proc/sys/dev/i915/perf_stream_paranoid`
+    to `0`:
+
+    ```sh
+    $ echo 0 | sudo tee /proc/sys/dev/i915/perf_stream_paranoid
     ```
 
     or:
 
     ```sh
-    $ sysctl dev.i915.perf_stream_paranoid=0
+    $ sudo sysctl dev.i915.perf_stream_paranoid=0
+    ```
+
+    For the `xe` kernel driver, set `/proc/sys/dev/xe/observation_paranoid` to
+    `0`:
+
+    ```sh
+    $ echo 0 | sudo tee /proc/sys/dev/xe/observation_paranoid
+    ```
+
+    or:
+
+    ```sh
+    $ sudo sysctl dev.xe.observation_paranoid=0
     ```
 
     For more information, see:

--- a/intercept/mdapi/intercept_mdapi.cpp
+++ b/intercept/mdapi/intercept_mdapi.cpp
@@ -152,7 +152,8 @@ void CLIntercept::initCustomPerfCounters()
         {
             log( permissionString );
         }
-        else if( config().DevicePerfCounterEventBasedSampling )
+
+        if( config().DevicePerfCounterEventBasedSampling )
         {
             m_pMDHelper = MetricsDiscovery::MDHelper::CreateEBS(
                 config().DevicePerfCounterLibName,


### PR DESCRIPTION
## Description of Changes

Adds updates for the new xe kernel driver used by Lunar Lake and Battlemage GPUs.  Specifically:

* Adds checks for MDAPI permissions for the xe kernel driver in addition to the previous i915 kernel driver.
* Tries to initialize MDAPI even if the MDAPI permission checks fail, to handle the case where there are multiple GPUs and sufficient permissions are set for the GPU used to collect metrics.
* Updates documentation to cover both kernel drivers.

Also, changes non-error output from cliloader to go to stdout rather than stderr.  This makes it easier to page through output using utilities like `more` and `less`.

## Testing Done

Tested on a machine with an Alder Lake iGPU using the i915 kernel driver and a Battlemage dGPU using the xe kernel driver.  Verified that both permission checks are properly performed.
