### PR TITLE
add tracing for cl_ext_immutable_memory_objects

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -1028,6 +1028,11 @@ cl_int CL_API_CALL clSetKernelArgDevicePointerEXT(
 #define CL_PARTITION_BY_NAMES_LIST_END_EXT          -1
 
 ///////////////////////////////////////////////////////////////////////////////
+// cl_ext_immutable_memory_objects
+
+#define CL_MEM_IMMUTABLE_EXT                        (1 << 6)
+
+///////////////////////////////////////////////////////////////////////////////
 // cl_ext_float_atomics
 
 typedef cl_bitfield         cl_device_fp_atomic_capabilities_ext;

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -304,7 +304,6 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_mem_flags, CL_MEM_USE_HOST_PTR );
     ADD_ENUM_NAME( m_cl_mem_flags, CL_MEM_ALLOC_HOST_PTR );
     ADD_ENUM_NAME( m_cl_mem_flags, CL_MEM_COPY_HOST_PTR );
-    // reserved                                         (1 << 6)
     ADD_ENUM_NAME( m_cl_mem_flags, CL_MEM_HOST_WRITE_ONLY );
     ADD_ENUM_NAME( m_cl_mem_flags, CL_MEM_HOST_READ_ONLY );
     ADD_ENUM_NAME( m_cl_mem_flags, CL_MEM_HOST_NO_ACCESS );
@@ -920,6 +919,9 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_int, CL_IMAGE_REQUIREMENTS_MAX_HEIGHT_EXT );
     ADD_ENUM_NAME( m_cl_int, CL_IMAGE_REQUIREMENTS_MAX_DEPTH_EXT );
     ADD_ENUM_NAME( m_cl_int, CL_IMAGE_REQUIREMENTS_MAX_ARRAY_SIZE_EXT );
+
+    // cl_ext_immutable_memory_objects
+    ADD_ENUM_NAME( m_cl_mem_flags, CL_MEM_IMMUTABLE_EXT );
 
     // cl_altera_compiler_mode
     ADD_ENUM_NAME( m_cl_int, CL_CONTEXT_COMPILER_MODE_ALTERA );


### PR DESCRIPTION
## Description of Changes

Adds tracing for the new `cl_mem_flag` added by `cl_ext_immutable_memory_objects`.

## Testing Done

Tested with a simpler tester that created a buffer with the new flag.  Verified that the new flags was printed properly via CallLogging.
