### PR TITLE
improve logging for specialization constants

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -2491,10 +2491,19 @@ CL_API_ENTRY cl_int CL_API_CALL CLIRN(clSetProgramSpecializationConstant)(
     if( pIntercept && pIntercept->dispatch().clSetProgramSpecializationConstant )
     {
         GET_ENQUEUE_COUNTER();
-        CALL_LOGGING_ENTER( "program = %p, spec_id = %u, spec_size = %zu",
+        std::string specConstString;
+        if( pIntercept->config().CallLogging )
+        {
+            pIntercept->getSpecConstantString(
+                spec_size,
+                spec_value,
+                specConstString );
+        }
+        CALL_LOGGING_ENTER( "program = %p, spec_id = %u, spec_size = %zu%s",
             program,
             spec_id,
-            spec_size );
+            spec_size,
+            specConstString.c_str() );
         HOST_PERFORMANCE_TIMING_START();
 
         cl_int  retVal = pIntercept->dispatch().clSetProgramSpecializationConstant(

--- a/intercept/src/intercept.cpp
+++ b/intercept/src/intercept.cpp
@@ -3170,6 +3170,44 @@ void CLIntercept::getCreateSubBufferArgsString(
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+void CLIntercept::getSpecConstantString(
+    size_t spec_size,
+    const void* spec_value,
+    std::string& str ) const
+{
+    if( spec_value != NULL )
+    {
+        char    s[256];
+
+        if( spec_size == sizeof(cl_uchar) )
+        {
+            cl_uchar*   pData = (cl_uchar*)spec_value;
+            CLI_SPRINTF( s, 256, ", spec_value = 0x%x",
+                pData[0] );
+        }
+        else if( spec_size == sizeof(cl_uint) )
+        {
+            cl_uint*    pData = (cl_uint*)spec_value;
+            CLI_SPRINTF( s, 256, ", spec_value = 0x%x",
+                pData[0] );
+        }
+        else if( spec_size == sizeof(cl_ulong) )
+        {
+            cl_ulong*   pData = (cl_ulong*)spec_value;
+            CLI_SPRINTF( s, 256, ", spec_value = 0x%" PRIx64,
+                pData[0] );
+        }
+
+        str = s;
+    }
+    else
+    {
+        str = ", spec_value = NULL";
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
 void CLIntercept::logCLInfo()
 {
     if( m_LoggedCLInfo == false )

--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -204,6 +204,10 @@ public:
                 cl_buffer_create_type createType,
                 const void *createInfo,
                 std::string& str ) const;
+    void    getSpecConstantString(
+                size_t spec_size,
+                const void* spec_value,
+                std::string& str ) const;
 
     void    logCLInfo();
     void    logBuild(


### PR DESCRIPTION
## Description of Changes

Improves call logging for specialization constants.  Specifically, logs the specialization constant value for many common specialization constant sizes.

## Testing Done

Tested with some in-flight conformance tests that set specialization constants.
