### PR TITLE
update copyright dates to 2025

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Intel Corporation
+# Copyright (c) 2018-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,4 +34,4 @@ required.
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2018-2024, Intel(R) Corporation
+Copyright (c) 2018-2025, Intel(R) Corporation

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2024 Intel Corporation
+Copyright (c) 2018-2025 Intel Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ OpenCL and the OpenCL logo are trademarks of Apple Inc. used by permission by Kh
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2018-2024, Intel(R) Corporation
+Copyright (c) 2018-2025, Intel(R) Corporation
 
 [khronos_cl_license]: https://github.com/KhronosGroup/OpenCL-Headers/blob/main/LICENSE
 [boost_license]: http://www.boost.org/LICENSE_1_0.txt

--- a/cliconfig/CLIConfig.cpp
+++ b/cliconfig/CLIConfig.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/cliconfig/CLIConfig.h
+++ b/cliconfig/CLIConfig.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/cliconfig/CLIConfig_version.rc2
+++ b/cliconfig/CLIConfig_version.rc2
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */
@@ -30,7 +30,7 @@ BEGIN
             VALUE "FileDescription", "Intercept Layer for OpenCL(tm) Applications Configuration App"
             VALUE "FileVersion", "v3.0"
             VALUE "InternalName", "CLIConfig"
-            VALUE "LegalCopyright", "Copyright (c) Intel Corporation 2018-2024"
+            VALUE "LegalCopyright", "Copyright (c) Intel Corporation 2018-2025"
             VALUE "OriginalFilename", "CLIConfig.exe"
             VALUE "ProductName", "Intercept Layer for OpenCL(tm) Applications Configuration App"
             VALUE "ProductVersion", "v3.0"

--- a/cliconfig/CMakeLists.txt
+++ b/cliconfig/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Intel Corporation
+# Copyright (c) 2018-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cliconfig/envVars.h
+++ b/cliconfig/envVars.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/cliloader/CMakeLists.txt
+++ b/cliloader/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Intel Corporation
+# Copyright (c) 2018-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cliloader/cliloader.cpp
+++ b/cliloader/cliloader.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/cliloader/git_version.h.in
+++ b/cliloader/git_version.h.in
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/cliloader/printcontrols.h
+++ b/cliloader/printcontrols.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/cliloader/printmetrics.h
+++ b/cliloader/printmetrics.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2023-2024 Intel Corporation
+// Copyright (c) 2023-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/cliprof/CMakeLists.txt
+++ b/cliprof/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Intel Corporation
+# Copyright (c) 2018-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cliprof/cliprof.cpp
+++ b/cliprof/cliprof.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/cliprof/git_version.h.in
+++ b/cliprof/git_version.h.in
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/cmake_modules/package.cmake
+++ b/cmake_modules/package.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Intel Corporation
+# Copyright (c) 2018-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -219,4 +219,4 @@ If you use the Intercept Layer for OpenCL Applications in your work please cite 
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2018-2024, Intel(R) Corporation
+Copyright (c) 2018-2025, Intel(R) Corporation

--- a/docs/aubcapture.md
+++ b/docs/aubcapture.md
@@ -82,4 +82,4 @@ If the first 10 enqueues do not include any kernel enqueues, increase the
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2018-2024, Intel(R) Corporation
+Copyright (c) 2018-2025, Intel(R) Corporation

--- a/docs/build.md
+++ b/docs/build.md
@@ -135,6 +135,6 @@ See your CMake documentation for more details.
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2018-2024, Intel(R) Corporation
+Copyright (c) 2018-2025, Intel(R) Corporation
 
 [CMake]: https://cmake.org

--- a/docs/chrome_tracing.md
+++ b/docs/chrome_tracing.md
@@ -81,6 +81,6 @@ without it.
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2018-2024, Intel(R) Corporation
+Copyright (c) 2018-2025, Intel(R) Corporation
 
 [chrome_tracing_format]: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview

