### PR TITLE
add a control to prepend a string to CL_DEVICE_EXTENSIONS

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -891,6 +891,10 @@ If set to a non-negative value, the clGetDeviceInfo() query for CL\_DEVICE\_PREF
 
 If set to a non-empty string, the clGetDeviceInfo() query for CL\_DRIVER\_VERSION will return this value instead of the true driver version.
 
+##### `PrependDeviceExtensions` (string)
+
+If set to a non-empty string, the clGetDeviceInfo() query for CL\_DEVICE\_EXTENSIONS will return this value followed by the true device extensions string.
+
 ### Precompiled Kernel and Builtin Kernel Override Controls
 
 ##### `ForceByteBufferOverrides` (bool)

--- a/intercept/src/controls.h
+++ b/intercept/src/controls.h
@@ -221,6 +221,7 @@ CLI_CONTROL( cl_uint,       DevicePreferredVectorWidthHalf,         UINT_MAX, "I
 CLI_CONTROL( cl_uint,       DevicePreferredVectorWidthFloat,        UINT_MAX, "If set to a non-negative value, the clGetDeviceInfo() query for CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT will return this value instead of the true device preferred vector width." )
 CLI_CONTROL( cl_uint,       DevicePreferredVectorWidthDouble,       UINT_MAX, "If set to a non-negative value, the clGetDeviceInfo() query for CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE will return this value instead of the true device preferred vector width." )
 CLI_CONTROL( std::string,   DriverVersion,                          "",    "If set to a non-empty string, the clGetDeviceInfo() query for CL_DRIVER_VERSION will return this value instead of the true driver version." )
+CLI_CONTROL( std::string,   PrependDeviceExtensions,                "",    "If set to a non-empty string, the clGetDeviceInfo() query for CL_DEVICE_EXTENSIONS will return this value followed by the true device extensions string." )
 
 CLI_CONTROL_SEPARATOR( Precompiled Kernel and Builtin Kernel Override Controls: )
 CLI_CONTROL( bool,          ForceByteBufferOverrides,               false, "If set to a nonzero value, each of the buffer functions that are overridden (via one or more of the keys below) will use a byte-wise operation to read/write/copy the buffer (default behavior is to try to copy multiple bytes at a time, if possible).  Note: Requires OpenCL 1.1 or the \"byte addressable store\" extension." )

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -11151,7 +11151,7 @@ bool CLIntercept::overrideGetPlatformInfo(
     switch( param_name )
     {
     case CL_PLATFORM_NAME:
-        if( m_Config.PlatformName != "" )
+        if( !m_Config.PlatformName.empty() )
         {
             char*   ptr = (char*)param_value;
             errorCode = writeStringToMemory(
@@ -11163,7 +11163,7 @@ bool CLIntercept::overrideGetPlatformInfo(
         }
         break;
     case CL_PLATFORM_VENDOR:
-        if( m_Config.PlatformVendor != "" )
+        if( !m_Config.PlatformVendor.empty() )
         {
             char*   ptr = (char*)param_value;
             errorCode = writeStringToMemory(
@@ -11175,7 +11175,7 @@ bool CLIntercept::overrideGetPlatformInfo(
         }
         break;
     case CL_PLATFORM_PROFILE:
-        if( m_Config.PlatformProfile != "" )
+        if( !m_Config.PlatformProfile.empty() )
         {
             char*   ptr = (char*)param_value;
             errorCode = writeStringToMemory(
@@ -11187,7 +11187,7 @@ bool CLIntercept::overrideGetPlatformInfo(
         }
         break;
     case CL_PLATFORM_VERSION:
-        if( m_Config.PlatformVersion != "" )
+        if( !m_Config.PlatformVersion.empty() )
         {
             char*   ptr = (char*)param_value;
             errorCode = writeStringToMemory(
@@ -11309,7 +11309,7 @@ bool CLIntercept::overrideGetDeviceInfo(
         }
         break;
     case CL_DEVICE_NAME:
-        if( m_Config.DeviceName != "" )
+        if( !m_Config.DeviceName.empty() )
         {
             char*   ptr = (char*)param_value;
             errorCode = writeStringToMemory(
@@ -11321,7 +11321,7 @@ bool CLIntercept::overrideGetDeviceInfo(
         }
         break;
     case CL_DEVICE_EXTENSIONS:
-        if( m_Config.DeviceExtensions != "" )
+        if( !m_Config.DeviceExtensions.empty() )
         {
             char*   ptr = (char*)param_value;
             errorCode = writeStringToMemory(
@@ -11331,11 +11331,16 @@ bool CLIntercept::overrideGetDeviceInfo(
                 ptr );
             override = true;
         }
-        else if( m_Config.Emulate_cl_khr_extended_versioning ||
+        else if( !m_Config.PrependDeviceExtensions.empty() ||
+                 m_Config.Emulate_cl_khr_extended_versioning ||
                  m_Config.Emulate_cl_khr_semaphore ||
                  m_Config.Emulate_cl_intel_unified_shared_memory )
         {
-            std::string newExtensions;
+            std::string newExtensions(m_Config.PrependDeviceExtensions);
+            if( !newExtensions.empty() && newExtensions.back() != ' ' )
+            {
+                newExtensions.push_back(' ');
+            }
             if( m_Config.Emulate_cl_khr_extended_versioning &&
                 !checkDeviceForExtension( device, "cl_khr_extended_versioning") )
             {
@@ -11376,7 +11381,7 @@ bool CLIntercept::overrideGetDeviceInfo(
         }
         break;
     case CL_DEVICE_VENDOR:
-        if( m_Config.DeviceVendor != "" )
+        if( !m_Config.DeviceVendor.empty() )
         {
             char*   ptr = (char*)param_value;
             errorCode = writeStringToMemory(
@@ -11388,7 +11393,7 @@ bool CLIntercept::overrideGetDeviceInfo(
         }
         break;
     case CL_DEVICE_PROFILE:
-        if( m_Config.DeviceProfile != "" )
+        if( !m_Config.DeviceProfile.empty() )
         {
             char*   ptr = (char*)param_value;
             errorCode = writeStringToMemory(
@@ -11400,7 +11405,7 @@ bool CLIntercept::overrideGetDeviceInfo(
         }
         break;
     case CL_DEVICE_VERSION:
-        if( m_Config.DeviceVersion != "" )
+        if( !m_Config.DeviceVersion.empty() )
         {
             char*   ptr = (char*)param_value;
             errorCode = writeStringToMemory(
@@ -11412,7 +11417,7 @@ bool CLIntercept::overrideGetDeviceInfo(
         }
         break;
     case CL_DEVICE_OPENCL_C_VERSION:
-        if( m_Config.DeviceCVersion != "" )
+        if( !m_Config.DeviceCVersion.empty() )
         {
             char*   ptr = (char*)param_value;
             errorCode = writeStringToMemory(
@@ -11424,7 +11429,7 @@ bool CLIntercept::overrideGetDeviceInfo(
         }
         break;
     case CL_DEVICE_IL_VERSION:
-        if( m_Config.DeviceILVersion != "" )
+        if( !m_Config.DeviceILVersion.empty() )
         {
             char*   ptr = (char*)param_value;
             errorCode = writeStringToMemory(
@@ -11702,7 +11707,7 @@ bool CLIntercept::overrideGetDeviceInfo(
         }
         break;
     case CL_DRIVER_VERSION:
-        if( m_Config.DriverVersion != "" )
+        if( !m_Config.DriverVersion.empty() )
         {
             char*   ptr = (char*)param_value;
             errorCode = writeStringToMemory(


### PR DESCRIPTION
## Description of Changes

Adds a control `PrependDeviceExtensions` to prepend an extension string to `CL_DEVICE_EXTENSIONS`.  This is an easy way to "add support" for a new extension, especially for multiple devices, without completely overriding the device extension string using the existing `DeviceExtensions` control.

Note that this only affects `CL_DEVICE_EXTENSIONS` and does not currently affect `CL_DEVICE_EXTENSIONS_WITH_VERSION`, similar to the existing `DeviceExtensions` control.

## Testing Done

Set the control and confirmed that the added extensions appeared in the extension string reported by `clinfo`.