### PR TITLE
include a NULL global work size in timing tags

### DIFF
--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -5893,21 +5893,28 @@ void CLIntercept::getTimingTagsKernel(
             deviceTag += ss.str();
         }
 
-        if( config().DevicePerformanceTimeGWSTracking && gws )
+        if( config().DevicePerformanceTimeGWSTracking )
         {
             std::ostringstream  ss;
             ss << " GWS[ ";
-            if( workDim >= 1 )
+            if( gws )
             {
-                ss << gws[0];
+                if( workDim >= 1 )
+                {
+                    ss << gws[0];
+                }
+                if( workDim >= 2 )
+                {
+                    ss << " x " << gws[1];
+                }
+                if( workDim >= 3 )
+                {
+                    ss << " x " << gws[2];
+                }
             }
-            if( workDim >= 2 )
+            else
             {
-                ss << " x " << gws[1];
-            }
-            if( workDim >= 3 )
-            {
-                ss << " x " << gws[2];
+                ss << "NULL";
             }
             ss << " ]";
             deviceTag += ss.str();


### PR DESCRIPTION
## Description of Changes

Previously, if the global work size was NULL, no information about the global work size was included in a timing tag, unlike a NULL global work offset or local work size. After this change, the global work size is included in the timing tags also.

## Testing Done

Tested with a recent CTS update that added explicit testing for a NULL global work size.
