### PR TITLE
allow dumping program build logs without logging

### DIFF
--- a/intercept/src/intercept.h
+++ b/intercept/src/intercept.h
@@ -2104,13 +2104,15 @@ inline CObjectTracker& CLIntercept::objectTracker()
 //
 #define BUILD_LOGGING_INIT()                                                \
     CLIntercept::clock::time_point  buildTimeStart;                         \
-    if( pIntercept->config().BuildLogging )                                 \
+    if( pIntercept->config().BuildLogging ||                                \
+        pIntercept->config().DumpProgramBuildLogs )                         \
     {                                                                       \
         buildTimeStart = CLIntercept::clock::now();                         \
     }
 
 #define BUILD_LOGGING( program, num_devices, device_list )                  \
-    if( pIntercept->config().BuildLogging )                                 \
+    if( pIntercept->config().BuildLogging ||                                \
+        pIntercept->config().DumpProgramBuildLogs )                         \
     {                                                                       \
         pIntercept->logBuild(                                               \
             buildTimeStart,                                                 \


### PR DESCRIPTION
## Description of Changes

There is no need to couple DumpProgramBuildLogs with BuildLogging. Allow setting just DumpProgramBuildLogs without also requiring BuildLogging to dump the program build logs.

## Testing Done

Executed a conformance test with just DumpProgramBuildLogs.  Prior to this change, no build logs were dumped, unless BuildLogging was also set.  After this change, build logs are dumped without logging.