### PR TITLE
fix the device performance timing checks for clReleaseContext

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -625,9 +625,9 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseContext)(
     {
         GET_ENQUEUE_COUNTER();
 
-        cl_uint ref_count =
-            pIntercept->config().CallLogging ?
-            pIntercept->getRefCount( context ) : 0;
+        // Note: we use the ref count to for device performance timing checks,
+        // so get it unconditionally.
+        cl_uint ref_count = pIntercept->getRefCount( context );
         CALL_LOGGING_ENTER( "[ ref count = %d ] context = %p",
             ref_count,
             context );
@@ -639,7 +639,8 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clReleaseContext)(
         HOST_PERFORMANCE_TIMING_END();
         CHECK_ERROR( retVal );
         ADD_OBJECT_RELEASE( context );
-        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", --ref_count );
+        --ref_count;
+        CALL_LOGGING_EXIT( retVal, "[ ref count = %d ]", ref_count );
         DEVICE_PERFORMANCE_TIMING_CHECK_CONDITIONAL( ref_count == 0 );
         FLUSH_CHROME_TRACE_BUFFERING_CONDITIONAL( ref_count == 0 );
 


### PR DESCRIPTION
## Description of Changes

The device performance timing checks were only supposed to happen when the context reference count went to zero, but because the reference count was only queried when call logging was enabled, it was happening much more often.  Fix by querying (and updating) the context reference count unconditionally.

## Testing Done

Tested with the SYCL llama.cpp with just chrome tracing enabled.  Verified that the device performance timing checks did not occur for calls to clReleaseContext.