### PR TITLE
add tracing for cl_khr_external_memory_android_hardware_buffer

### DIFF
--- a/intercept/src/cli_ext.h
+++ b/intercept/src/cli_ext.h
@@ -656,8 +656,6 @@ typedef struct _cl_name_version_khr
 ///////////////////////////////////////////////////////////////////////////////
 // cl_khr_external_memory
 
-// Note: This implements the provisional extension v0.9.3.
-
 typedef cl_uint             cl_external_memory_handle_type_khr;
 
 #define CL_PLATFORM_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR      0x2044
@@ -688,6 +686,9 @@ cl_int CL_API_CALL clEnqueueReleaseExternalMemObjectsKHR(
     cl_uint num_events_in_wait_list,
     const cl_event *event_wait_list,
     cl_event *event);
+
+// cl_khr_external_memory_android_hardware_buffer
+#define CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR 0x2070
 
 // cl_khr_external_memory_dma_buf
 #define CL_EXTERNAL_MEMORY_HANDLE_DMA_BUF_KHR           0x2067

--- a/intercept/src/enummap.cpp
+++ b/intercept/src/enummap.cpp
@@ -780,6 +780,9 @@ CEnumNameMap::CEnumNameMap()
     ADD_ENUM_NAME( m_cl_int, CL_COMMAND_ACQUIRE_EXTERNAL_MEM_OBJECTS_KHR );
     ADD_ENUM_NAME( m_cl_int, CL_COMMAND_RELEASE_EXTERNAL_MEM_OBJECTS_KHR );
 
+    // cl_khr_external_memory_android_hardware_buffer
+    ADD_ENUM_NAME( m_cl_int, CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR );
+
     // cl_khr_external_memory_dma_buf
     ADD_ENUM_NAME( m_cl_int, CL_EXTERNAL_MEMORY_HANDLE_DMA_BUF_KHR );
 

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -2433,6 +2433,7 @@ void CLIntercept::getMemPropertiesString(
                     properties += 2;
                 }
                 break;
+            case CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR:
             case CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR:
             case CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR:
             case CL_EXTERNAL_MEMORY_HANDLE_D3D11_TEXTURE_KHR:
@@ -2440,8 +2441,8 @@ void CLIntercept::getMemPropertiesString(
             case CL_EXTERNAL_MEMORY_HANDLE_D3D12_HEAP_KHR:
             case CL_EXTERNAL_MEMORY_HANDLE_D3D12_RESOURCE_KHR:
                 {
-                    auto pfd = (const void**)( properties + 1);
-                    CLI_SPRINTF( s, 256, "%p", pfd[0] );
+                    auto pvp = (const void**)( properties + 1);
+                    CLI_SPRINTF( s, 256, "%p", pvp[0] );
                     str += s;
                     properties += 2;
                 }


### PR DESCRIPTION
## Description of Changes

Adds tracing for cl_khr_external_memory_android_hardware_buffer.

## Testing Done

Followed established patterns for other external memory handle types; don't have an implementation to test this currently.
