### PR TITLE
fix: Strip host-write-only flag and cover all capture-replay allocations

### DIFF
--- a/intercept/src/dispatch.cpp
+++ b/intercept/src/dispatch.cpp
@@ -992,9 +992,10 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateBuffer)(
 
         if( pIntercept->config().CaptureReplay )
         {
-            // Make sure that there are no device only buffers
-            // Since we need them to replay the kernel
-            flags &= ~CL_MEM_HOST_NO_ACCESS;
+            // Make sure that there are no device only or host write only
+            // buffers, since we need to read buffer contents back on the
+            // host to dump and replay the kernel.
+            flags &= ~( CL_MEM_HOST_NO_ACCESS | CL_MEM_HOST_WRITE_ONLY );
         }
         INITIALIZE_BUFFER_CONTENTS_INIT( flags, size, host_ptr );
         CHECK_ERROR_INIT( errcode_ret );
@@ -1052,6 +1053,13 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateBufferWithProperties)(
             flags,
             size,
             host_ptr );
+        if( pIntercept->config().CaptureReplay )
+        {
+            // Make sure that there are no device only or host write only
+            // buffers, since we need to read buffer contents back on the
+            // host to dump and replay the kernel.
+            flags &= ~( CL_MEM_HOST_NO_ACCESS | CL_MEM_HOST_WRITE_ONLY );
+        }
         INITIALIZE_BUFFER_CONTENTS_INIT( flags, size, host_ptr );
         CHECK_ERROR_INIT( errcode_ret );
         HOST_PERFORMANCE_TIMING_START();
@@ -1305,6 +1313,14 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateImage)(
         CHECK_ERROR_INIT( errcode_ret );
         HOST_PERFORMANCE_TIMING_START();
 
+        if( pIntercept->config().CaptureReplay )
+        {
+            // Make sure that there are no device only or host write only
+            // images, since we need to read image contents back on the
+            // host to dump and replay the kernel.
+            flags &= ~( CL_MEM_HOST_NO_ACCESS | CL_MEM_HOST_WRITE_ONLY );
+        }
+
         cl_mem  retVal = pIntercept->dispatch().clCreateImage(
             context,
             flags,
@@ -1394,6 +1410,14 @@ CL_API_ENTRY cl_mem CL_API_CALL CLIRN(clCreateImageWithProperties)(
 
         CHECK_ERROR_INIT( errcode_ret );
         HOST_PERFORMANCE_TIMING_START();
+
+        if( pIntercept->config().CaptureReplay )
+        {
+            // Make sure that there are no device only or host write only
+            // images, since we need to read image contents back on the
+            // host to dump and replay the kernel.
+            flags &= ~( CL_MEM_HOST_NO_ACCESS | CL_MEM_HOST_WRITE_ONLY );
+        }
 
         cl_mem  retVal = pIntercept->dispatch().clCreateImageWithProperties(
             context,


### PR DESCRIPTION
## Summary
- `CaptureReplay` needs to read back buffer/image contents on the host to dump and replay kernels, so `CL_MEM_HOST_WRITE_ONLY` must be cleared in addition to `CL_MEM_HOST_NO_ACCESS`.
- Extends this flag masking (previously only applied in `clCreateBuffer`) to `clCreateBufferWithProperties`, `clCreateImage`, and `clCreateImageWithProperties` which were previously missing it.

## Fixes
CLUMD's internal sanity test _copybuf_test_ wasn't being replayed properly as the capture was missing source data.

## Testing Done

- [x] Built and linked successfully for Windows x64
- [x] Captured a workload using **clCreateBuffer** and verified replay works with host-write-only/device-only flags set
- [x] Captured a workload using **clCreateBufferWithProperties** and verified replay works with host-write-only/device-only flags set
- [x] Captured a workload using **clCreateImage** and verified replay works with host-write-only/device-only flags set
- [x] Captured a workload using **clCreateImageWithProperties** and verified replay works with host-write-only/device-only flags set
