### PR TITLE
update to the provisional cl_khr_command_buffers version 0.9.6

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -13,7 +13,7 @@ extern "C" {
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_command_buffer
 
-// Note: This implements the provisional extension v0.9.5.
+// Note: This implements the provisional extension v0.9.6.
 
 typedef cl_bitfield         cl_device_command_buffer_capabilities_khr;
 typedef struct _cl_command_buffer_khr* cl_command_buffer_khr;
@@ -26,12 +26,12 @@ typedef cl_properties       cl_command_properties_khr;
 typedef struct _cl_mutable_command_khr* cl_mutable_command_khr;
 
 #define CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR           0x12A9
+#define CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR 0x129A
 #define CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR 0x12AA
 
 #define CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR      (1 << 0)
 #define CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR (1 << 1)
 #define CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR   (1 << 2)
-#define CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR       (1 << 3)
 
 #define CL_COMMAND_BUFFER_FLAGS_KHR                         0x1293
 #define CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR              (1 << 0)

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -688,12 +688,12 @@ CEnumNameMap::CEnumNameMap()
 
     // cl_khr_command_buffer
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR );
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR );
 
     ADD_ENUM_NAME( m_cl_device_command_buffer_capabilities_khr, CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR );
     ADD_ENUM_NAME( m_cl_device_command_buffer_capabilities_khr, CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR );
     ADD_ENUM_NAME( m_cl_device_command_buffer_capabilities_khr, CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR );
-    ADD_ENUM_NAME( m_cl_device_command_buffer_capabilities_khr, CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR );
 
     ADD_ENUM_NAME( m_cl_int, CL_COMMAND_BUFFER_FLAGS_KHR );
 


### PR DESCRIPTION
## Description of Changes

Updatest to the latest provisional extension `cl_khr_command_buffers` version 0.9.6.

## Testing Done

Verified that tracing works by running the commandbuffers sample with the updated command buffer emulation later.
