### PR TITLE
dump output program binaries after clCompileProgram

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -2337,6 +2337,7 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clCompileProgram)(
         BUILD_LOGGING( program, num_devices, device_list );
         CALL_LOGGING_EXIT( retVal );
 
+        DUMP_OUTPUT_PROGRAM_BINARIES( program );
         INCREMENT_PROGRAM_COMPILE_COUNT( program );
         PROGRAM_OPTIONS_CLEANUP( newOptions );
 


### PR DESCRIPTION
## Description of Changes

OpenCL allows querying program binaries after clCompileProgram, so we may as well dump output program binaries after calling clCompileProgram in addition to the existing paths after clBuildProgram and clLinkProgram.

## Testing Done

Tested with an OpenCL sample that calls clCompileProgram and clLinkProgram.
