### PR TITLE
add support for dumping command buffers to dot files

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -525,6 +525,16 @@ This is the list of options that is implicitly passed to CLANG to build a non-Op
 
 This is the list of options that is implicitly passed to CLANG to build an OpenCL 2.0 SPIR-V module.  Any application-provided build options will be appended to these build options.
 
+### Controls for Dumping Command Buffers
+
+##### `OmitCommandBufferNumber` (bool)
+
+If set to a nonzero value, the Intercept Layer for OpenCL Applications will omit the command buffer number from dumped file names and hash tracking.  This can produce deterministic results even if command buffers are creatd and finalized in a non-deterministic order (say, by multiple threads).
+
+##### `DumpCommandBuffers` (bool)
+
+If set to a nonzero value, the Intercept Layer for OpenCL Applications will dump the commands and dependencies in a command buffer to a file when the command buffer is successfully finalized.  The file name will have the form "CLI\_\<Command BufferNumber\>\_\<Uniqueue Command BufferHash Code\>\_cmdbuf.dot".   The command buffer is described using the DOT graph description language.
+
 ### Controls for Dumping and Injecting Buffers and Images
 
 ##### `DumpBufferHashes` (bool)

--- a/intercept/CMakeLists.txt
+++ b/intercept/CMakeLists.txt
@@ -60,6 +60,7 @@ source_group(Resources FILES
 set(CLINTERCEPT_SOURCE_FILES
     src/chrometracer.h
     src/chrometracer.cpp
+    src/cmdbufrecorder.h
     src/clIntercept.def
     src/clIntercept.map
     src/cli_ext.h

--- a/intercept/src/cmdbuftracer.h
+++ b/intercept/src/cmdbuftracer.h
@@ -1,0 +1,168 @@
+/*
+// Copyright (c) 2025 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+*/
+#pragma once
+
+#include <atomic>
+#include <cinttypes>
+#include <map>
+#include <vector>
+#include <sstream>
+
+#include <stdint.h>
+
+#include "common.h"
+
+struct SCommandBufferTraceInfo
+{
+    std::ostringstream trace;
+
+    void    create(
+                cl_command_buffer_khr cmdbuf,
+                bool isInOrder)
+    {
+        queueIsInOrder = isInOrder;
+        trace << "digraph {\n";
+        trace << "  // " << (queueIsInOrder ? "in-order" : "out-of-order") << " command-buffer\n";
+    }
+
+    void    traceCommand(
+                cl_command_queue queue,
+                const char* cmd,
+                const std::string& tag,
+                cl_uint num_sync_points_in_wait_list,
+                const cl_sync_point_khr* sync_point_wait_list,
+                cl_sync_point_khr* sync_point)
+    {
+        SCommandBufferTraceId id =
+            sync_point == nullptr ?
+            makeInternalId() :
+            makeSyncPointId(*sync_point);
+
+        trace << "  " << (id.isInternal ? "internal" : "syncpoint") << id.id
+              << " [shape=oval, label=\"" << cmd;
+        if( !tag.empty() )
+        {
+            trace << "( " << tag << " )";
+        }
+        trace << "\"]\n";
+
+        for( cl_uint s = 0; s < num_sync_points_in_wait_list; s++ )
+        {
+            trace << "  syncpoint" << sync_point_wait_list[s]
+                  << " -> "
+                  << (id.isInternal ? "internal" : "syncpoint") << id.id
+                  << " // explicit dependency\n";
+        }
+
+        for( const auto& dep : implicitDeps )
+        {
+            trace << "  " << (dep.isInternal ? "internal" : "syncpoint") << dep.id
+                  << " -> "
+                  << (id.isInternal ? "internal" : "syncpoint") << id.id
+                  << " [style=dashed] // implicit dependency\n";
+        }
+
+        if( queueIsInOrder )
+        {
+            implicitDeps.clear();
+            implicitDeps.push_back(id);
+        }
+        else
+        {
+            outstandingIds.push_back(id);
+        }
+    }
+
+    void    traceBarrier(
+                cl_command_queue queue,
+                const char* cmd,
+                cl_uint num_sync_points_in_wait_list,
+                const cl_sync_point_khr* sync_point_wait_list,
+                cl_sync_point_khr* sync_point)
+    {
+        SCommandBufferTraceId id =
+            sync_point == nullptr ?
+            makeInternalId() :
+            makeSyncPointId(*sync_point);
+
+        trace << "  " << (id.isInternal ? "internal" : "syncpoint") << id.id
+              << " [shape=octagon, label=\"" << cmd << "\"]\n";
+
+        // If there is a sync point wait list, then the barrier depends on all
+        // of the commands in the sync point wait list. Otherwise, the barrier
+        // depends on all of the outstanding ids.
+        if( num_sync_points_in_wait_list > 0 )
+        {
+            for( cl_uint s = 0; s < num_sync_points_in_wait_list; s++ )
+            {
+                trace << "  syncpoint" << sync_point_wait_list[s]
+                      << " -> "
+                      << (id.isInternal ? "internal" : "syncpoint") << id.id
+                      << " // explicit dependency\n";
+            }
+        }
+        else
+        {
+            for( const auto& dep : outstandingIds )
+            {
+                trace << "  " << (dep.isInternal ? "internal" : "syncpoint") << dep.id
+                      << " -> "
+                      << (id.isInternal ? "internal" : "syncpoint") << id.id
+                      << " [style=dotted] // barrier dependency\n";
+            }
+            outstandingIds.clear();
+        }
+
+        // Add the implicit dependencies.
+        for( const auto& dep : implicitDeps )
+        {
+            trace << "  " << (dep.isInternal ? "internal" : "syncpoint") << dep.id
+                  << " -> "
+                  << (id.isInternal ? "internal" : "syncpoint") << id.id
+                  << " [style=dashed] // implicit dependency\n";
+        }
+
+        // Now, the only implicit dependency that remains is this barrier.
+        implicitDeps.clear();
+        implicitDeps.push_back(id);
+    }
+
+    void finalize()
+    {
+        trace << "}\n";
+    }
+
+private:
+    struct SCommandBufferTraceId
+    {
+        bool        isInternal = false;
+        uint32_t    id = 0;
+    };
+
+    std::atomic<uint32_t> nextInternalId;
+
+    bool    queueIsInOrder;
+
+    std::vector<SCommandBufferTraceId>  implicitDeps;
+    std::vector<SCommandBufferTraceId>  outstandingIds;
+
+    SCommandBufferTraceId makeInternalId()
+    {
+        SCommandBufferTraceId id;
+        id.isInternal = true;
+        id.id = nextInternalId.fetch_add(1, std::memory_order_relaxed);
+        return id;
+    }
+
+    SCommandBufferTraceId makeSyncPointId(
+        cl_sync_point_khr sync_point)
+    {
+        SCommandBufferTraceId id;
+        id.isInternal = false;
+        id.id = sync_point;
+        return id;
+    }
+};

--- a/intercept/src/controls.h
+++ b/intercept/src/controls.h
@@ -120,6 +120,9 @@ CLI_CONTROL( std::string,   SPIRVDis,                               "spirv-dis",
 CLI_CONTROL( std::string,   DefaultOptions,                         "-cc1 -x cl -cl-std=CL1.2 -D__OPENCL_C_VERSION__=120 -D__OPENCL_VERSION__=120 -emit-spirv -triple=spir", "This is the list of options that is implicitly passed to CLANG to build a non-OpenCL 2.0 SPIR-V module.  Any application-provided build options will be appended to these build options." )
 CLI_CONTROL( std::string,   OpenCL2Options,                         "-cc1 -x cl -cl-std=CL2.0 -D__OPENCL_C_VERSION__=200 -D__OPENCL_VERSION__=200 -emit-spirv -triple=spir", "This is the list of options that is implicitly passed to CLANG to build an OpenCL 2.0 SPIR-V module.  Any application-provided build options will be appended to these build options." )
 
+CLI_CONTROL_SEPARATOR( Controls for Dumping Command Buffers: )
+CLI_CONTROL( bool,          DumpCommandBuffers,                     false, "TODO" )
+
 CLI_CONTROL_SEPARATOR( Controls for Dumping and Injecting Buffers and Images: )
 CLI_CONTROL( bool,          DumpBufferHashes,                       false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will dump hashes of a buffer, SVM, or USM allocation rather than the full contents of the buffer.  This can be useful to identify which kernel enqueues generate different results without requiring a large amount of disk space." )
 CLI_CONTROL( bool,          DumpImageHashes,                        false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will dump hashes of an image rather than the full contents of the image.  This can be useful to identify which kernel enqueues generate different results without requiring a large amount of disk space." )

--- a/intercept/src/controls.h
+++ b/intercept/src/controls.h
@@ -121,7 +121,8 @@ CLI_CONTROL( std::string,   DefaultOptions,                         "-cc1 -x cl 
 CLI_CONTROL( std::string,   OpenCL2Options,                         "-cc1 -x cl -cl-std=CL2.0 -D__OPENCL_C_VERSION__=200 -D__OPENCL_VERSION__=200 -emit-spirv -triple=spir", "This is the list of options that is implicitly passed to CLANG to build an OpenCL 2.0 SPIR-V module.  Any application-provided build options will be appended to these build options." )
 
 CLI_CONTROL_SEPARATOR( Controls for Dumping Command Buffers: )
-CLI_CONTROL( bool,          DumpCommandBuffers,                     false, "TODO" )
+CLI_CONTROL( bool,          OmitCommandBufferNumber,                false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will omit the command buffer number from dumped file names and hash tracking.  This can produce deterministic results even if command buffers are creatd and finalized in a non-deterministic order (say, by multiple threads)." )
+CLI_CONTROL( bool,          DumpCommandBuffers,                     false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will dump the commands and dependencies in a command buffer to a file when the command buffer is successfully finalized.  The file name will have the form \"CLI_<Command BufferNumber>_<Uniqueue Command BufferHash Code>_cmdbuf.dot\".   The command buffer is described using the DOT graph description language." )
 
 CLI_CONTROL_SEPARATOR( Controls for Dumping and Injecting Buffers and Images: )
 CLI_CONTROL( bool,          DumpBufferHashes,                       false, "If set to a nonzero value, the Intercept Layer for OpenCL Applications will dump hashes of a buffer, SVM, or USM allocation rather than the full contents of the buffer.  This can be useful to identify which kernel enqueues generate different results without requiring a large amount of disk space." )

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -10469,7 +10469,7 @@ CL_API_ENTRY cl_command_buffer_khr CL_API_CALL clCreateCommandBufferKHR(
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( errcode_ret[0] );
             ADD_OBJECT_ALLOCATION( retVal );
-            TRACE_COMMAND_BUFFER_CREATE( retVal, num_queues, queues );
+            RECORD_COMMAND_BUFFER_CREATE( retVal, num_queues, queues );
             CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
             if( retVal != NULL )
@@ -10510,7 +10510,8 @@ CL_API_ENTRY cl_int CL_API_CALL clFinalizeCommandBufferKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            TRACE_COMMAND_BUFFER_FINALIZE( retVal, command_buffer );
+            RECORD_COMMAND_BUFFER_FINALIZE( retVal, command_buffer );
+            DUMP_COMMAND_BUFFER_RECORDING( retVal, command_buffer );
             CALL_LOGGING_EXIT( retVal );
 
             return retVal;
@@ -10717,7 +10718,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandBarrierWithWaitListKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            TRACE_COMMAND_BUFFER_BARRIER(
+            RECORD_COMMAND_BUFFER_BARRIER(
                 retVal,
                 command_buffer,
                 num_sync_points_in_wait_list,
@@ -10787,7 +10788,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyBufferKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            TRACE_COMMAND_BUFFER_COMMAND(
+            RECORD_COMMAND_BUFFER_COMMAND(
                 retVal,
                 command_buffer,
                 num_sync_points_in_wait_list,
@@ -10865,7 +10866,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyBufferRectKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            TRACE_COMMAND_BUFFER_COMMAND(
+            RECORD_COMMAND_BUFFER_COMMAND(
                 retVal,
                 command_buffer,
                 num_sync_points_in_wait_list,
@@ -10935,7 +10936,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyBufferToImageKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            TRACE_COMMAND_BUFFER_COMMAND(
+            RECORD_COMMAND_BUFFER_COMMAND(
                 retVal,
                 command_buffer,
                 num_sync_points_in_wait_list,
@@ -11005,7 +11006,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyImageKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            TRACE_COMMAND_BUFFER_COMMAND(
+            RECORD_COMMAND_BUFFER_COMMAND(
                 retVal,
                 command_buffer,
                 num_sync_points_in_wait_list,
@@ -11077,7 +11078,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyImageToBufferKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            TRACE_COMMAND_BUFFER_COMMAND(
+            RECORD_COMMAND_BUFFER_COMMAND(
                 retVal,
                 command_buffer,
                 num_sync_points_in_wait_list,
@@ -11148,7 +11149,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandFillBufferKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            TRACE_COMMAND_BUFFER_COMMAND(
+            RECORD_COMMAND_BUFFER_COMMAND(
                 retVal,
                 command_buffer,
                 num_sync_points_in_wait_list,
@@ -11217,7 +11218,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandFillImageKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            TRACE_COMMAND_BUFFER_COMMAND(
+            RECORD_COMMAND_BUFFER_COMMAND(
                 retVal,
                 command_buffer,
                 num_sync_points_in_wait_list,
@@ -11286,7 +11287,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandSVMMemcpyKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            TRACE_COMMAND_BUFFER_COMMAND(
+            RECORD_COMMAND_BUFFER_COMMAND(
                 retVal,
                 command_buffer,
                 num_sync_points_in_wait_list,
@@ -11357,7 +11358,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandSVMMemFillKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            TRACE_COMMAND_BUFFER_COMMAND(
+            RECORD_COMMAND_BUFFER_COMMAND(
                 retVal,
                 command_buffer,
                 num_sync_points_in_wait_list,
@@ -11449,7 +11450,7 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandNDRangeKernelKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
-            TRACE_COMMAND_BUFFER_COMMAND_WITH_TAG(
+            RECORD_COMMAND_BUFFER_COMMAND_WITH_TAG(
                 retVal,
                 command_buffer,
                 num_sync_points_in_wait_list,

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -10469,6 +10469,7 @@ CL_API_ENTRY cl_command_buffer_khr CL_API_CALL clCreateCommandBufferKHR(
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( errcode_ret[0] );
             ADD_OBJECT_ALLOCATION( retVal );
+            TRACE_COMMAND_BUFFER_CREATE( retVal, num_queues, queues );
             CALL_LOGGING_EXIT( errcode_ret[0], "returned %p", retVal );
 
             if( retVal != NULL )
@@ -10509,6 +10510,7 @@ CL_API_ENTRY cl_int CL_API_CALL clFinalizeCommandBufferKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
+            TRACE_COMMAND_BUFFER_FINALIZE( retVal, command_buffer );
             CALL_LOGGING_EXIT( retVal );
 
             return retVal;
@@ -10715,6 +10717,12 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandBarrierWithWaitListKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
+            TRACE_COMMAND_BUFFER_BARRIER(
+                retVal,
+                command_buffer,
+                num_sync_points_in_wait_list,
+                sync_point_wait_list,
+                sync_point );
             CALL_LOGGING_EXIT_SYNC_POINT( retVal, sync_point );
             ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
@@ -10779,6 +10787,12 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyBufferKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
+            TRACE_COMMAND_BUFFER_COMMAND(
+                retVal,
+                command_buffer,
+                num_sync_points_in_wait_list,
+                sync_point_wait_list,
+                sync_point );
             CALL_LOGGING_EXIT_SYNC_POINT( retVal, sync_point );
             ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
@@ -10851,6 +10865,12 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyBufferRectKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
+            TRACE_COMMAND_BUFFER_COMMAND(
+                retVal,
+                command_buffer,
+                num_sync_points_in_wait_list,
+                sync_point_wait_list,
+                sync_point );
             CALL_LOGGING_EXIT_SYNC_POINT( retVal, sync_point );
             ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
@@ -10915,6 +10935,12 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyBufferToImageKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
+            TRACE_COMMAND_BUFFER_COMMAND(
+                retVal,
+                command_buffer,
+                num_sync_points_in_wait_list,
+                sync_point_wait_list,
+                sync_point );
             CALL_LOGGING_EXIT_SYNC_POINT( retVal, sync_point );
             ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
@@ -10979,6 +11005,12 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyImageKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
+            TRACE_COMMAND_BUFFER_COMMAND(
+                retVal,
+                command_buffer,
+                num_sync_points_in_wait_list,
+                sync_point_wait_list,
+                sync_point );
             CALL_LOGGING_EXIT_SYNC_POINT( retVal, sync_point );
             ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
@@ -11045,6 +11077,12 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandCopyImageToBufferKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
+            TRACE_COMMAND_BUFFER_COMMAND(
+                retVal,
+                command_buffer,
+                num_sync_points_in_wait_list,
+                sync_point_wait_list,
+                sync_point );
             CALL_LOGGING_EXIT_SYNC_POINT( retVal, sync_point );
             ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
@@ -11110,6 +11148,12 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandFillBufferKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
+            TRACE_COMMAND_BUFFER_COMMAND(
+                retVal,
+                command_buffer,
+                num_sync_points_in_wait_list,
+                sync_point_wait_list,
+                sync_point );
             CALL_LOGGING_EXIT_SYNC_POINT( retVal, sync_point );
             ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
@@ -11173,6 +11217,12 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandFillImageKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
+            TRACE_COMMAND_BUFFER_COMMAND(
+                retVal,
+                command_buffer,
+                num_sync_points_in_wait_list,
+                sync_point_wait_list,
+                sync_point );
             CALL_LOGGING_EXIT_SYNC_POINT( retVal, sync_point );
             ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
@@ -11236,6 +11286,12 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandSVMMemcpyKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
+            TRACE_COMMAND_BUFFER_COMMAND(
+                retVal,
+                command_buffer,
+                num_sync_points_in_wait_list,
+                sync_point_wait_list,
+                sync_point );
             CALL_LOGGING_EXIT_SYNC_POINT( retVal, sync_point );
             ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
@@ -11301,6 +11357,12 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandSVMMemFillKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
+            TRACE_COMMAND_BUFFER_COMMAND(
+                retVal,
+                command_buffer,
+                num_sync_points_in_wait_list,
+                sync_point_wait_list,
+                sync_point );
             CALL_LOGGING_EXIT_SYNC_POINT( retVal, sync_point );
             ADD_MUTABLE_COMMAND( mutable_handle, command_buffer );
 
@@ -11362,6 +11424,13 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandNDRangeKernelKHR(
                 command_queue,
                 kernel,
                 argsString.c_str() );
+            GET_TIMING_TAGS_COMMAND_BUFFER_KERNEL(
+                command_buffer,
+                kernel,
+                work_dim,
+                global_work_offset,
+                global_work_size,
+                local_work_size );
             HOST_PERFORMANCE_TIMING_START();
 
             cl_int  retVal = dispatchX.clCommandNDRangeKernelKHR(
@@ -11380,6 +11449,12 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandNDRangeKernelKHR(
 
             HOST_PERFORMANCE_TIMING_END();
             CHECK_ERROR( retVal );
+            TRACE_COMMAND_BUFFER_COMMAND_WITH_TAG(
+                retVal,
+                command_buffer,
+                num_sync_points_in_wait_list,
+                sync_point_wait_list,
+                sync_point );
             CALL_LOGGING_EXIT_SYNC_POINT( retVal, sync_point );
             ADD_MUTABLE_COMMAND_NDRANGE( mutable_handle, command_buffer, work_dim );
 

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -11425,13 +11425,14 @@ CL_API_ENTRY cl_int CL_API_CALL clCommandNDRangeKernelKHR(
                 command_queue,
                 kernel,
                 argsString.c_str() );
-            GET_TIMING_TAGS_COMMAND_BUFFER_KERNEL(
+            GET_RECORD_TAG_COMMAND_BUFFER_KERNEL(
                 command_buffer,
                 kernel,
                 work_dim,
                 global_work_offset,
                 global_work_size,
-                local_work_size );
+                local_work_size,
+                mutable_handle );
             HOST_PERFORMANCE_TIMING_START();
 
             cl_int  retVal = dispatchX.clCommandNDRangeKernelKHR(

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -6738,7 +6738,7 @@ void CLIntercept::recordCommandBufferCreate(
         queues,
         cmdbuf );
 
-    cl_command_queue_properties props = 0xA5A5A5A5;
+    cl_command_queue_properties props = 0;
     dispatch().clGetCommandQueueInfo(
         queue,
         CL_QUEUE_PROPERTIES,

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -1364,6 +1364,8 @@ private:
     typedef std::map< cl_semaphore_khr, cl_platform_id >    CSemaphoreInfoMap;
     CSemaphoreInfoMap   m_SemaphoreInfoMap;
 
+    unsigned int    m_CommandBufferNumber;
+
     typedef std::map< cl_command_buffer_khr, cl_platform_id >   CCommandBufferInfoMap;
     CCommandBufferInfoMap   m_CommandBufferInfoMap;
 

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -419,15 +419,15 @@ public:
                 const size_t* lws,
                 std::string& hostTag,
                 std::string& deviceTag );
-    void    getTimingTagsCommandBufferKernel(
+    void    getRecordTagCommandBufferKernel(
                 const cl_command_buffer_khr cmdbuf,
                 const cl_kernel kernel,
                 const cl_uint workDim,
                 const size_t* gwo,
                 const size_t* gws,
                 const size_t* lws,
-                std::string& hostTag,
-                std::string& deviceTag );
+                const cl_mutable_command_khr* mutable_handle,
+                std::string& recordTag);
 
     void    updateHostTimingStats(
                 const char* functionName,
@@ -3203,19 +3203,19 @@ inline bool CLIntercept::checkAubCaptureEnqueueLimits(
             deviceTag );                                                    \
     }
 
-#define GET_TIMING_TAGS_COMMAND_BUFFER_KERNEL( _cmdbuf, _kernel, _dim, _gwo, _gws, _lws )\
-    std::string hostTag, deviceTag;                                         \
+#define GET_RECORD_TAG_COMMAND_BUFFER_KERNEL( _cmdbuf, _kernel, _dim, _gwo, _gws, _lws, _mh )\
+    std::string recordTag;                                                  \
     if( pIntercept->config().DumpCommandBuffers )                           \
     {                                                                       \
-        pIntercept->getTimingTagsCommandBufferKernel(                       \
+        pIntercept->getRecordTagCommandBufferKernel(                        \
             _cmdbuf,                                                        \
             _kernel,                                                        \
             _dim,                                                           \
             _gwo,                                                           \
             _gws,                                                           \
             _lws,                                                           \
-            hostTag,                                                        \
-            deviceTag );                                                    \
+            _mh,                                                            \
+            recordTag );                                                    \
     }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3518,7 +3518,7 @@ inline void CLIntercept::flushChromeTraceBuffering()
         pIntercept->recordCommandBufferCommand(                             \
             _cmdbuf,                                                        \
             __FUNCTION__,                                                   \
-            hostTag,                                                        \
+            recordTag,                                                      \
             _nspwl,                                                         \
             _spwl,                                                          \
             _sp);                                                           \

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -3545,7 +3545,7 @@ inline void CLIntercept::flushChromeTraceBuffering()
     if( _errcode == CL_SUCCESS && _cmdbuf &&                                \
         pIntercept->config().DumpCommandBuffers ) {                         \
         pIntercept->dumpCommandBufferRecording( _cmdbuf );                  \
-    } 
+    }
 
 ///////////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
## Description of Changes

Adds support for dumping the contents of a command buffer to a file when the command buffer is finalized.  The command buffers are described using the [DOT graph description language](https://en.wikipedia.org/wiki/DOT_(graph_description_language)), which can be used by various tools and editor extensions to visualize the structure of a command buffer.

## Testing Done

Tested by dumping command buffers for all of the command buffer and command buffer mutable dispatch CTS tests and verifying that they generate valid DOT files.
