### PR TITLE
Fix emulation of clEnqueueMemFillINTEL

### DIFF
--- a/intercept/src/emulate.cpp
+++ b/intercept/src/emulate.cpp
@@ -229,8 +229,8 @@ cl_int CL_API_CALL clEnqueueMemFillINTEL_EMU(
         return pIntercept->dispatch().clEnqueueSVMMemFill(
             queue,
             dst_ptr,
-            &pattern,
-            sizeof(pattern),
+            pattern,
+            pattern_size,
             size,
             num_events_in_wait_list,
             event_wait_list,


### PR DESCRIPTION
## Description of Changes

The original emulation treats `pattern` as single value to be copied, but it seems not that case.
This changes to forwarding function arguments to `clEnqueueSVMMemFill`.

## Testing Done

I was testing opencl-intercept-layer for emulating USM on SVM, e.g. Rusticl + radeonsi & llvmpipe, so tested using this setup. Also checked with PoCL's implementation and tested on PoCL CPU.

Code edited from AdaptiveCpp test.

```c++
#include <sycl/sycl.hpp>

int main(int argc, char** argv) {
  sycl::queue q{sycl::property_list{sycl::property::queue::in_order{}}};
  std::cout << " [main] "
            << "device name = "
            << q.get_device().get_info<sycl::info::device::name>()
            << std::endl;

  std::size_t test_size = 4096;
  unsigned char *mem = sycl::malloc_device<unsigned char>(test_size, q);

  q.memset(mem, 0, test_size).wait();
  q.memset(mem + 1, 12, test_size - 2).wait();
  std::vector<unsigned char> host_mem(test_size);
  q.memcpy(host_mem.data(), mem, test_size);

  q.wait();

  for (int i = 0; i < test_size; ++i) {
    if (i == 0 || i == test_size - 1)
      assert(host_mem[i] == 0);
    else
      assert(host_mem[i] == 12);
  }

  sycl::free(mem, q);
}
```

Run with
```bash
export RUSTICL_ENABLE=radeonsi
export LD_PRELOAD=/opt/opencl-intercept-layer/lib/libOpenCL.so
export CLI_Emulate_cl_intel_unified_shared_memory=1
export CLI_SuppressLogging=1

./memset
```