### PR TITLE
bump the required CMake version to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)


### PR DESCRIPTION
## Description of Changes

The latest CI pipelines have updated to CMake 4.0, which drops support for CMake 3.5 and before.  Updating the required CMake version to 3.16 should still support older operating systems, but allow the latest CI pipelines to run.

## Testing Done

Basic testing plus CI testing to ensure the project still builds with the updated CMake requirement.
