### PR TITLE
add tracing for cl_khr_spirv_queries

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -926,6 +926,13 @@ cl_int CL_API_CALL clReleaseSemaphoreKHR(
 #define CL_PROGRAM_BINARY_TYPE_INTERMEDIATE         0x40E1
 
 ///////////////////////////////////////////////////////////////////////////////
+// cl_khr_spirv_queries
+
+#define CL_DEVICE_SPIRV_EXTENDED_INSTRUCTION_SETS_KHR       0x12B9
+#define CL_DEVICE_SPIRV_EXTENSIONS_KHR                      0x12BA
+#define CL_DEVICE_SPIRV_CAPABILITIES_KHR                    0x12BB
+
+///////////////////////////////////////////////////////////////////////////////
 // cl_khr_subgroup_named_barrier
 
 #define CL_DEVICE_MAX_NAMED_BARRIER_COUNT_KHR       0x2035

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -863,6 +863,11 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SPIR_VERSIONS );
     ADD_ENUM_NAME( m_cl_int, CL_PROGRAM_BINARY_TYPE_INTERMEDIATE );
 
+    // cl_khr_spirv_queries
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SPIRV_EXTENDED_INSTRUCTION_SETS_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SPIRV_EXTENSIONS_KHR );
+    ADD_ENUM_NAME( m_cl_int, CL_DEVICE_SPIRV_CAPABILITIES_KHR );
+
     // cl_khr_subgroup_named_barrier
     ADD_ENUM_NAME( m_cl_int, CL_DEVICE_MAX_NAMED_BARRIER_COUNT_KHR );
 


### PR DESCRIPTION
## Description of Changes

Adds basic enum tracing for the cl_khr_spirv_queries extension.  See: https://github.com/KhronosGroup/OpenCL-Docs/pull/1385

## Testing Done

Tested with the proposed cl_khr_spirv_queries CTS tests.
