### PR TITLE
add back control checks prior to error code checks

### DIFF
--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -2253,7 +2253,10 @@ inline CObjectTracker& CLIntercept::objectTracker()
     }
 
 #define CHECK_ERROR( errorCode )                                            \
-    if( errorCode != CL_SUCCESS )                                           \
+    if( ( pIntercept->config().ErrorLogging ||                              \
+          pIntercept->config().ErrorAssert ||                               \
+          pIntercept->config().NoErrors ) &&                                \
+        ( errorCode != CL_SUCCESS ) )                                       \
     {                                                                       \
         if( pIntercept->config().ErrorLogging )                             \
         {                                                                   \


### PR DESCRIPTION
## Description of Changes

We cannot skip the control checks prior to the error code check since we might need to dereference a pointer to check the error code, and the pointer may not have been setup, depending on the controls.

## Testing Done

Tested with an application that calls an API where the error code is returned through a pointer with no controls set.
