### PR TITLE
Add basic support for replaying from SPIR-V

### DIFF
--- a/intercept/scripts/run.py
+++ b/intercept/scripts/run.py
@@ -150,6 +150,11 @@ if os.path.isfile("kernel.cl"):
     with open("kernel.cl", 'r') as file:
         kernel = file.read()
     prg = cl.Program(ctx, kernel).build(options)
+elif os.path.isfile("kernel.spv"):
+    print("Using kernel IL")
+    with open("kernel.spv", 'r') as file:
+        kernel = np.fromfile(file, dtype='uint8').tobytes()
+    prg = cl.Program(ctx, kernel).build(options)
 else:
     print("Using kernel device binary")
     binary_files = gl.glob("./DeviceBinary*.bin")


### PR DESCRIPTION
## Description of Changes

Previously, replay checked for either an OpenCL C source file (kernel.cl) or a device binary (*.bin). This commit adds another check for a SPIR-V binary (kernel.spv).

The intent behind these changes is to make it simpler to capture on one device and replay on another device, without needing access to the original source. More sophisticated changes would be required to fully automate this and support all cases (e.g., multiple SPIR-V files) but this simple change seemed in keeping with the existing "kernel.cl" path and is enough for my use-case.

## Testing Done

I only ran a very simple test:

1. Used OpenCL Intercept Layer to capture a kernel running on an Intel GPU, producing a `DeviceBinary0.bin` file.
2. Used `readelf` and `dd` to extract the `.spv` section from `DeviceBinary0.bin` into `kernel.spv`.
3. Used the modified `run.py` script to replay the kernel on an Intel CPU via PoCL.
