### PR TITLE
initial support for cl_ext_buffer_device_address

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -989,7 +989,7 @@ extern CL_API_ENTRY
 cl_int CL_API_CALL clSetKernelArgDevicePointerEXT(
     cl_kernel kernel,
     cl_uint arg_index,
-    const cl_mem_device_address_ext* arg_value);
+    cl_mem_device_address_ext arg_value);
 
 #define CL_MEM_DEVICE_PRIVATE_ADDRESS_EXT           0x5000
 #define CL_MEM_DEVICE_ADDRESS_EXT                   0x5001

--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -981,6 +981,21 @@ cl_int CL_API_CALL clGetKernelSuggestedLocalWorkSizeKHR(
 #define CL_DEVICE_MAX_ATOMIC_COUNTERS_EXT           0x4032
 
 ///////////////////////////////////////////////////////////////////////////////
+// cl_ext_buffer_device_address
+
+typedef cl_ulong cl_mem_device_address_ext;
+
+extern CL_API_ENTRY
+cl_int CL_API_CALL clSetKernelArgDevicePointerEXT(
+    cl_kernel kernel,
+    cl_uint arg_index,
+    const cl_mem_device_address_ext* arg_value);
+
+#define CL_MEM_DEVICE_PRIVATE_ADDRESS_EXT           0x5000
+#define CL_MEM_DEVICE_ADDRESS_EXT                   0x5001
+#define CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT         0x5002
+
+///////////////////////////////////////////////////////////////////////////////
 // cl_ext_cxx_for_opencl
 
 #define CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT 0x4230

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -8915,6 +8915,46 @@ CL_API_ENTRY cl_int CL_API_CALL clGetKernelSuggestedLocalWorkSizeKHR(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+// cl_ext_buffer_device_address
+CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgDevicePointerEXT(
+    cl_kernel kernel,
+    cl_uint arg_index,
+    const cl_mem_device_address_ext* arg_value)
+{
+    CLIntercept*    pIntercept = GetIntercept();
+
+    if( pIntercept )
+    {
+        const auto& dispatchX = pIntercept->dispatchX(kernel);
+        if( dispatchX.clSetKernelArgDevicePointerEXT )
+        {
+            GET_ENQUEUE_COUNTER();
+            CALL_LOGGING_ENTER_KERNEL(
+                kernel,
+                "kernel = %p, index = %u, value = %" PRIu64,
+                kernel,
+                arg_index,
+                arg_value );
+            HOST_PERFORMANCE_TIMING_START();
+
+            cl_int  retVal = dispatchX.clSetKernelArgDevicePointerEXT(
+                kernel,
+                arg_index,
+                arg_value );
+
+            HOST_PERFORMANCE_TIMING_END();
+            CHECK_ERROR( retVal );
+            CALL_LOGGING_EXIT( retVal );
+
+            return retVal;
+        }
+    }
+
+    NULL_FUNCTION_POINTER_RETURN_ERROR(CL_INVALID_KERNEL);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
 // cl_ext_image_requirements_info
 CL_API_ENTRY cl_int CL_API_CALL clGetImageRequirementsInfoEXT(
     cl_context context,

--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -8919,7 +8919,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetKernelSuggestedLocalWorkSizeKHR(
 CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgDevicePointerEXT(
     cl_kernel kernel,
     cl_uint arg_index,
-    const cl_mem_device_address_ext* arg_value)
+    cl_mem_device_address_ext arg_value)
 {
     CLIntercept*    pIntercept = GetIntercept();
 
@@ -8931,7 +8931,7 @@ CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgDevicePointerEXT(
             GET_ENQUEUE_COUNTER();
             CALL_LOGGING_ENTER_KERNEL(
                 kernel,
-                "kernel = %p, index = %u, value = %" PRIu64,
+                "kernel = %p, index = %u, value = %" PRIx64,
                 kernel,
                 arg_index,
                 arg_value );

--- a/intercept/src/dispatch.h
+++ b/intercept/src/dispatch.h
@@ -487,6 +487,12 @@ struct CLdispatchX
         const size_t* global_work_size,
         size_t* suggested_local_work_size);
 
+    // cl_ext_buffer_device_address
+    cl_int  (CL_API_CALL *clSetKernelArgDevicePointerEXT) (
+        cl_kernel kernel,
+        cl_uint arg_index,
+        const cl_mem_device_address_ext* arg_value);
+
     // cl_ext_image_requirements_info
     cl_int  (CL_API_CALL *clGetImageRequirementsInfoEXT) (
         cl_context context,

--- a/intercept/src/dispatch.h
+++ b/intercept/src/dispatch.h
@@ -491,7 +491,7 @@ struct CLdispatchX
     cl_int  (CL_API_CALL *clSetKernelArgDevicePointerEXT) (
         cl_kernel kernel,
         cl_uint arg_index,
-        const cl_mem_device_address_ext* arg_value);
+        cl_mem_device_address_ext arg_value);
 
     // cl_ext_image_requirements_info
     cl_int  (CL_API_CALL *clGetImageRequirementsInfoEXT) (

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -882,6 +882,11 @@ CEnumNameMap::CEnumNameMap()
     // cl_ext_atomic_counters
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_MAX_ATOMIC_COUNTERS_EXT );
 
+    // cl_ext_buffer_device_address
+    ADD_ENUM_NAME( m_cl_int, CL_MEM_DEVICE_PRIVATE_ADDRESS_EXT );
+    ADD_ENUM_NAME( m_cl_int, CL_MEM_DEVICE_ADDRESS_EXT );
+    ADD_ENUM_NAME( m_cl_int, CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT );
+
     // cl_ext_cxx_for_opencl
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT );
 

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -2444,6 +2444,14 @@ void CLIntercept::getMemPropertiesString(
                     properties += 2;
                 }
                 break;
+            case CL_MEM_DEVICE_PRIVATE_ADDRESS_EXT:
+                {
+                    auto pb = (const cl_bool*)( properties + 1 );
+                    cl_bool value = pb[0];
+                    str += enumName().name_bool( value );
+                    properties += 2;
+                }
+                break;
             default:
                 {
                     CLI_SPRINTF( s, 256, "<Unknown %08X!>", (cl_uint)property );
@@ -13176,6 +13184,9 @@ void* CLIntercept::getExtensionFunctionAddress(
 
     // cl_khr_suggested_local_work_size
     CHECK_RETURN_EXTENSION_FUNCTION( clGetKernelSuggestedLocalWorkSizeKHR );
+
+    // cl_ext_buffer_device_address
+    CHECK_RETURN_EXTENSION_FUNCTION( clSetKernelArgDevicePointerEXT );
 
     // cl_ext_image_requirements_info
     CHECK_RETURN_EXTENSION_FUNCTION( clGetImageRequirementsInfoEXT );


### PR DESCRIPTION
## Description of Changes

Adds tracing for the [cl_ext_buffer_device_address](https://github.com/KhronosGroup/OpenCL-Docs/pull/1159) extension.

## Testing Done

Basic testing with POCL, which supports an early version of the cl_ext_buffer_device_address extension.