### PR TITLE
add Win32 build configurations to GitHub actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,12 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: windows-latest
+            windows-arch: x64
+          - os: windows-latest
+            windows-arch: Win32
 
     runs-on: ${{matrix.os}}
 
@@ -48,7 +53,12 @@ jobs:
     - name: Run CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake -DENABLE_CLILOADER=1 -DCMAKE_BUILD_TYPE=$BUILD_TYPE $GITHUB_WORKSPACE
+      run: |
+        if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+          cmake -DENABLE_CLILOADER=1 -DCMAKE_BUILD_TYPE=$BUILD_TYPE -A ${{ matrix.windows-arch }} $GITHUB_WORKSPACE
+        else
+          cmake -DENABLE_CLILOADER=1 -DCMAKE_BUILD_TYPE=$BUILD_TYPE                               $GITHUB_WORKSPACE
+        fi
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,12 @@ jobs:
   release:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
+        include:
+          - os: windows-latest
+            windows-arch: x64
+          - os: windows-latest
+            windows-arch: Win32
 
     runs-on: ${{matrix.os}}
 
@@ -42,7 +47,12 @@ jobs:
     - name: Run CMake
       shell: bash
       working-directory: ./build
-      run: cmake -DENABLE_CLILOADER=1 -DCMAKE_BUILD_TYPE=$BUILD_TYPE $GITHUB_WORKSPACE
+      run: |
+        if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+          cmake -DENABLE_CLILOADER=1 -DCMAKE_BUILD_TYPE=$BUILD_TYPE -A ${{ matrix.windows-arch }} $GITHUB_WORKSPACE
+        else
+          cmake -DENABLE_CLILOADER=1 -DCMAKE_BUILD_TYPE=$BUILD_TYPE                               $GITHUB_WORKSPACE
+        fi
 
     - name: Build
       working-directory: ./build


### PR DESCRIPTION
## Description of Changes

Adds win32 builds to GitHub actions, including GitHub actions for releases.  This means that 32-bit Windows builds will be included in upcoming releases, and adds some redundancy with the AppVeyor builds.  Note that AppVeyor builds are still not removed completely, since they still test older Visual Studio versions, though support may be removed at some point in the future.

## Testing Done

Verified that GitHub actions builds succeed, including releases.