--- a/docs/cliloader.md
+++ b/docs/cliloader.md
@@ -54,4 +54,4 @@ If you encounter other bugs or issues running `cliloader`, including the `--debu
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2018-2024, Intel(R) Corporation
+Copyright (c) 2018-2025, Intel(R) Corporation

--- a/docs/cliprof.md
+++ b/docs/cliprof.md
@@ -84,4 +84,4 @@ troubleshoot the problem.
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2018-2024, Intel(R) Corporation
+Copyright (c) 2018-2025, Intel(R) Corporation

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -920,4 +920,4 @@ If set to a nonzero value, the Intercept Layer for OpenCL Applications will use 
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2018-2024, Intel(R) Corporation
+Copyright (c) 2018-2025, Intel(R) Corporation

--- a/docs/injecting_buffers_images.md
+++ b/docs/injecting_buffers_images.md
@@ -67,4 +67,4 @@ If the size of the buffer is larger than the size of the file then only the init
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2024, Intel(R) Corporation
+Copyright (c) 2024-2025, Intel(R) Corporation

--- a/docs/injecting_programs.md
+++ b/docs/injecting_programs.md
@@ -94,4 +94,4 @@ in your log.
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2018-2024, Intel(R) Corporation
+Copyright (c) 2018-2025, Intel(R) Corporation

--- a/docs/install.md
+++ b/docs/install.md
@@ -203,4 +203,4 @@ DevicePerformanceTimeLogging=1
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2018-2024, Intel(R) Corporation
+Copyright (c) 2018-2025, Intel(R) Corporation

--- a/docs/kernel_isa.md
+++ b/docs/kernel_isa.md
@@ -12,4 +12,4 @@ for other devices may be added at a later date.
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2018-2024, Intel(R) Corporation
+Copyright (c) 2018-2025, Intel(R) Corporation

--- a/docs/kernel_isa_cpu.md
+++ b/docs/kernel_isa_cpu.md
@@ -49,4 +49,4 @@ may be useful to disassemble all program binaries in a specified directory.
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2018-2024, Intel(R) Corporation
+Copyright (c) 2018-2025, Intel(R) Corporation

--- a/docs/kernel_isa_gpu.md
+++ b/docs/kernel_isa_gpu.md
@@ -102,4 +102,4 @@ may be useful to invoke a disassembler on all ISA binaries in a specified direct
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2018-2024, Intel(R) Corporation
+Copyright (c) 2018-2025, Intel(R) Corporation

--- a/docs/mdapi.md
+++ b/docs/mdapi.md
@@ -157,4 +157,4 @@ To determine the kernel driver for your GPU, run:
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2018-2024, Intel(R) Corporation
+Copyright (c) 2018-2025, Intel(R) Corporation

--- a/docs/vtune_logging.md
+++ b/docs/vtune_logging.md
@@ -72,6 +72,6 @@ output like the picture below that you'd get with the native VTune tracing:
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2018-2024, Intel(R) Corporation
+Copyright (c) 2018-2025, Intel(R) Corporation
 
 [itt]: https://software.intel.com/en-us/node/544195

--- a/intercept/CMakeLists.txt
+++ b/intercept/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Intel Corporation
+# Copyright (c) 2018-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/intercept/OS/OS.h
+++ b/intercept/OS/OS.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/OS/OS_linux.cpp
+++ b/intercept/OS/OS_linux.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/OS/OS_linux.h
+++ b/intercept/OS/OS_linux.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/OS/OS_linux_common.cpp
+++ b/intercept/OS/OS_linux_common.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/OS/OS_linux_common.h
+++ b/intercept/OS/OS_linux_common.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/OS/OS_mac.cpp
+++ b/intercept/OS/OS_mac.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/OS/OS_mac.h
+++ b/intercept/OS/OS_mac.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/OS/OS_mac_common.cpp
+++ b/intercept/OS/OS_mac_common.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/OS/OS_mac_common.h
+++ b/intercept/OS/OS_mac_common.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/OS/OS_mac_interpose.h
+++ b/intercept/OS/OS_mac_interpose.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/OS/OS_windows.cpp
+++ b/intercept/OS/OS_windows.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/OS/OS_windows.h
+++ b/intercept/OS/OS_windows.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/OS/OS_windows_common.cpp
+++ b/intercept/OS/OS_windows_common.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/OS/OS_windows_common.h
+++ b/intercept/OS/OS_windows_common.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/kernels/builtin_kernels.cl
+++ b/intercept/kernels/builtin_kernels.cl
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/kernels/precompiled_kernels.cl
+++ b/intercept/kernels/precompiled_kernels.cl
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/mdapi/DriverStorePath.h
+++ b/intercept/mdapi/DriverStorePath.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/mdapi/MetricsDiscoveryHelper.cpp
+++ b/intercept/mdapi/MetricsDiscoveryHelper.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/mdapi/MetricsDiscoveryHelper.h
+++ b/intercept/mdapi/MetricsDiscoveryHelper.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/mdapi/intercept_mdapi.cpp
+++ b/intercept/mdapi/intercept_mdapi.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/scripts/run.py
+++ b/intercept/scripts/run.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023-2024 Intel Corporation
+# Copyright (c) 2023-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/intercept/src/chrometracer.cpp
+++ b/intercept/src/chrometracer.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2023-2024 Intel Corporation
+// Copyright (c) 2023-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/chrometracer.h
+++ b/intercept/src/chrometracer.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2023-2024 Intel Corporation
+// Copyright (c) 2023-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/clIntercept.def
+++ b/intercept/src/clIntercept.def
@@ -1,4 +1,4 @@
-; Copyright (c) 2018-2024 Intel Corporation
+; Copyright (c) 2018-2025 Intel Corporation
 ;
 ; SPDX-License-Identifier: MIT
 

--- a/intercept/src/clIntercept.map
+++ b/intercept/src/clIntercept.map
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/cliprof_init.cpp
+++ b/intercept/src/cliprof_init.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/common.h
+++ b/intercept/src/common.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/controls.h
+++ b/intercept/src/controls.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/demangle.h
+++ b/intercept/src/demangle.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2022-2024 Intel Corporation
+// Copyright (c) 2022-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/dispatch.h
+++ b/intercept/src/dispatch.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/emulate.cpp
+++ b/intercept/src/emulate.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/emulate.h
+++ b/intercept/src/emulate.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/enummap.h
+++ b/intercept/src/enummap.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/git_version.cpp.in
+++ b/intercept/src/git_version.cpp.in
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/git_version.rc.in
+++ b/intercept/src/git_version.rc.in
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */
@@ -32,7 +32,7 @@ BEGIN
             VALUE "FileDescription", "Intercept Layer for OpenCL(tm) Applications"
             VALUE "FileVersion", "@GIT_DESCRIBE@"
             VALUE "InternalName", "CLIntercept"
-            VALUE "LegalCopyright", "Copyright (c) Intel Corporation 2018-2024"
+            VALUE "LegalCopyright", "Copyright (c) Intel Corporation 2018-2025"
             VALUE "OriginalFilename", "OpenCL.dll"
             VALUE "ProductName", "Intercept Layer for OpenCL(tm) Applications"
             VALUE "ProductVersion", "@GIT_DESCRIBE@"

--- a/intercept/src/instrumentation.h
+++ b/intercept/src/instrumentation.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/main.cpp
+++ b/intercept/src/main.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/objtracker.cpp
+++ b/intercept/src/objtracker.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/objtracker.h
+++ b/intercept/src/objtracker.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2024 Intel Corporation
+// Copyright (c) 2018-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/utils.cpp
+++ b/intercept/src/utils.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2024 Intel Corporation
+// Copyright (c) 2024-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/intercept/src/utils.h
+++ b/intercept/src/utils.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2024 Intel Corporation
+// Copyright (c) 2024-2025 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 */

--- a/scripts/capture_and_validate.py
+++ b/scripts/capture_and_validate.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023-2024 Intel Corporation
+# Copyright (c) 2023-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/scripts/combine_chrome_traces.py
+++ b/scripts/combine_chrome_traces.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (c) 2018-2024 Intel Corporation
+# Copyright (c) 2018-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/scripts/disassemble_all_cpu.py
+++ b/scripts/disassemble_all_cpu.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2024 Intel Corporation
+# Copyright (c) 2018-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/scripts/disassemble_all_gpu.py
+++ b/scripts/disassemble_all_gpu.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2024 Intel Corporation
+# Copyright (c) 2018-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/scripts/disassemble_cpu.sh
+++ b/scripts/disassemble_cpu.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright (c) 2018-2024 Intel Corporation
+# Copyright (c) 2018-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/scripts/generate_controls_doc.py
+++ b/scripts/generate_controls_doc.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2024 Intel Corporation
+# Copyright (c) 2018-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #
@@ -150,7 +150,7 @@ def GetFooter():
 
 \* Other names and brands may be claimed as the property of others.
 
-Copyright (c) 2018-2024, Intel(R) Corporation
+Copyright (c) 2018-2025, Intel(R) Corporation
 """
 
 printHelp = False

--- a/scripts/parse_output_to_xlsx.py
+++ b/scripts/parse_output_to_xlsx.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2024 Intel Corporation
+# Copyright (c) 2019-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #


### PR DESCRIPTION
## Description of Changes

Updates all copyright dates to 2025.  No functional changes.

## Testing Done

Visually verified that only intended copyright dates were updated.
