### PR TITLE
need to get the chrome tracing lock when flushing the trace file

### DIFF
--- a/intercept/src/chrometracer.h
+++ b/intercept/src/chrometracer.h
@@ -366,9 +366,9 @@ public:
 
     std::ostream& flush()
     {
+        std::lock_guard<std::mutex> lock(m_Mutex);
         if( m_RecordBuffer.size() > 0 )
         {
-            std::lock_guard<std::mutex> lock(m_Mutex);
             flushRecords();
         }
         return m_TraceFile.flush();


### PR DESCRIPTION
## Description of Changes

If one thread is writing to the chrome trace file while another thread flushes the file then the file may be corrupted.  So, grab the chrome tracing lock when flushing the file, even if there are no chrome tracing records.

## Testing Done

Tested with a heavily multi-threaded application that very occasionally generated a corrupted file before this change, but never after this change.