### PR TITLE
add basic support for SVM and USM capture and replay

### DIFF
--- a/docs/capture_single_kernels.md
+++ b/docs/capture_single_kernels.md
@@ -54,13 +54,16 @@ If the buffers don't agree, it will show a message in the terminal.
   * Device only buffers, i.e. those with `CL_MEM_HOST_NO_ACCESS`.  When kernel capture is enabled, any device-only access flags are removed.
 * OpenCL Images
   * 2D, and 3D images are supported.
+* OpenCL SVM and USM
+  * Pointers to the base of an SVM or USM allocation are supported.
 * OpenCL Samplers
 * OpenCL Kernels from source or IL
 * OpenCL Kernels from device binary
 
 ## Limitations (incomplete)
 
-* Does not work with OpenCL SVM or USM.
+* Does not work with pointers to the middle of an OpenCL SVM or USM allocation.
+* Does not work with SVM or USM indirect access, where the SVM or USM allocation is not set as a kernel argument.
 * Does not work with OpenCL pipes.
 * Untested for out-of-order queues.
 * Sub-buffers are not dealt with explicitly, this may affect the results for both debugging and performance.

--- a/intercept/scripts/run.py
+++ b/intercept/scripts/run.py
@@ -162,8 +162,10 @@ else:
         try:
             prg = cl.Program(ctx, [device], [binaries[idx]]).build(options)
             getattr(prg, kernel_name)
+            print(f"Successfully loaded kernel device binary file: {binary_files[idx]}")
             break
         except Exception as e:
+            print(f"Failed to load kernel device binary file: {binary_files[idx]}")
             pass
 
 kernel = getattr(prg, kernel_name)

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -7706,6 +7706,16 @@ void CLIntercept::setKernelArgSVMPointer(
         CArgMemMap& argMemMap = m_KernelArgMemMap[ kernel ];
         argMemMap[ arg_index ] = startPtr;
     }
+
+    // Currently, only pointers to the start of an SVM allocation are supported for
+    // capture and replay.
+    if( arg == startPtr )
+    {
+        CArgDataMap& argDataMap = m_KernelArgDataMap[kernel];
+        const uint8_t* pRawArgData = reinterpret_cast<const uint8_t*>(arg);
+        argDataMap[ arg_index ] = std::vector<uint8_t>(
+            pRawArgData, pRawArgData + sizeof(void*) );
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7735,6 +7745,16 @@ void CLIntercept::setKernelArgUSMPointer(
     {
         CArgMemMap& argMemMap = m_KernelArgMemMap[ kernel ];
         argMemMap[ arg_index ] = startPtr;
+    }
+
+    // Currently, only pointers to the start of an SVM allocation are supported for
+    // capture and replay.
+    if( arg == startPtr )
+    {
+        CArgDataMap& argDataMap = m_KernelArgDataMap[kernel];
+        const uint8_t* pRawArgData = reinterpret_cast<const uint8_t*>(arg);
+        argDataMap[ arg_index ] = std::vector<uint8_t>(
+            pRawArgData, pRawArgData + sizeof(void*) );
     }
 }
 

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -7712,7 +7712,7 @@ void CLIntercept::setKernelArgSVMPointer(
     if( arg == startPtr )
     {
         CArgDataMap& argDataMap = m_KernelArgDataMap[kernel];
-        const uint8_t* pRawArgData = reinterpret_cast<const uint8_t*>(arg);
+        const uint8_t* pRawArgData = reinterpret_cast<const uint8_t*>(&arg);
         argDataMap[ arg_index ] = std::vector<uint8_t>(
             pRawArgData, pRawArgData + sizeof(void*) );
     }
@@ -7752,7 +7752,7 @@ void CLIntercept::setKernelArgUSMPointer(
     if( arg == startPtr )
     {
         CArgDataMap& argDataMap = m_KernelArgDataMap[kernel];
-        const uint8_t* pRawArgData = reinterpret_cast<const uint8_t*>(arg);
+        const uint8_t* pRawArgData = reinterpret_cast<const uint8_t*>(&arg);
         argDataMap[ arg_index ] = std::vector<uint8_t>(
             pRawArgData, pRawArgData + sizeof(void*) );
     }


### PR DESCRIPTION
## Description of Changes

Adds basic capture and replay support for SVM and USM allocations.  There are still limitations, specifically when setting a pointer to the middle of an SVM or USM allocation as a kernel argument, or when accessing SVM or USM indirectly.  Basic cases should be working, though, that set a pointer to the base of an SVM or USM allocation as a kernel argument.

## Testing Done

Tested with basic SYCL book samples that use USM.