### PR TITLE
a few more minor OpenCL 3.1 related changes

### DIFF
--- a/intercept/src/clIntercept.def
+++ b/intercept/src/clIntercept.def
@@ -85,6 +85,7 @@ EXPORTS
     clGetKernelArgInfo
     clGetKernelInfo
     clGetKernelSubGroupInfo
+    clGetKernelSuggestedLocalWorkSize
     clGetKernelWorkGroupInfo
     clGetMemObjectInfo
     clGetPipeInfo

--- a/intercept/src/clIntercept.map
+++ b/intercept/src/clIntercept.map
@@ -164,3 +164,8 @@ OPENCL_3.0 {
         clCreateImageWithProperties;
         clSetContextDestructorCallback;
 } OPENCL_2.2;
+
+OPENCL_3.1 {
+    global:
+        clGetKernelSuggestedLocalWorkSize;
+} OPENCL_3.0;

--- a/intercept/src/cliprof_init.cpp
+++ b/intercept/src/cliprof_init.cpp
@@ -171,6 +171,7 @@ DWORD cliprof_init( void* dummy )
                     REPLACE_FUNCTION( name, clGetKernelArgInfo );
                     REPLACE_FUNCTION( name, clGetKernelInfo );
                     REPLACE_FUNCTION( name, clGetKernelSubGroupInfo );
+                    REPLACE_FUNCTION( name, clGetKernelSuggestedLocalWorkSize );
                     REPLACE_FUNCTION( name, clGetKernelWorkGroupInfo );
                     REPLACE_FUNCTION( name, clGetMemObjectInfo );
                     REPLACE_FUNCTION( name, clGetPipeInfo );


### PR DESCRIPTION
## Description of Changes

Adds a few minor missing OpenCL 3.1-related changes related to missing exports and specific cliloader functionality on Windows.

## Testing Done

Dumped exported symbols and verified that the OpenCL 3.1 API clGetKernelSuggestedLocalWorkSize is now exported.
